### PR TITLE
Ensure PubSubHubbub\Publisher::notifyAll() calls HTTP client send() method

### DIFF
--- a/src/PubSubHubbub/Publisher.php
+++ b/src/PubSubHubbub/Publisher.php
@@ -256,6 +256,7 @@ class Publisher
         $this->errors = [];
         foreach ($hubs as $url) {
             $client->setUri($url);
+            $client->send();
             $response = $client->getResponse();
             if ($response->getStatusCode() !== 204) {
                 $this->errors[] = [

--- a/test/PubSubHubbub/ClientNotReset.php
+++ b/test/PubSubHubbub/ClientNotReset.php
@@ -9,11 +9,17 @@
 namespace LaminasTest\Feed\PubSubHubbub;
 
 use Laminas\Http\Client as HttpClient;
+use Laminas\Http\Request;
 
 class ClientNotReset extends HttpClient
 {
     public function resetParameters($clearCookies = false, $clearAuth = true)
     {
         // Do nothing
+    }
+
+    public function send(Request $request = null)
+    {
+        return $this->response;
     }
 }

--- a/test/PubSubHubbub/PublisherTest.php
+++ b/test/PubSubHubbub/PublisherTest.php
@@ -321,4 +321,31 @@ class PublisherTest extends TestCase
         $this->publisher->notifyAll();
         $this->assertFalse($this->publisher->isSuccess());
     }
+
+    public function testNotifyAllSendsRequestViaClient(): void
+    {
+        $response = $this->createMock(HttpResponse::class);
+        $response->expects($this->once())->method('getStatusCode')->willReturn(204);
+
+        $client = $this->createMock(HttpClient::class);
+        $client
+            ->expects($this->once())
+            ->method('setUri')
+            ->with('http://www.example.com/hub');
+        $client
+            ->expects($this->once())
+            ->method('send');
+        $client
+            ->expects($this->once())
+            ->method('getResponse')
+            ->willReturn($response);
+
+        PubSubHubbub::setHttpClient($client);
+
+        $this->publisher->addHubUrl('http://www.example.com/hub');
+        $this->publisher->addUpdatedTopicUrl('http://www.example.com/topic');
+        $this->publisher->setParameter('foo', 'bar');
+        $this->publisher->notifyAll();
+        $this->assertTrue($this->publisher->isSuccess());
+    }
 }


### PR DESCRIPTION
Per the report in #36, `PubSubHubbub\Publisher::notifyAll()` was not calling the HTTP client `send()` method, and, as such, was not notifying hubs at all.

Fixes #36
