### PR TITLE
Fixes line length in Writer\ExtensionPluginManager

### DIFF
--- a/src/Writer/ExtensionPluginManager.php
+++ b/src/Writer/ExtensionPluginManager.php
@@ -116,15 +116,19 @@ class ExtensionPluginManager extends AbstractPluginManager implements ExtensionM
         \Zend\Feed\Writer\Extension\DublinCore\Renderer\Feed::class => Extension\DublinCore\Renderer\Feed::class,
         \Zend\Feed\Writer\Extension\GooglePlayPodcast\Entry::class => Extension\GooglePlayPodcast\Entry::class,
         \Zend\Feed\Writer\Extension\GooglePlayPodcast\Feed::class => Extension\GooglePlayPodcast\Feed::class,
+        // @codingStandardsIgnoreStart
         \Zend\Feed\Writer\Extension\GooglePlayPodcast\Renderer\Entry::class => Extension\GooglePlayPodcast\Renderer\Entry::class,
         \Zend\Feed\Writer\Extension\GooglePlayPodcast\Renderer\Feed::class => Extension\GooglePlayPodcast\Renderer\Feed::class,
+        // @codingStandardsIgnoreEnd
         \Zend\Feed\Writer\Extension\ITunes\Entry::class => Extension\ITunes\Entry::class,
         \Zend\Feed\Writer\Extension\ITunes\Feed::class => Extension\ITunes\Feed::class,
         \Zend\Feed\Writer\Extension\ITunes\Renderer\Entry::class => Extension\ITunes\Renderer\Entry::class,
         \Zend\Feed\Writer\Extension\ITunes\Renderer\Feed::class => Extension\ITunes\Renderer\Feed::class,
         \Zend\Feed\Writer\Extension\Slash\Renderer\Entry::class => Extension\Slash\Renderer\Entry::class,
         \Zend\Feed\Writer\Extension\Threading\Renderer\Entry::class => Extension\Threading\Renderer\Entry::class,
+        // @codingStandardsIgnoreStart
         \Zend\Feed\Writer\Extension\WellFormedWeb\Renderer\Entry::class => Extension\WellFormedWeb\Renderer\Entry::class,
+        // @codingStandardsIgnoreEnd
 
         // v2 normalized FQCNs
         'zendfeedwriterextensionatomrendererfeed' => Extension\Atom\Renderer\Feed::class,


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| QA            | yes

This pull request should remove the warning about line lengths.

```
FILE: ...build/laminas/laminas-feed/src/Writer/ExtensionPluginManager.php
----------------------------------------------------------------------
FOUND 0 ERRORS AND 3 WARNINGS AFFECTING 3 LINES
----------------------------------------------------------------------
 119 | WARNING | Line exceeds 120 characters; contains 129 characters
 120 | WARNING | Line exceeds 120 characters; contains 127 characters
 127 | WARNING | Line exceeds 120 characters; contains 121 characters
----------------------------------------------------------------------
```

https://travis-ci.com/laminas/laminas-feed/jobs/284472941#L575-L582