### PR TITLE
Fixes 32 - Method getDateModified of RSS reader doesn't iterate over different formats

### DIFF
--- a/src/Reader/Feed/Rss.php
+++ b/src/Reader/Feed/Rss.php
@@ -206,22 +206,21 @@ class Rss extends AbstractFeed
                         DateTime::RSS,
                         DateTime::RFC822,
                         DateTime::RFC2822,
-                        null,
                     ];
                     foreach ($dateStandards as $standard) {
-                        try {
-                            $date = DateTime::createFromFormat($standard, $dateModified);
+                        $date = DateTime::createFromFormat(
+                            $standard,
+                            $dateModified
+                        );
+                        if ($date instanceof DateTime) {
                             break;
-                        } catch (\Exception $e) {
-                            if ($standard === null) {
-                                throw new Exception\RuntimeException(
-                                    'Could not load date due to unrecognised format'
-                                    . ' (should follow RFC 822 or 2822): ' . $e->getMessage(),
-                                    0,
-                                    $e
-                                );
-                            }
                         }
+                    }
+                    if (! $date) {
+                        throw new Exception\RuntimeException(
+                            'Could not load date due to unrecognised'
+                            . ' format (should follow RFC 822 or 2822).'
+                        );
                     }
                 }
             }

--- a/test/Reader/Feed/RssTest.php
+++ b/test/Reader/Feed/RssTest.php
@@ -19,6 +19,7 @@ use PHPUnit\Framework\TestCase;
  */
 class RssTest extends TestCase
 {
+    /** @var string */
     protected $feedSamplePath;
 
     protected $expectedCats = [];
@@ -2176,6 +2177,22 @@ class RssTest extends TestCase
             ['/datemodified/plain/none/rss10.xml', null],
             ['/datemodified/plain/none/rss090.xml', null],
         ];
+    }
+
+    public function testGetDateModifiedShouldThrowExceptionForInvalidDate(): void
+    {
+        $feed = Reader\Reader::importString(
+            file_get_contents(
+                $this->feedSamplePath . '/datemodified/plain/invalid.xml'
+            )
+        );
+
+        $this->expectException(Reader\Exception\RuntimeException::class);
+        $this->expectExceptionMessage(
+            'Could not load date due to unrecognised format (should follow RFC 822 or 2822).'
+        );
+
+        $feed->getDateModified();
     }
 
     /**

--- a/test/Reader/Feed/_files/Rss/datemodified/plain/invalid.xml
+++ b/test/Reader/Feed/_files/Rss/datemodified/plain/invalid.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<rss version="2.0">
+    <channel>
+        <!-- missing year -->
+        <lastBuildDate>Sat, 07 Mar 08:03:50 +0000</lastBuildDate>
+    </channel>
+</rss>


### PR DESCRIPTION

|    Q          |   A
|-------------- | ------
| Bugfix        | yes

