### PR TITLE
Provide PHP 8.1 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 /.phpcs-cache
 /.phpunit.result.cache
-/.psalm-cache
+/.psalm-cache/
 /clover.xml
 /coveralls-upload.json
 /docs/html/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.phpcs-cache
 /.phpunit.result.cache
 /.psalm-cache
 /clover.xml

--- a/.laminas-ci.json
+++ b/.laminas-ci.json
@@ -1,5 +1,8 @@
 {
     "extensions": [
         "tidy"
-    ]
+    ],
+    "ignore_php_platform_requirements": {
+        "8.1": true
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -21,27 +21,27 @@
     "extra": {
     },
     "require": {
-        "php": "^7.3 || ~8.0.0",
+        "php": "^7.3 || ~8.0.0 || ~8.1.0",
         "ext-dom": "*",
         "ext-libxml": "*",
-        "laminas/laminas-escaper": "^2.5.2",
-        "laminas/laminas-stdlib": "^3.2.1",
-        "laminas/laminas-zendframework-bridge": "^1.0"
+        "laminas/laminas-escaper": "^2.9",
+        "laminas/laminas-stdlib": "^3.6"
     },
     "require-dev": {
         "laminas/laminas-cache": "^2.7.2",
-        "laminas/laminas-coding-standard": "~1.0.0",
+        "laminas/laminas-coding-standard": "~2.2.1",
         "laminas/laminas-db": "^2.8.2",
-        "laminas/laminas-http": "^2.7",
+        "laminas/laminas-http": "^2.15",
         "laminas/laminas-servicemanager": "^3.3",
-        "laminas/laminas-validator": "^2.10.1",
-        "phpunit/phpunit": "^9.3",
+        "laminas/laminas-validator": "^2.15",
+        "phpunit/phpunit": "^9.5.5",
         "psalm/plugin-phpunit": "^0.13.0",
         "psr/http-message": "^1.0.1",
         "vimeo/psalm": "^4.1"
     },
     "conflict": {
-        "laminas/laminas-servicemanager": "<3.3"
+        "laminas/laminas-servicemanager": "<3.3",
+        "zendframework/zend-feed": "*"
     },
     "suggest": {
         "laminas/laminas-cache": "Laminas\\Cache component, for optionally caching feeds between requests",
@@ -71,8 +71,5 @@
         "static-analysis": "psalm --shepherd --stats",
         "test": "phpunit --colors=always",
         "test-coverage": "phpunit --colors=always --coverage-clover clover.xml"
-    },
-    "replace": {
-        "zendframework/zend-feed": "^2.12.0"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -30,9 +30,9 @@
     "require-dev": {
         "laminas/laminas-cache": "^2.7.2",
         "laminas/laminas-coding-standard": "~2.2.1",
-        "laminas/laminas-db": "^2.8.2",
+        "laminas/laminas-db": "^2.13.3",
         "laminas/laminas-http": "^2.15",
-        "laminas/laminas-servicemanager": "^3.3",
+        "laminas/laminas-servicemanager": "^3.7",
         "laminas/laminas-validator": "^2.15",
         "phpunit/phpunit": "^9.5.5",
         "psalm/plugin-phpunit": "^0.13.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,31 +4,30 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "34881a2629d253b84302efada95a645f",
+    "content-hash": "bf58c61fa037d1454d498cdae95b28a1",
     "packages": [
         {
             "name": "laminas/laminas-escaper",
-            "version": "2.7.0",
+            "version": "2.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-escaper.git",
-                "reference": "5e04bc5ae5990b17159d79d331055e2c645e5cc5"
+                "reference": "891ad70986729e20ed2e86355fcf93c9dc238a5f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-escaper/zipball/5e04bc5ae5990b17159d79d331055e2c645e5cc5",
-                "reference": "5e04bc5ae5990b17159d79d331055e2c645e5cc5",
+                "url": "https://api.github.com/repos/laminas/laminas-escaper/zipball/891ad70986729e20ed2e86355fcf93c9dc238a5f",
+                "reference": "891ad70986729e20ed2e86355fcf93c9dc238a5f",
                 "shasum": ""
             },
             "require": {
-                "laminas/laminas-zendframework-bridge": "^1.0",
-                "php": "^7.3 || ~8.0.0"
+                "php": "^7.3 || ~8.0.0 || ~8.1.0"
             },
-            "replace": {
-                "zendframework/zend-escaper": "^2.6.1"
+            "conflict": {
+                "zendframework/zend-escaper": "*"
             },
             "require-dev": {
-                "laminas/laminas-coding-standard": "~1.0.0",
+                "laminas/laminas-coding-standard": "~2.3.0",
                 "phpunit/phpunit": "^9.3",
                 "psalm/plugin-phpunit": "^0.12.2",
                 "vimeo/psalm": "^3.16"
@@ -67,33 +66,34 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2020-11-17T21:26:43+00:00"
+            "time": "2021-09-02T17:10:53+00:00"
         },
         {
             "name": "laminas/laminas-stdlib",
-            "version": "3.3.1",
+            "version": "3.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-stdlib.git",
-                "reference": "d81c7ffe602ed0e6ecb18691019111c0f4bf1efe"
+                "reference": "c53d8537f108fac3fae652677a19735db730ba46"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-stdlib/zipball/d81c7ffe602ed0e6ecb18691019111c0f4bf1efe",
-                "reference": "d81c7ffe602ed0e6ecb18691019111c0f4bf1efe",
+                "url": "https://api.github.com/repos/laminas/laminas-stdlib/zipball/c53d8537f108fac3fae652677a19735db730ba46",
+                "reference": "c53d8537f108fac3fae652677a19735db730ba46",
                 "shasum": ""
             },
             "require": {
-                "laminas/laminas-zendframework-bridge": "^1.0",
-                "php": "^7.3 || ^8.0"
+                "php": "^7.3 || ~8.0.0 || ~8.1.0"
             },
-            "replace": {
-                "zendframework/zend-stdlib": "^3.2.1"
+            "conflict": {
+                "zendframework/zend-stdlib": "*"
             },
             "require-dev": {
-                "laminas/laminas-coding-standard": "~1.0.0",
+                "laminas/laminas-coding-standard": "~2.3.0",
                 "phpbench/phpbench": "^0.17.1",
-                "phpunit/phpunit": "~9.3.7"
+                "phpunit/phpunit": "~9.3.7",
+                "psalm/plugin-phpunit": "^0.16.0",
+                "vimeo/psalm": "^4.7"
             },
             "type": "library",
             "autoload": {
@@ -125,93 +125,33 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2020-11-19T20:18:59+00:00"
-        },
-        {
-            "name": "laminas/laminas-zendframework-bridge",
-            "version": "1.1.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laminas/laminas-zendframework-bridge.git",
-                "reference": "6ede70583e101030bcace4dcddd648f760ddf642"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-zendframework-bridge/zipball/6ede70583e101030bcace4dcddd648f760ddf642",
-                "reference": "6ede70583e101030bcace4dcddd648f760ddf642",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.6 || ^7.0 || ^8.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5 || ^8.1 || ^9.3",
-                "squizlabs/php_codesniffer": "^3.5"
-            },
-            "type": "library",
-            "extra": {
-                "laminas": {
-                    "module": "Laminas\\ZendFrameworkBridge"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "src/autoload.php"
-                ],
-                "psr-4": {
-                    "Laminas\\ZendFrameworkBridge\\": "src//"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "Alias legacy ZF class names to Laminas Project equivalents.",
-            "keywords": [
-                "ZendFramework",
-                "autoloading",
-                "laminas",
-                "zf"
-            ],
-            "support": {
-                "forum": "https://discourse.laminas.dev/",
-                "issues": "https://github.com/laminas/laminas-zendframework-bridge/issues",
-                "rss": "https://github.com/laminas/laminas-zendframework-bridge/releases.atom",
-                "source": "https://github.com/laminas/laminas-zendframework-bridge"
-            },
-            "funding": [
-                {
-                    "url": "https://funding.communitybridge.org/projects/laminas-project",
-                    "type": "community_bridge"
-                }
-            ],
-            "time": "2020-09-14T14:23:00+00:00"
+            "time": "2021-09-02T16:11:32+00:00"
         }
     ],
     "packages-dev": [
         {
             "name": "amphp/amp",
-            "version": "v2.5.2",
+            "version": "v2.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/amphp/amp.git",
-                "reference": "efca2b32a7580087adb8aabbff6be1dc1bb924a9"
+                "reference": "caa95edeb1ca1bf7532e9118ede4a3c3126408cc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/amphp/amp/zipball/efca2b32a7580087adb8aabbff6be1dc1bb924a9",
-                "reference": "efca2b32a7580087adb8aabbff6be1dc1bb924a9",
+                "url": "https://api.github.com/repos/amphp/amp/zipball/caa95edeb1ca1bf7532e9118ede4a3c3126408cc",
+                "reference": "caa95edeb1ca1bf7532e9118ede4a3c3126408cc",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7"
+                "php": ">=7.1"
             },
             "require-dev": {
                 "amphp/php-cs-fixer-config": "dev-master",
                 "amphp/phpunit-util": "^1",
                 "ext-json": "*",
                 "jetbrains/phpstorm-stubs": "^2019.3",
-                "phpunit/phpunit": "^6.0.9 | ^7",
+                "phpunit/phpunit": "^7 | ^8 | ^9",
                 "psalm/phar": "^3.11@dev",
                 "react/promise": "^2"
             },
@@ -268,7 +208,7 @@
             "support": {
                 "irc": "irc://irc.freenode.org/amphp",
                 "issues": "https://github.com/amphp/amp/issues",
-                "source": "https://github.com/amphp/amp/tree/v2.5.2"
+                "source": "https://github.com/amphp/amp/tree/v2.6.0"
             },
             "funding": [
                 {
@@ -276,20 +216,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-01-10T17:06:37+00:00"
+            "time": "2021-07-16T20:06:06+00:00"
         },
         {
             "name": "amphp/byte-stream",
-            "version": "v1.8.0",
+            "version": "v1.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/amphp/byte-stream.git",
-                "reference": "f0c20cf598a958ba2aa8c6e5a71c697d652c7088"
+                "reference": "acbd8002b3536485c997c4e019206b3f10ca15bd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/amphp/byte-stream/zipball/f0c20cf598a958ba2aa8c6e5a71c697d652c7088",
-                "reference": "f0c20cf598a958ba2aa8c6e5a71c697d652c7088",
+                "url": "https://api.github.com/repos/amphp/byte-stream/zipball/acbd8002b3536485c997c4e019206b3f10ca15bd",
+                "reference": "acbd8002b3536485c997c4e019206b3f10ca15bd",
                 "shasum": ""
             },
             "require": {
@@ -345,22 +285,28 @@
             "support": {
                 "irc": "irc://irc.freenode.org/amphp",
                 "issues": "https://github.com/amphp/byte-stream/issues",
-                "source": "https://github.com/amphp/byte-stream/tree/master"
+                "source": "https://github.com/amphp/byte-stream/tree/v1.8.1"
             },
-            "time": "2020-06-29T18:35:05+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-03-30T17:13:30+00:00"
         },
         {
             "name": "composer/package-versions-deprecated",
-            "version": "1.11.99.1",
+            "version": "1.11.99.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/package-versions-deprecated.git",
-                "reference": "7413f0b55a051e89485c5cb9f765fe24bb02a7b6"
+                "reference": "fff576ac850c045158a250e7e27666e146e78d18"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/package-versions-deprecated/zipball/7413f0b55a051e89485c5cb9f765fe24bb02a7b6",
-                "reference": "7413f0b55a051e89485c5cb9f765fe24bb02a7b6",
+                "url": "https://api.github.com/repos/composer/package-versions-deprecated/zipball/fff576ac850c045158a250e7e27666e146e78d18",
+                "reference": "fff576ac850c045158a250e7e27666e146e78d18",
                 "shasum": ""
             },
             "require": {
@@ -404,7 +350,7 @@
             "description": "Composer plugin that provides efficient querying for installed package versions (no runtime IO)",
             "support": {
                 "issues": "https://github.com/composer/package-versions-deprecated/issues",
-                "source": "https://github.com/composer/package-versions-deprecated/tree/1.11.99.1"
+                "source": "https://github.com/composer/package-versions-deprecated/tree/1.11.99.3"
             },
             "funding": [
                 {
@@ -420,20 +366,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-11-11T10:22:58+00:00"
+            "time": "2021-08-17T13:49:14+00:00"
         },
         {
             "name": "composer/semver",
-            "version": "3.2.4",
+            "version": "3.2.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/semver.git",
-                "reference": "a02fdf930a3c1c3ed3a49b5f63859c0c20e10464"
+                "reference": "31f3ea725711245195f62e54ffa402d8ef2fdba9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/semver/zipball/a02fdf930a3c1c3ed3a49b5f63859c0c20e10464",
-                "reference": "a02fdf930a3c1c3ed3a49b5f63859c0c20e10464",
+                "url": "https://api.github.com/repos/composer/semver/zipball/31f3ea725711245195f62e54ffa402d8ef2fdba9",
+                "reference": "31f3ea725711245195f62e54ffa402d8ef2fdba9",
                 "shasum": ""
             },
             "require": {
@@ -485,7 +431,7 @@
             "support": {
                 "irc": "irc://irc.freenode.org/composer",
                 "issues": "https://github.com/composer/semver/issues",
-                "source": "https://github.com/composer/semver/tree/3.2.4"
+                "source": "https://github.com/composer/semver/tree/3.2.5"
             },
             "funding": [
                 {
@@ -501,28 +447,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-11-13T08:59:24+00:00"
+            "time": "2021-05-24T12:41:47+00:00"
         },
         {
             "name": "composer/xdebug-handler",
-            "version": "1.4.5",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/xdebug-handler.git",
-                "reference": "f28d44c286812c714741478d968104c5e604a1d4"
+                "reference": "84674dd3a7575ba617f5a76d7e9e29a7d3891339"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/f28d44c286812c714741478d968104c5e604a1d4",
-                "reference": "f28d44c286812c714741478d968104c5e604a1d4",
+                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/84674dd3a7575ba617f5a76d7e9e29a7d3891339",
+                "reference": "84674dd3a7575ba617f5a76d7e9e29a7d3891339",
                 "shasum": ""
             },
             "require": {
                 "php": "^5.3.2 || ^7.0 || ^8.0",
-                "psr/log": "^1.0"
+                "psr/log": "^1 || ^2 || ^3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || 6.5 - 8"
+                "phpstan/phpstan": "^0.12.55",
+                "symfony/phpunit-bridge": "^4.2 || ^5"
             },
             "type": "library",
             "autoload": {
@@ -548,7 +495,7 @@
             "support": {
                 "irc": "irc://irc.freenode.org/composer",
                 "issues": "https://github.com/composer/xdebug-handler/issues",
-                "source": "https://github.com/composer/xdebug-handler/tree/1.4.5"
+                "source": "https://github.com/composer/xdebug-handler/tree/2.0.2"
             },
             "funding": [
                 {
@@ -564,7 +511,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-11-13T08:04:11+00:00"
+            "time": "2021-07-31T17:03:58+00:00"
         },
         {
             "name": "container-interop/container-interop",
@@ -601,6 +548,76 @@
             },
             "abandoned": "psr/container",
             "time": "2017-02-14T19:40:03+00:00"
+        },
+        {
+            "name": "dealerdirect/phpcodesniffer-composer-installer",
+            "version": "v0.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer.git",
+                "reference": "fe390591e0241955f22eb9ba327d137e501c771c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/fe390591e0241955f22eb9ba327d137e501c771c",
+                "reference": "fe390591e0241955f22eb9ba327d137e501c771c",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0 || ^2.0",
+                "php": ">=5.3",
+                "squizlabs/php_codesniffer": "^2.0 || ^3.0 || ^4.0"
+            },
+            "require-dev": {
+                "composer/composer": "*",
+                "phpcompatibility/php-compatibility": "^9.0",
+                "sensiolabs/security-checker": "^4.1.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Franck Nijhof",
+                    "email": "franck.nijhof@dealerdirect.com",
+                    "homepage": "http://www.frenck.nl",
+                    "role": "Developer / IT Manager"
+                }
+            ],
+            "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
+            "homepage": "http://www.dealerdirect.com",
+            "keywords": [
+                "PHPCodeSniffer",
+                "PHP_CodeSniffer",
+                "code quality",
+                "codesniffer",
+                "composer",
+                "installer",
+                "phpcs",
+                "plugin",
+                "qa",
+                "quality",
+                "standard",
+                "standards",
+                "style guide",
+                "stylecheck",
+                "tests"
+            ],
+            "support": {
+                "issues": "https://github.com/dealerdirect/phpcodesniffer-composer-installer/issues",
+                "source": "https://github.com/dealerdirect/phpcodesniffer-composer-installer"
+            },
+            "time": "2020-12-07T18:04:37+00:00"
         },
         {
             "name": "dnoegel/php-xdg-base-dir",
@@ -710,20 +727,20 @@
         },
         {
             "name": "felixfbecker/advanced-json-rpc",
-            "version": "v3.2.0",
+            "version": "v3.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/felixfbecker/php-advanced-json-rpc.git",
-                "reference": "06f0b06043c7438959dbdeed8bb3f699a19be22e"
+                "reference": "b5f37dbff9a8ad360ca341f3240dc1c168b45447"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/felixfbecker/php-advanced-json-rpc/zipball/06f0b06043c7438959dbdeed8bb3f699a19be22e",
-                "reference": "06f0b06043c7438959dbdeed8bb3f699a19be22e",
+                "url": "https://api.github.com/repos/felixfbecker/php-advanced-json-rpc/zipball/b5f37dbff9a8ad360ca341f3240dc1c168b45447",
+                "reference": "b5f37dbff9a8ad360ca341f3240dc1c168b45447",
                 "shasum": ""
             },
             "require": {
-                "netresearch/jsonmapper": "^1.0 || ^2.0",
+                "netresearch/jsonmapper": "^1.0 || ^2.0 || ^3.0 || ^4.0",
                 "php": "^7.1 || ^8.0",
                 "phpdocumentor/reflection-docblock": "^4.3.4 || ^5.0.0"
             },
@@ -749,22 +766,22 @@
             "description": "A more advanced JSONRPC implementation",
             "support": {
                 "issues": "https://github.com/felixfbecker/php-advanced-json-rpc/issues",
-                "source": "https://github.com/felixfbecker/php-advanced-json-rpc/tree/v3.2.0"
+                "source": "https://github.com/felixfbecker/php-advanced-json-rpc/tree/v3.2.1"
             },
-            "time": "2021-01-10T17:48:47+00:00"
+            "time": "2021-06-11T22:34:44+00:00"
         },
         {
             "name": "felixfbecker/language-server-protocol",
-            "version": "v1.5.0",
+            "version": "1.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/felixfbecker/php-language-server-protocol.git",
-                "reference": "85e83cacd2ed573238678c6875f8f0d7ec699541"
+                "reference": "9d846d1f5cf101deee7a61c8ba7caa0a975cd730"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/felixfbecker/php-language-server-protocol/zipball/85e83cacd2ed573238678c6875f8f0d7ec699541",
-                "reference": "85e83cacd2ed573238678c6875f8f0d7ec699541",
+                "url": "https://api.github.com/repos/felixfbecker/php-language-server-protocol/zipball/9d846d1f5cf101deee7a61c8ba7caa0a975cd730",
+                "reference": "9d846d1f5cf101deee7a61c8ba7caa0a975cd730",
                 "shasum": ""
             },
             "require": {
@@ -805,22 +822,22 @@
             ],
             "support": {
                 "issues": "https://github.com/felixfbecker/php-language-server-protocol/issues",
-                "source": "https://github.com/felixfbecker/php-language-server-protocol/tree/v1.5.0"
+                "source": "https://github.com/felixfbecker/php-language-server-protocol/tree/1.5.1"
             },
-            "time": "2020-10-23T13:55:30+00:00"
+            "time": "2021-02-22T14:02:09+00:00"
         },
         {
             "name": "laminas/laminas-cache",
-            "version": "2.10.0",
+            "version": "2.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-cache.git",
-                "reference": "060b2a71d42b12122a3546594727e7d4b870abd5"
+                "reference": "566948e32f30881cb903ffbd0e3e20dac00cd83e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-cache/zipball/060b2a71d42b12122a3546594727e7d4b870abd5",
-                "reference": "060b2a71d42b12122a3546594727e7d4b870abd5",
+                "url": "https://api.github.com/repos/laminas/laminas-cache/zipball/566948e32f30881cb903ffbd0e3e20dac00cd83e",
+                "reference": "566948e32f30881cb903ffbd0e3e20dac00cd83e",
                 "shasum": ""
             },
             "require": {
@@ -839,13 +856,16 @@
                 "laminas/laminas-cache-storage-adapter-wincache": "^1.0",
                 "laminas/laminas-cache-storage-adapter-xcache": "^1.0",
                 "laminas/laminas-cache-storage-adapter-zend-server": "^1.0",
-                "laminas/laminas-eventmanager": "^2.6.3 || ^3.2",
-                "laminas/laminas-servicemanager": "^2.7.8 || ^3.3",
-                "laminas/laminas-stdlib": "^3.2.1",
+                "laminas/laminas-eventmanager": "^3.3",
+                "laminas/laminas-servicemanager": "^3.6",
+                "laminas/laminas-stdlib": "^3.3",
                 "laminas/laminas-zendframework-bridge": "^1.0",
-                "php": "^5.6 || ^7.0",
+                "php": "^7.3 || ~8.0.0",
                 "psr/cache": "^1.0",
                 "psr/simple-cache": "^1.0"
+            },
+            "conflict": {
+                "symfony/console": "<5.1"
             },
             "provide": {
                 "psr/cache-implementation": "1.0",
@@ -855,13 +875,17 @@
                 "zendframework/zend-cache": "^2.9.0"
             },
             "require-dev": {
-                "cache/integration-tests": "^0.16",
+                "laminas/laminas-cli": "^1.0",
                 "laminas/laminas-coding-standard": "~1.0.0",
+                "laminas/laminas-config-aggregator": "^1.5",
+                "laminas/laminas-feed": "^2.14",
                 "laminas/laminas-serializer": "^2.6",
-                "phpbench/phpbench": "^0.13",
-                "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1.2"
+                "phpbench/phpbench": "^1.0.0-beta2",
+                "phpspec/prophecy-phpunit": "^2.0",
+                "phpunit/phpunit": "^9.5"
             },
             "suggest": {
+                "laminas/laminas-cli": "The laminas-cli binary can be used to consume commands provided by this component",
                 "laminas/laminas-serializer": "Laminas\\Serializer component"
             },
             "type": "library",
@@ -905,7 +929,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2020-11-08T13:01:19+00:00"
+            "time": "2021-08-08T10:21:18+00:00"
         },
         {
             "name": "laminas/laminas-cache-storage-adapter-apc",
@@ -967,24 +991,25 @@
                     "type": "community_bridge"
                 }
             ],
+            "abandoned": true,
             "time": "2020-10-12T16:04:12+00:00"
         },
         {
             "name": "laminas/laminas-cache-storage-adapter-apcu",
-            "version": "1.0.1",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-cache-storage-adapter-apcu.git",
-                "reference": "1fdd7585042c1a577f6e630535df1e86e23cf5dc"
+                "reference": "e182aab739d6b03992a9915cc3c7019391a94548"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-cache-storage-adapter-apcu/zipball/1fdd7585042c1a577f6e630535df1e86e23cf5dc",
-                "reference": "1fdd7585042c1a577f6e630535df1e86e23cf5dc",
+                "url": "https://api.github.com/repos/laminas/laminas-cache-storage-adapter-apcu/zipball/e182aab739d6b03992a9915cc3c7019391a94548",
+                "reference": "e182aab739d6b03992a9915cc3c7019391a94548",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6 || ^7.0"
+                "php": "^7.3 || ~8.0.0"
             },
             "conflict": {
                 "laminas/laminas-cache": "<2.10"
@@ -993,8 +1018,9 @@
                 "laminas/laminas-cache-storage-implementation": "1.0"
             },
             "require-dev": {
-                "laminas/laminas-cache": "^2.10",
-                "laminas/laminas-cache-storage-adapter-test": "^1.0@dev",
+                "ext-apcu": "*",
+                "laminas/laminas-cache": "^2.10.1",
+                "laminas/laminas-cache-storage-adapter-test": "^1.1.1",
                 "laminas/laminas-coding-standard": "~1.0.0",
                 "squizlabs/php_codesniffer": "^2.7"
             },
@@ -1029,24 +1055,24 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2020-10-12T16:05:19+00:00"
+            "time": "2021-05-03T20:41:53+00:00"
         },
         {
             "name": "laminas/laminas-cache-storage-adapter-blackhole",
-            "version": "1.0.1",
+            "version": "1.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-cache-storage-adapter-blackhole.git",
-                "reference": "5f2cb437160fbc01d7f216b11e4f1ff4c9b95c49"
+                "reference": "4af1053efd81785a292c2a9442871c075700345a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-cache-storage-adapter-blackhole/zipball/5f2cb437160fbc01d7f216b11e4f1ff4c9b95c49",
-                "reference": "5f2cb437160fbc01d7f216b11e4f1ff4c9b95c49",
+                "url": "https://api.github.com/repos/laminas/laminas-cache-storage-adapter-blackhole/zipball/4af1053efd81785a292c2a9442871c075700345a",
+                "reference": "4af1053efd81785a292c2a9442871c075700345a",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6 || ^7.0"
+                "php": "^7.3 || ~8.0.0"
             },
             "conflict": {
                 "laminas/laminas-cache": "<2.10"
@@ -1055,10 +1081,10 @@
                 "laminas/laminas-cache-storage-implementation": "1.0"
             },
             "require-dev": {
-                "laminas/laminas-cache": "^2.10",
-                "laminas/laminas-cache-storage-adapter-test": "^1.0@dev",
-                "laminas/laminas-coding-standard": "~1.0.0",
-                "squizlabs/php_codesniffer": "^2.7"
+                "laminas/laminas-cache": "^2.10.1",
+                "laminas/laminas-cache-storage-adapter-test": "^1.1.1",
+                "laminas/laminas-coding-standard": "^2.1.4",
+                "squizlabs/php_codesniffer": "^3.5.8"
             },
             "type": "library",
             "autoload": {
@@ -1088,7 +1114,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2020-10-12T16:07:07+00:00"
+            "time": "2021-04-29T21:06:24+00:00"
         },
         {
             "name": "laminas/laminas-cache-storage-adapter-dba",
@@ -1150,39 +1176,44 @@
                     "type": "community_bridge"
                 }
             ],
+            "abandoned": true,
             "time": "2020-10-12T16:08:58+00:00"
         },
         {
             "name": "laminas/laminas-cache-storage-adapter-ext-mongodb",
-            "version": "1.0.1",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-cache-storage-adapter-ext-mongodb.git",
-                "reference": "011ec5a8ca721ba012d232b1a01b50a55904b99f"
+                "reference": "72f68589cc8323fa688167a4720b795dd0907f4e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-cache-storage-adapter-ext-mongodb/zipball/011ec5a8ca721ba012d232b1a01b50a55904b99f",
-                "reference": "011ec5a8ca721ba012d232b1a01b50a55904b99f",
+                "url": "https://api.github.com/repos/laminas/laminas-cache-storage-adapter-ext-mongodb/zipball/72f68589cc8323fa688167a4720b795dd0907f4e",
+                "reference": "72f68589cc8323fa688167a4720b795dd0907f4e",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6 || ^7.0"
+                "php": "^7.3 || ~8.0.0"
             },
             "conflict": {
-                "laminas/laminas-cache": "<2.10"
+                "laminas/laminas-cache": "<2.10",
+                "mongodb/mongodb": "<1.8"
             },
             "provide": {
                 "laminas/laminas-cache-storage-implementation": "1.0"
             },
             "require-dev": {
-                "laminas/laminas-cache": "^2.10",
-                "laminas/laminas-cache-storage-adapter-test": "^1.0@dev",
-                "laminas/laminas-coding-standard": "~1.0.0",
-                "squizlabs/php_codesniffer": "^2.7"
+                "laminas/laminas-cache": "^2.10.3",
+                "laminas/laminas-cache-storage-adapter-test": "^1.1.1",
+                "laminas/laminas-coding-standard": "~2.2.0",
+                "laminas/laminas-serializer": "^2.10.1",
+                "mongodb/mongodb": "^1.8.0",
+                "psalm/plugin-phpunit": "^0.16.1",
+                "vimeo/psalm": "^4.9"
             },
             "suggest": {
-                "ext-mongodb": "MongoDB, to use the ExtMongoDb storage adapter"
+                "mongodb/mongodb": "MongoDB, to use the ExtMongoDb storage adapter"
             },
             "type": "library",
             "autoload": {
@@ -1212,32 +1243,37 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2020-10-12T16:11:06+00:00"
+            "time": "2021-08-10T18:17:48+00:00"
         },
         {
             "name": "laminas/laminas-cache-storage-adapter-filesystem",
-            "version": "1.1.0",
+            "version": "1.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-cache-storage-adapter-filesystem.git",
-                "reference": "e803d9942b30396491efbe649a3886450d22385f"
+                "reference": "76fc488c3fa0ad442e4e70f807305c940d1bdcbc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-cache-storage-adapter-filesystem/zipball/e803d9942b30396491efbe649a3886450d22385f",
-                "reference": "e803d9942b30396491efbe649a3886450d22385f",
+                "url": "https://api.github.com/repos/laminas/laminas-cache-storage-adapter-filesystem/zipball/76fc488c3fa0ad442e4e70f807305c940d1bdcbc",
+                "reference": "76fc488c3fa0ad442e4e70f807305c940d1bdcbc",
                 "shasum": ""
             },
             "require": {
-                "laminas/laminas-cache": "^2.10@dev",
                 "php": "^7.3 || ~8.0.0"
+            },
+            "conflict": {
+                "laminas/laminas-cache": "<2.10"
             },
             "provide": {
                 "laminas/laminas-cache-storage-implementation": "1.0"
             },
             "require-dev": {
-                "laminas/laminas-cache-storage-adapter-test": "^1.0@dev",
+                "laminas/laminas-cache": "^2.10",
+                "laminas/laminas-cache-storage-adapter-test": "^1.1.1",
                 "laminas/laminas-coding-standard": "~1.0.0",
+                "laminas/laminas-serializer": "^2.10",
+                "phpunit/phpunit": "^9.5",
                 "squizlabs/php_codesniffer": "^2.7"
             },
             "type": "library",
@@ -1268,24 +1304,24 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2020-12-31T04:18:10+00:00"
+            "time": "2021-04-25T00:27:54+00:00"
         },
         {
             "name": "laminas/laminas-cache-storage-adapter-memcache",
-            "version": "1.0.1",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-cache-storage-adapter-memcache.git",
-                "reference": "62d0fab1cd261b44a81821e986c0110d7dda896b"
+                "reference": "1d2a74e300a0fd0b8d0e0cb4e379a173ccad0088"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-cache-storage-adapter-memcache/zipball/62d0fab1cd261b44a81821e986c0110d7dda896b",
-                "reference": "62d0fab1cd261b44a81821e986c0110d7dda896b",
+                "url": "https://api.github.com/repos/laminas/laminas-cache-storage-adapter-memcache/zipball/1d2a74e300a0fd0b8d0e0cb4e379a173ccad0088",
+                "reference": "1d2a74e300a0fd0b8d0e0cb4e379a173ccad0088",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6 || ^7.0"
+                "php": "^7.3 || ~8.0.0"
             },
             "conflict": {
                 "laminas/laminas-cache": "<2.10"
@@ -1294,10 +1330,11 @@
                 "laminas/laminas-cache-storage-implementation": "1.0"
             },
             "require-dev": {
-                "laminas/laminas-cache": "^2.10",
-                "laminas/laminas-cache-storage-adapter-test": "^1.0@dev",
-                "laminas/laminas-coding-standard": "~1.0.0",
-                "squizlabs/php_codesniffer": "^2.7"
+                "laminas/laminas-cache": "^2.10.1",
+                "laminas/laminas-cache-storage-adapter-test": "^1.1.1",
+                "laminas/laminas-coding-standard": "^2.1.4",
+                "laminas/laminas-serializer": "^2.10.1",
+                "squizlabs/php_codesniffer": "^3.6.0"
             },
             "suggest": {
                 "ext-memcache": "Memcache >= 2.0.0 to use the Memcache storage adapter"
@@ -1330,24 +1367,25 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2020-10-12T16:13:36+00:00"
+            "abandoned": true,
+            "time": "2021-04-29T19:57:43+00:00"
         },
         {
             "name": "laminas/laminas-cache-storage-adapter-memcached",
-            "version": "1.0.1",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-cache-storage-adapter-memcached.git",
-                "reference": "29599106bb501eb96207b175c460c95487518db1"
+                "reference": "d05f33e43a352b85c6d0208e9cfbf2a59f02ede3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-cache-storage-adapter-memcached/zipball/29599106bb501eb96207b175c460c95487518db1",
-                "reference": "29599106bb501eb96207b175c460c95487518db1",
+                "url": "https://api.github.com/repos/laminas/laminas-cache-storage-adapter-memcached/zipball/d05f33e43a352b85c6d0208e9cfbf2a59f02ede3",
+                "reference": "d05f33e43a352b85c6d0208e9cfbf2a59f02ede3",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6 || ^7.0"
+                "php": "^7.3 || ~8.0.0"
             },
             "conflict": {
                 "laminas/laminas-cache": "<2.10"
@@ -1357,9 +1395,12 @@
             },
             "require-dev": {
                 "laminas/laminas-cache": "^2.10",
-                "laminas/laminas-cache-storage-adapter-test": "^1.0@dev",
-                "laminas/laminas-coding-standard": "~1.0.0",
-                "squizlabs/php_codesniffer": "^2.7"
+                "laminas/laminas-cache-storage-adapter-test": "^1.0.2",
+                "laminas/laminas-coding-standard": "~2.2.0",
+                "phpunit/phpunit": "^9.5.8"
+            },
+            "suggest": {
+                "ext-memcached": "Memcached >= 1.0.0 to use the Memcached storage adapter"
             },
             "type": "library",
             "autoload": {
@@ -1374,7 +1415,8 @@
             "description": "Laminas cache adapter for memcached",
             "keywords": [
                 "cache",
-                "laminas"
+                "laminas",
+                "memcached"
             ],
             "support": {
                 "docs": "https://docs.laminas.dev/laminas-cache-storage-adapter-memcached/",
@@ -1389,24 +1431,24 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2020-10-12T16:16:42+00:00"
+            "time": "2021-08-08T14:51:12+00:00"
         },
         {
             "name": "laminas/laminas-cache-storage-adapter-memory",
-            "version": "1.0.1",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-cache-storage-adapter-memory.git",
-                "reference": "58f4b45281552bb6673c900fadddad21e0ed05c8"
+                "reference": "02c7a4a1118bbd47d1c0f0bfe1e8b140af79d2bd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-cache-storage-adapter-memory/zipball/58f4b45281552bb6673c900fadddad21e0ed05c8",
-                "reference": "58f4b45281552bb6673c900fadddad21e0ed05c8",
+                "url": "https://api.github.com/repos/laminas/laminas-cache-storage-adapter-memory/zipball/02c7a4a1118bbd47d1c0f0bfe1e8b140af79d2bd",
+                "reference": "02c7a4a1118bbd47d1c0f0bfe1e8b140af79d2bd",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6 || ^7.0"
+                "php": "^7.3 || ~8.0.0"
             },
             "conflict": {
                 "laminas/laminas-cache": "<2.10"
@@ -1415,10 +1457,10 @@
                 "laminas/laminas-cache-storage-implementation": "1.0"
             },
             "require-dev": {
-                "laminas/laminas-cache": "^2.10",
-                "laminas/laminas-cache-storage-adapter-test": "^1.0@dev",
-                "laminas/laminas-coding-standard": "~1.0.0",
-                "squizlabs/php_codesniffer": "^2.7"
+                "laminas/laminas-cache": "^2.10.1",
+                "laminas/laminas-cache-storage-adapter-test": "^1.1.1",
+                "laminas/laminas-coding-standard": "^2.1.4",
+                "squizlabs/php_codesniffer": "^3.5.8"
             },
             "type": "library",
             "autoload": {
@@ -1448,7 +1490,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2020-10-12T16:17:47+00:00"
+            "time": "2021-04-28T17:27:13+00:00"
         },
         {
             "name": "laminas/laminas-cache-storage-adapter-mongodb",
@@ -1507,36 +1549,43 @@
                     "type": "community_bridge"
                 }
             ],
+            "abandoned": true,
             "time": "2020-10-12T16:19:10+00:00"
         },
         {
             "name": "laminas/laminas-cache-storage-adapter-redis",
-            "version": "1.0.1",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-cache-storage-adapter-redis.git",
-                "reference": "3fe904953d17728d7fdaa87be603231f23fb0a4d"
+                "reference": "de8a63d4a0ef1ccead401eb7fb6d75b57fa3f9ee"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-cache-storage-adapter-redis/zipball/3fe904953d17728d7fdaa87be603231f23fb0a4d",
-                "reference": "3fe904953d17728d7fdaa87be603231f23fb0a4d",
+                "url": "https://api.github.com/repos/laminas/laminas-cache-storage-adapter-redis/zipball/de8a63d4a0ef1ccead401eb7fb6d75b57fa3f9ee",
+                "reference": "de8a63d4a0ef1ccead401eb7fb6d75b57fa3f9ee",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6 || ^7.0"
+                "php": "^7.3 || ~8.0.0"
             },
             "conflict": {
-                "laminas/laminas-cache": "<2.10"
+                "laminas/laminas-cache": "<2.10",
+                "phpunit/phpunit": "<6.1.0"
             },
             "provide": {
                 "laminas/laminas-cache-storage-implementation": "1.0"
             },
             "require-dev": {
+                "composer-runtime-api": "^2",
+                "ext-posix": "*",
+                "ext-redis": "*",
                 "laminas/laminas-cache": "^2.10",
-                "laminas/laminas-cache-storage-adapter-test": "^1.0@dev",
-                "laminas/laminas-coding-standard": "~1.0.0",
-                "squizlabs/php_codesniffer": "^2.7"
+                "laminas/laminas-cache-storage-adapter-test": "^1.1",
+                "laminas/laminas-coding-standard": "^2.1",
+                "laminas/laminas-serializer": "^2.10",
+                "psalm/plugin-phpunit": "^0.15.1",
+                "vimeo/psalm": "^4.7"
             },
             "type": "library",
             "autoload": {
@@ -1566,24 +1615,24 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2020-10-12T16:20:13+00:00"
+            "time": "2021-06-03T16:14:07+00:00"
         },
         {
             "name": "laminas/laminas-cache-storage-adapter-session",
-            "version": "1.0.1",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-cache-storage-adapter-session.git",
-                "reference": "0d2276cd61bd162cd38c53aaa22f18137621dc0c"
+                "reference": "74a275056cfca2300eb9a67cd1d917f7066b4113"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-cache-storage-adapter-session/zipball/0d2276cd61bd162cd38c53aaa22f18137621dc0c",
-                "reference": "0d2276cd61bd162cd38c53aaa22f18137621dc0c",
+                "url": "https://api.github.com/repos/laminas/laminas-cache-storage-adapter-session/zipball/74a275056cfca2300eb9a67cd1d917f7066b4113",
+                "reference": "74a275056cfca2300eb9a67cd1d917f7066b4113",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6 || ^7.0"
+                "php": "^7.3 || ~8.0.0"
             },
             "conflict": {
                 "laminas/laminas-cache": "<2.10"
@@ -1593,10 +1642,9 @@
             },
             "require-dev": {
                 "laminas/laminas-cache": "^2.10",
-                "laminas/laminas-cache-storage-adapter-test": "^1.0@dev",
-                "laminas/laminas-coding-standard": "~1.0.0",
-                "laminas/laminas-session": "^2.7.4",
-                "squizlabs/php_codesniffer": "^2.7"
+                "laminas/laminas-cache-storage-adapter-test": "^1.1",
+                "laminas/laminas-coding-standard": "^2.1",
+                "laminas/laminas-session": "^2.7.4"
             },
             "suggest": {
                 "laminas/laminas-session": "Laminas\\Session component"
@@ -1629,7 +1677,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2020-10-12T16:21:28+00:00"
+            "time": "2021-05-02T13:52:36+00:00"
         },
         {
             "name": "laminas/laminas-cache-storage-adapter-wincache",
@@ -1691,6 +1739,7 @@
                     "type": "community_bridge"
                 }
             ],
+            "abandoned": true,
             "time": "2020-10-12T16:22:49+00:00"
         },
         {
@@ -1754,6 +1803,7 @@
                     "type": "community_bridge"
                 }
             ],
+            "abandoned": true,
             "time": "2020-10-12T16:23:46+00:00"
         },
         {
@@ -1817,31 +1867,36 @@
         },
         {
             "name": "laminas/laminas-coding-standard",
-            "version": "1.0.0",
+            "version": "2.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-coding-standard.git",
-                "reference": "08880ce2fbfe62d471cd3cb766a91da630b32539"
+                "reference": "c953ecb1d37034f4aa326046e2c24a10fe0a2845"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-coding-standard/zipball/08880ce2fbfe62d471cd3cb766a91da630b32539",
-                "reference": "08880ce2fbfe62d471cd3cb766a91da630b32539",
+                "url": "https://api.github.com/repos/laminas/laminas-coding-standard/zipball/c953ecb1d37034f4aa326046e2c24a10fe0a2845",
+                "reference": "c953ecb1d37034f4aa326046e2c24a10fe0a2845",
                 "shasum": ""
             },
             "require": {
-                "laminas/laminas-zendframework-bridge": "^1.0",
-                "squizlabs/php_codesniffer": "^2.7"
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7",
+                "php": "^7.3 || ~8.0.0",
+                "slevomat/coding-standard": "^6.4.1",
+                "squizlabs/php_codesniffer": "^3.5.8",
+                "webimpress/coding-standard": "^1.1.6"
             },
-            "replace": {
-                "zendframework/zend-coding-standard": "self.version"
+            "type": "phpcodesniffer-standard",
+            "autoload": {
+                "psr-4": {
+                    "LaminasCodingStandard\\": "src/LaminasCodingStandard/"
+                }
             },
-            "type": "library",
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "BSD-3-Clause"
             ],
-            "description": "Laminas coding standard",
+            "description": "Laminas Coding Standard",
             "homepage": "https://laminas.dev",
             "keywords": [
                 "Coding Standard",
@@ -1855,48 +1910,51 @@
                 "rss": "https://github.com/laminas/laminas-coding-standard/releases.atom",
                 "source": "https://github.com/laminas/laminas-coding-standard"
             },
-            "time": "2019-12-31T16:28:26+00:00"
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2021-05-17T17:39:41+00:00"
         },
         {
             "name": "laminas/laminas-db",
-            "version": "2.11.3",
+            "version": "2.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-db.git",
-                "reference": "6c4238918b9204db1eb8cafae2c1940d40f4c007"
+                "reference": "80cbba4e749f9eb7d8036172acb9ad41e8b6923f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-db/zipball/6c4238918b9204db1eb8cafae2c1940d40f4c007",
-                "reference": "6c4238918b9204db1eb8cafae2c1940d40f4c007",
+                "url": "https://api.github.com/repos/laminas/laminas-db/zipball/80cbba4e749f9eb7d8036172acb9ad41e8b6923f",
+                "reference": "80cbba4e749f9eb7d8036172acb9ad41e8b6923f",
                 "shasum": ""
             },
             "require": {
-                "laminas/laminas-stdlib": "^2.7 || ^3.0",
+                "laminas/laminas-stdlib": "^3.3",
                 "laminas/laminas-zendframework-bridge": "^1.0",
-                "php": "^5.6 || ^7.0"
+                "php": "^7.3 || ~8.0.0"
             },
             "replace": {
                 "zendframework/zend-db": "^2.11.0"
             },
             "require-dev": {
                 "laminas/laminas-coding-standard": "~1.0.0",
-                "laminas/laminas-eventmanager": "^2.6.2 || ^3.0",
-                "laminas/laminas-hydrator": "^1.1 || ^2.1 || ^3.0",
-                "laminas/laminas-servicemanager": "^2.7.5 || ^3.0.3",
-                "phpunit/phpunit": "^5.7.27 || ^6.5.14"
+                "laminas/laminas-eventmanager": "^3.3",
+                "laminas/laminas-hydrator": "^3.2 || ^4.0",
+                "laminas/laminas-servicemanager": "^3.3",
+                "phpspec/prophecy-phpunit": "^2.0",
+                "phpunit/phpunit": "^9.3"
             },
             "suggest": {
                 "laminas/laminas-eventmanager": "Laminas\\EventManager component",
-                "laminas/laminas-hydrator": "Laminas\\Hydrator component for using HydratingResultSets",
+                "laminas/laminas-hydrator": "(^3.2 || ^4.0) Laminas\\Hydrator component for using HydratingResultSets",
                 "laminas/laminas-servicemanager": "Laminas\\ServiceManager component"
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-master": "2.11.x-dev",
-                    "dev-develop": "2.12.x-dev"
-                },
                 "laminas": {
                     "component": "Laminas\\Db",
                     "config-provider": "Laminas\\Db\\ConfigProvider"
@@ -1925,47 +1983,47 @@
                 "rss": "https://github.com/laminas/laminas-db/releases.atom",
                 "source": "https://github.com/laminas/laminas-db"
             },
-            "time": "2020-03-29T12:08:51+00:00"
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2021-02-22T22:27:56+00:00"
         },
         {
             "name": "laminas/laminas-eventmanager",
-            "version": "3.3.0",
+            "version": "3.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-eventmanager.git",
-                "reference": "1940ccf30e058b2fd66f5a9d696f1b5e0027b082"
+                "reference": "a93fd278c97b2d41ebbce5ba048a24e3e6f580ba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-eventmanager/zipball/1940ccf30e058b2fd66f5a9d696f1b5e0027b082",
-                "reference": "1940ccf30e058b2fd66f5a9d696f1b5e0027b082",
+                "url": "https://api.github.com/repos/laminas/laminas-eventmanager/zipball/a93fd278c97b2d41ebbce5ba048a24e3e6f580ba",
+                "reference": "a93fd278c97b2d41ebbce5ba048a24e3e6f580ba",
                 "shasum": ""
             },
             "require": {
-                "laminas/laminas-zendframework-bridge": "^1.0",
-                "php": "^7.3 || ^8.0"
+                "php": "^7.3 || ~8.0.0 || ~8.1.0"
             },
-            "replace": {
-                "zendframework/zend-eventmanager": "^3.2.1"
+            "conflict": {
+                "zendframework/zend-eventmanager": "*"
             },
             "require-dev": {
                 "container-interop/container-interop": "^1.1",
-                "laminas/laminas-coding-standard": "~1.0.0",
-                "laminas/laminas-stdlib": "^2.7.3 || ^3.0",
-                "phpbench/phpbench": "^0.17.1",
-                "phpunit/phpunit": "^8.5.8"
+                "laminas/laminas-coding-standard": "~2.2.1",
+                "laminas/laminas-stdlib": "^3.6",
+                "phpbench/phpbench": "^1.1",
+                "phpspec/prophecy-phpunit": "^2.0",
+                "phpunit/phpunit": "^9.5.5"
             },
             "suggest": {
                 "container-interop/container-interop": "^1.1, to use the lazy listeners feature",
                 "laminas/laminas-stdlib": "^2.7.3 || ^3.0, to use the FilterChain feature"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.3.x-dev",
-                    "dev-develop": "3.4.x-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Laminas\\EventManager\\": "src/"
@@ -1997,37 +2055,35 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2020-08-25T11:10:44+00:00"
+            "time": "2021-09-07T22:35:32+00:00"
         },
         {
             "name": "laminas/laminas-http",
-            "version": "2.14.2",
+            "version": "2.15.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-http.git",
-                "reference": "298f732e1acb031db70ea4fd2133a283b2a4a65e"
+                "reference": "e1f3420ab35e21ea135913d213b8d570e5e7b513"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-http/zipball/298f732e1acb031db70ea4fd2133a283b2a4a65e",
-                "reference": "298f732e1acb031db70ea4fd2133a283b2a4a65e",
+                "url": "https://api.github.com/repos/laminas/laminas-http/zipball/e1f3420ab35e21ea135913d213b8d570e5e7b513",
+                "reference": "e1f3420ab35e21ea135913d213b8d570e5e7b513",
                 "shasum": ""
             },
             "require": {
-                "laminas/laminas-loader": "^2.5.1",
-                "laminas/laminas-stdlib": "^3.2.1",
-                "laminas/laminas-uri": "^2.5.2",
-                "laminas/laminas-validator": "^2.10.1",
-                "laminas/laminas-zendframework-bridge": "^1.0",
-                "php": "^7.3 || ~8.0.0"
+                "laminas/laminas-loader": "^2.8",
+                "laminas/laminas-stdlib": "^3.6",
+                "laminas/laminas-uri": "^2.9.1",
+                "laminas/laminas-validator": "^2.15",
+                "php": "^7.3 || ~8.0.0 || ~8.1.0"
             },
-            "replace": {
-                "zendframework/zend-http": "^2.11.2"
+            "conflict": {
+                "zendframework/zend-http": "*"
             },
             "require-dev": {
-                "laminas/laminas-coding-standard": "~1.0.0",
-                "laminas/laminas-config": "^3.1 || ^2.6",
-                "phpunit/phpunit": "^9.3"
+                "laminas/laminas-coding-standard": "~2.2.1",
+                "phpunit/phpunit": "^9.5.5"
             },
             "suggest": {
                 "paragonie/certainty": "For automated management of cacert.pem"
@@ -2063,40 +2119,33 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2021-01-05T16:10:52+00:00"
+            "time": "2021-09-10T10:45:31+00:00"
         },
         {
             "name": "laminas/laminas-loader",
-            "version": "2.6.1",
+            "version": "2.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-loader.git",
-                "reference": "5d01c2c237ae9e68bec262f339947e2ea18979bc"
+                "reference": "d0589ec9dd48365fd95ad10d1c906efd7711c16b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-loader/zipball/5d01c2c237ae9e68bec262f339947e2ea18979bc",
-                "reference": "5d01c2c237ae9e68bec262f339947e2ea18979bc",
+                "url": "https://api.github.com/repos/laminas/laminas-loader/zipball/d0589ec9dd48365fd95ad10d1c906efd7711c16b",
+                "reference": "d0589ec9dd48365fd95ad10d1c906efd7711c16b",
                 "shasum": ""
             },
             "require": {
-                "laminas/laminas-zendframework-bridge": "^1.0",
-                "php": "^5.6 || ^7.0"
+                "php": "^7.3 || ~8.0.0 || ~8.1.0"
             },
-            "replace": {
-                "zendframework/zend-loader": "self.version"
+            "conflict": {
+                "zendframework/zend-loader": "*"
             },
             "require-dev": {
-                "laminas/laminas-coding-standard": "~1.0.0",
-                "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1.4"
+                "laminas/laminas-coding-standard": "~2.2.1",
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.6.x-dev",
-                    "dev-develop": "2.7.x-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Laminas\\Loader\\": "src/"
@@ -2120,20 +2169,26 @@
                 "rss": "https://github.com/laminas/laminas-loader/releases.atom",
                 "source": "https://github.com/laminas/laminas-loader"
             },
-            "time": "2019-12-31T17:18:27+00:00"
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2021-09-02T18:30:53+00:00"
         },
         {
             "name": "laminas/laminas-servicemanager",
-            "version": "3.6.4",
+            "version": "3.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-servicemanager.git",
-                "reference": "b1445e1a7077c21b0fad0974a1b7a11b9dbe0828"
+                "reference": "2b0aee477fdbd3191af7c302b93dbc5fda0626f4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-servicemanager/zipball/b1445e1a7077c21b0fad0974a1b7a11b9dbe0828",
-                "reference": "b1445e1a7077c21b0fad0974a1b7a11b9dbe0828",
+                "url": "https://api.github.com/repos/laminas/laminas-servicemanager/zipball/2b0aee477fdbd3191af7c302b93dbc5fda0626f4",
+                "reference": "2b0aee477fdbd3191af7c302b93dbc5fda0626f4",
                 "shasum": ""
             },
             "require": {
@@ -2156,14 +2211,16 @@
             },
             "require-dev": {
                 "composer/package-versions-deprecated": "^1.0",
-                "laminas/laminas-coding-standard": "~1.0.0",
+                "laminas/laminas-coding-standard": "~2.2.0",
                 "laminas/laminas-container-config-test": "^0.3",
-                "laminas/laminas-dependency-plugin": "^2.1",
+                "laminas/laminas-dependency-plugin": "^2.1.2",
                 "mikey179/vfsstream": "^1.6.8",
                 "ocramius/proxy-manager": "^2.2.3",
-                "phpbench/phpbench": "^1.0.0-alpha3",
+                "phpbench/phpbench": "^1.0.4",
                 "phpspec/prophecy-phpunit": "^2.0",
-                "phpunit/phpunit": "^9.4"
+                "phpunit/phpunit": "^9.4",
+                "psalm/plugin-phpunit": "^0.16.1",
+                "vimeo/psalm": "^4.8"
             },
             "suggest": {
                 "ocramius/proxy-manager": "ProxyManager ^2.1.1 to handle lazy initialization of services"
@@ -2207,34 +2264,33 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2021-02-03T08:44:41+00:00"
+            "time": "2021-07-24T19:33:07+00:00"
         },
         {
             "name": "laminas/laminas-uri",
-            "version": "2.8.0",
+            "version": "2.9.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-uri.git",
-                "reference": "8651611b6285529f25a4cb9a466c686d9b31468e"
+                "reference": "7e837dc15c8fd3949df7d1213246fd7c8640032b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-uri/zipball/8651611b6285529f25a4cb9a466c686d9b31468e",
-                "reference": "8651611b6285529f25a4cb9a466c686d9b31468e",
+                "url": "https://api.github.com/repos/laminas/laminas-uri/zipball/7e837dc15c8fd3949df7d1213246fd7c8640032b",
+                "reference": "7e837dc15c8fd3949df7d1213246fd7c8640032b",
                 "shasum": ""
             },
             "require": {
-                "laminas/laminas-escaper": "^2.5",
-                "laminas/laminas-validator": "^2.10",
-                "laminas/laminas-zendframework-bridge": "^1.0",
-                "php": "^7.3 || ~8.0.0"
+                "laminas/laminas-escaper": "^2.9",
+                "laminas/laminas-validator": "^2.15",
+                "php": "^7.3 || ~8.0.0 || ~8.1.0"
             },
-            "replace": {
-                "zendframework/zend-uri": "^2.7.1"
+            "conflict": {
+                "zendframework/zend-uri": "*"
             },
             "require-dev": {
-                "laminas/laminas-coding-standard": "^2.1",
-                "phpunit/phpunit": "^9.3"
+                "laminas/laminas-coding-standard": "~2.2.1",
+                "phpunit/phpunit": "^9.5.5"
             },
             "type": "library",
             "autoload": {
@@ -2266,35 +2322,33 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2020-10-31T20:20:07+00:00"
+            "time": "2021-09-09T18:37:15+00:00"
         },
         {
             "name": "laminas/laminas-validator",
-            "version": "2.14.4",
+            "version": "2.15.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-validator.git",
-                "reference": "e370c4695db1c81e6dfad38d8c4dbdb37b23d776"
+                "reference": "270380e87904f5a1a1fba3059989d4ca157e16a9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-validator/zipball/e370c4695db1c81e6dfad38d8c4dbdb37b23d776",
-                "reference": "e370c4695db1c81e6dfad38d8c4dbdb37b23d776",
+                "url": "https://api.github.com/repos/laminas/laminas-validator/zipball/270380e87904f5a1a1fba3059989d4ca157e16a9",
+                "reference": "270380e87904f5a1a1fba3059989d4ca157e16a9",
                 "shasum": ""
             },
             "require": {
                 "container-interop/container-interop": "^1.1",
-                "laminas/laminas-stdlib": "^3.3",
-                "laminas/laminas-zendframework-bridge": "^1.0",
-                "php": "^7.3 || ~8.0.0"
+                "laminas/laminas-stdlib": "^3.6",
+                "php": "^7.3 || ~8.0.0 || ~8.1.0"
             },
-            "replace": {
-                "zendframework/zend-validator": "^2.13.0"
+            "conflict": {
+                "zendframework/zend-validator": "*"
             },
             "require-dev": {
                 "laminas/laminas-cache": "^2.6.1",
-                "laminas/laminas-coding-standard": "~1.0.0",
-                "laminas/laminas-config": "^2.6",
+                "laminas/laminas-coding-standard": "~2.2.1",
                 "laminas/laminas-db": "^2.7",
                 "laminas/laminas-filter": "^2.6",
                 "laminas/laminas-http": "^2.14.2",
@@ -2304,7 +2358,7 @@
                 "laminas/laminas-session": "^2.8",
                 "laminas/laminas-uri": "^2.7",
                 "phpspec/prophecy-phpunit": "^2.0",
-                "phpunit/phpunit": "^9.3",
+                "phpunit/phpunit": "^9.5.5",
                 "psalm/plugin-phpunit": "^0.15.0",
                 "psr/http-client": "^1.0",
                 "psr/http-factory": "^1.0",
@@ -2358,7 +2412,69 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2021-01-24T20:45:49+00:00"
+            "time": "2021-09-08T23:16:56+00:00"
+        },
+        {
+            "name": "laminas/laminas-zendframework-bridge",
+            "version": "1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-zendframework-bridge.git",
+                "reference": "bf180a382393e7db5c1e8d0f2ec0c4af9c724baf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-zendframework-bridge/zipball/bf180a382393e7db5c1e8d0f2ec0c4af9c724baf",
+                "reference": "bf180a382393e7db5c1e8d0f2ec0c4af9c724baf",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3 || ~8.0.0 || ~8.1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3",
+                "psalm/plugin-phpunit": "^0.15.1",
+                "squizlabs/php_codesniffer": "^3.5",
+                "vimeo/psalm": "^4.6"
+            },
+            "type": "library",
+            "extra": {
+                "laminas": {
+                    "module": "Laminas\\ZendFrameworkBridge"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/autoload.php"
+                ],
+                "psr-4": {
+                    "Laminas\\ZendFrameworkBridge\\": "src//"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Alias legacy ZF class names to Laminas Project equivalents.",
+            "keywords": [
+                "ZendFramework",
+                "autoloading",
+                "laminas",
+                "zf"
+            ],
+            "support": {
+                "forum": "https://discourse.laminas.dev/",
+                "issues": "https://github.com/laminas/laminas-zendframework-bridge/issues",
+                "rss": "https://github.com/laminas/laminas-zendframework-bridge/releases.atom",
+                "source": "https://github.com/laminas/laminas-zendframework-bridge"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2021-09-03T17:53:30+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -2420,16 +2536,16 @@
         },
         {
             "name": "netresearch/jsonmapper",
-            "version": "v2.1.0",
+            "version": "v4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cweiske/jsonmapper.git",
-                "reference": "e0f1e33a71587aca81be5cffbb9746510e1fe04e"
+                "reference": "8bbc021a8edb2e4a7ea2f8ad4fa9ec9dce2fcb8d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cweiske/jsonmapper/zipball/e0f1e33a71587aca81be5cffbb9746510e1fe04e",
-                "reference": "e0f1e33a71587aca81be5cffbb9746510e1fe04e",
+                "url": "https://api.github.com/repos/cweiske/jsonmapper/zipball/8bbc021a8edb2e4a7ea2f8ad4fa9ec9dce2fcb8d",
+                "reference": "8bbc021a8edb2e4a7ea2f8ad4fa9ec9dce2fcb8d",
                 "shasum": ""
             },
             "require": {
@@ -2437,10 +2553,10 @@
                 "ext-pcre": "*",
                 "ext-reflection": "*",
                 "ext-spl": "*",
-                "php": ">=5.6"
+                "php": ">=7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.8.35 || ~5.7 || ~6.4 || ~7.0",
+                "phpunit/phpunit": "~7.5 || ~8.0 || ~9.0",
                 "squizlabs/php_codesniffer": "~3.5"
             },
             "type": "library",
@@ -2465,22 +2581,22 @@
             "support": {
                 "email": "cweiske@cweiske.de",
                 "issues": "https://github.com/cweiske/jsonmapper/issues",
-                "source": "https://github.com/cweiske/jsonmapper/tree/master"
+                "source": "https://github.com/cweiske/jsonmapper/tree/v4.0.0"
             },
-            "time": "2020-04-16T18:48:43+00:00"
+            "time": "2020-12-01T19:48:11+00:00"
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.10.4",
+            "version": "v4.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "c6d052fc58cb876152f89f532b95a8d7907e7f0e"
+                "reference": "6608f01670c3cc5079e18c1dab1104e002579143"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/c6d052fc58cb876152f89f532b95a8d7907e7f0e",
-                "reference": "c6d052fc58cb876152f89f532b95a8d7907e7f0e",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/6608f01670c3cc5079e18c1dab1104e002579143",
+                "reference": "6608f01670c3cc5079e18c1dab1104e002579143",
                 "shasum": ""
             },
             "require": {
@@ -2521,9 +2637,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.10.4"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.12.0"
             },
-            "time": "2020-12-20T10:01:03+00:00"
+            "time": "2021-07-21T10:44:31+00:00"
         },
         {
             "name": "openlss/lib-array2xml",
@@ -2580,16 +2696,16 @@
         },
         {
             "name": "phar-io/manifest",
-            "version": "2.0.1",
+            "version": "2.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phar-io/manifest.git",
-                "reference": "85265efd3af7ba3ca4b2a2c34dbfc5788dd29133"
+                "reference": "97803eca37d319dfa7826cc2437fc020857acb53"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/manifest/zipball/85265efd3af7ba3ca4b2a2c34dbfc5788dd29133",
-                "reference": "85265efd3af7ba3ca4b2a2c34dbfc5788dd29133",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/97803eca37d319dfa7826cc2437fc020857acb53",
+                "reference": "97803eca37d319dfa7826cc2437fc020857acb53",
                 "shasum": ""
             },
             "require": {
@@ -2634,22 +2750,22 @@
             "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
             "support": {
                 "issues": "https://github.com/phar-io/manifest/issues",
-                "source": "https://github.com/phar-io/manifest/tree/master"
+                "source": "https://github.com/phar-io/manifest/tree/2.0.3"
             },
-            "time": "2020-06-27T14:33:11+00:00"
+            "time": "2021-07-20T11:28:43+00:00"
         },
         {
             "name": "phar-io/version",
-            "version": "3.0.4",
+            "version": "3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phar-io/version.git",
-                "reference": "e4782611070e50613683d2b9a57730e9a3ba5451"
+                "reference": "bae7c545bef187884426f042434e561ab1ddb182"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/version/zipball/e4782611070e50613683d2b9a57730e9a3ba5451",
-                "reference": "e4782611070e50613683d2b9a57730e9a3ba5451",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/bae7c545bef187884426f042434e561ab1ddb182",
+                "reference": "bae7c545bef187884426f042434e561ab1ddb182",
                 "shasum": ""
             },
             "require": {
@@ -2685,9 +2801,9 @@
             "description": "Library for handling version information and constraints",
             "support": {
                 "issues": "https://github.com/phar-io/version/issues",
-                "source": "https://github.com/phar-io/version/tree/3.0.4"
+                "source": "https://github.com/phar-io/version/tree/3.1.0"
             },
-            "time": "2020-12-13T23:18:30+00:00"
+            "time": "2021-02-23T14:00:09+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -2849,33 +2965,33 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "1.12.2",
+            "version": "1.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "245710e971a030f42e08f4912863805570f23d39"
+                "reference": "d86dfc2e2a3cd366cee475e52c6bb3bbc371aa0e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/245710e971a030f42e08f4912863805570f23d39",
-                "reference": "245710e971a030f42e08f4912863805570f23d39",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/d86dfc2e2a3cd366cee475e52c6bb3bbc371aa0e",
+                "reference": "d86dfc2e2a3cd366cee475e52c6bb3bbc371aa0e",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.2",
-                "php": "^7.2 || ~8.0, <8.1",
+                "php": "^7.2 || ~8.0, <8.2",
                 "phpdocumentor/reflection-docblock": "^5.2",
                 "sebastian/comparator": "^3.0 || ^4.0",
                 "sebastian/recursion-context": "^3.0 || ^4.0"
             },
             "require-dev": {
-                "phpspec/phpspec": "^6.0",
+                "phpspec/phpspec": "^6.0 || ^7.0",
                 "phpunit/phpunit": "^8.0 || ^9.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.11.x-dev"
+                    "dev-master": "1.x-dev"
                 }
             },
             "autoload": {
@@ -2910,22 +3026,75 @@
             ],
             "support": {
                 "issues": "https://github.com/phpspec/prophecy/issues",
-                "source": "https://github.com/phpspec/prophecy/tree/1.12.2"
+                "source": "https://github.com/phpspec/prophecy/tree/1.14.0"
             },
-            "time": "2020-12-19T10:15:11+00:00"
+            "time": "2021-09-10T09:02:12+00:00"
         },
         {
-            "name": "phpunit/php-code-coverage",
-            "version": "9.2.5",
+            "name": "phpstan/phpdoc-parser",
+            "version": "0.4.9",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "f3e026641cc91909d421802dd3ac7827ebfd97e1"
+                "url": "https://github.com/phpstan/phpdoc-parser.git",
+                "reference": "98a088b17966bdf6ee25c8a4b634df313d8aa531"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/f3e026641cc91909d421802dd3ac7827ebfd97e1",
-                "reference": "f3e026641cc91909d421802dd3ac7827ebfd97e1",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/98a088b17966bdf6ee25c8a4b634df313d8aa531",
+                "reference": "98a088b17966bdf6ee25c8a4b634df313d8aa531",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "consistence/coding-standard": "^3.5",
+                "ergebnis/composer-normalize": "^2.0.2",
+                "jakub-onderka/php-parallel-lint": "^0.9.2",
+                "phing/phing": "^2.16.0",
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "^0.12.26",
+                "phpstan/phpstan-strict-rules": "^0.12",
+                "phpunit/phpunit": "^6.3",
+                "slevomat/coding-standard": "^4.7.2",
+                "symfony/process": "^4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\PhpDocParser\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPDoc parser with support for nullable, intersection and generic types",
+            "support": {
+                "issues": "https://github.com/phpstan/phpdoc-parser/issues",
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/master"
+            },
+            "time": "2020-08-03T20:32:43+00:00"
+        },
+        {
+            "name": "phpunit/php-code-coverage",
+            "version": "9.2.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "f6293e1b30a2354e8428e004689671b83871edde"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/f6293e1b30a2354e8428e004689671b83871edde",
+                "reference": "f6293e1b30a2354e8428e004689671b83871edde",
                 "shasum": ""
             },
             "require": {
@@ -2981,7 +3150,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.5"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.6"
             },
             "funding": [
                 {
@@ -2989,7 +3158,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-11-28T06:44:49+00:00"
+            "time": "2021-03-28T07:26:59+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -3234,16 +3403,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.5.2",
+            "version": "9.5.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "f661659747f2f87f9e72095bb207bceb0f151cb4"
+                "reference": "ea8c2dfb1065eb35a79b3681eee6e6fb0a6f273b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/f661659747f2f87f9e72095bb207bceb0f151cb4",
-                "reference": "f661659747f2f87f9e72095bb207bceb0f151cb4",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/ea8c2dfb1065eb35a79b3681eee6e6fb0a6f273b",
+                "reference": "ea8c2dfb1065eb35a79b3681eee6e6fb0a6f273b",
                 "shasum": ""
             },
             "require": {
@@ -3255,7 +3424,7 @@
                 "ext-xml": "*",
                 "ext-xmlwriter": "*",
                 "myclabs/deep-copy": "^1.10.1",
-                "phar-io/manifest": "^2.0.1",
+                "phar-io/manifest": "^2.0.3",
                 "phar-io/version": "^3.0.2",
                 "php": ">=7.3",
                 "phpspec/prophecy": "^1.12.1",
@@ -3273,7 +3442,7 @@
                 "sebastian/global-state": "^5.0.1",
                 "sebastian/object-enumerator": "^4.0.3",
                 "sebastian/resource-operations": "^3.0.3",
-                "sebastian/type": "^2.3",
+                "sebastian/type": "^2.3.4",
                 "sebastian/version": "^3.0.2"
             },
             "require-dev": {
@@ -3321,7 +3490,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.2"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.9"
             },
             "funding": [
                 {
@@ -3333,7 +3502,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-02-02T14:45:58+00:00"
+            "time": "2021-08-31T06:47:40+00:00"
         },
         {
             "name": "psalm/plugin-phpunit",
@@ -3442,27 +3611,22 @@
         },
         {
             "name": "psr/container",
-            "version": "1.0.0",
+            "version": "1.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/container.git",
-                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f"
+                "reference": "8622567409010282b7aeebe4bb841fe98b58dcaf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/container/zipball/b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
-                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/8622567409010282b7aeebe4bb841fe98b58dcaf",
+                "reference": "8622567409010282b7aeebe4bb841fe98b58dcaf",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0"
+                "php": ">=7.2.0"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Psr\\Container\\": "src/"
@@ -3475,7 +3639,7 @@
             "authors": [
                 {
                     "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
+                    "homepage": "https://www.php-fig.org/"
                 }
             ],
             "description": "Common Container Interface (PHP FIG PSR-11)",
@@ -3489,9 +3653,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-fig/container/issues",
-                "source": "https://github.com/php-fig/container/tree/master"
+                "source": "https://github.com/php-fig/container/tree/1.1.1"
             },
-            "time": "2017-02-14T16:28:37+00:00"
+            "time": "2021-03-05T17:36:06+00:00"
         },
         {
             "name": "psr/http-message",
@@ -3548,16 +3712,16 @@
         },
         {
             "name": "psr/log",
-            "version": "1.1.3",
+            "version": "1.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/log.git",
-                "reference": "0f73288fd15629204f9d42b7055f72dacbe811fc"
+                "reference": "d49695b909c3b7628b6289db5479a1c204601f11"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/0f73288fd15629204f9d42b7055f72dacbe811fc",
-                "reference": "0f73288fd15629204f9d42b7055f72dacbe811fc",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/d49695b909c3b7628b6289db5479a1c204601f11",
+                "reference": "d49695b909c3b7628b6289db5479a1c204601f11",
                 "shasum": ""
             },
             "require": {
@@ -3581,7 +3745,7 @@
             "authors": [
                 {
                     "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
+                    "homepage": "https://www.php-fig.org/"
                 }
             ],
             "description": "Common interface for logging libraries",
@@ -3592,9 +3756,9 @@
                 "psr-3"
             ],
             "support": {
-                "source": "https://github.com/php-fig/log/tree/1.1.3"
+                "source": "https://github.com/php-fig/log/tree/1.1.4"
             },
-            "time": "2020-03-23T09:12:05+00:00"
+            "time": "2021-05-03T11:20:27+00:00"
         },
         {
             "name": "psr/simple-cache",
@@ -4153,16 +4317,16 @@
         },
         {
             "name": "sebastian/global-state",
-            "version": "5.0.2",
+            "version": "5.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "a90ccbddffa067b51f574dea6eb25d5680839455"
+                "reference": "23bd5951f7ff26f12d4e3242864df3e08dec4e49"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/a90ccbddffa067b51f574dea6eb25d5680839455",
-                "reference": "a90ccbddffa067b51f574dea6eb25d5680839455",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/23bd5951f7ff26f12d4e3242864df3e08dec4e49",
+                "reference": "23bd5951f7ff26f12d4e3242864df3e08dec4e49",
                 "shasum": ""
             },
             "require": {
@@ -4205,7 +4369,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.2"
+                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.3"
             },
             "funding": [
                 {
@@ -4213,7 +4377,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T15:55:19+00:00"
+            "time": "2021-06-11T13:31:12+00:00"
         },
         {
             "name": "sebastian/lines-of-code",
@@ -4500,20 +4664,21 @@
                     "type": "github"
                 }
             ],
+            "abandoned": true,
             "time": "2020-09-28T06:45:17+00:00"
         },
         {
             "name": "sebastian/type",
-            "version": "2.3.1",
+            "version": "2.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "81cd61ab7bbf2de744aba0ea61fae32f721df3d2"
+                "reference": "b8cd8a1c753c90bc1a0f5372170e3e489136f914"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/81cd61ab7bbf2de744aba0ea61fae32f721df3d2",
-                "reference": "81cd61ab7bbf2de744aba0ea61fae32f721df3d2",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/b8cd8a1c753c90bc1a0f5372170e3e489136f914",
+                "reference": "b8cd8a1c753c90bc1a0f5372170e3e489136f914",
                 "shasum": ""
             },
             "require": {
@@ -4548,7 +4713,7 @@
             "homepage": "https://github.com/sebastianbergmann/type",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/type/issues",
-                "source": "https://github.com/sebastianbergmann/type/tree/2.3.1"
+                "source": "https://github.com/sebastianbergmann/type/tree/2.3.4"
             },
             "funding": [
                 {
@@ -4556,7 +4721,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:18:59+00:00"
+            "time": "2021-06-15T12:49:02+00:00"
         },
         {
             "name": "sebastian/version",
@@ -4612,64 +4777,98 @@
             "time": "2020-09-28T06:39:44+00:00"
         },
         {
-            "name": "squizlabs/php_codesniffer",
-            "version": "2.9.2",
+            "name": "slevomat/coding-standard",
+            "version": "6.4.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "2acf168de78487db620ab4bc524135a13cfe6745"
+                "url": "https://github.com/slevomat/coding-standard.git",
+                "reference": "696dcca217d0c9da2c40d02731526c1e25b65346"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/2acf168de78487db620ab4bc524135a13cfe6745",
-                "reference": "2acf168de78487db620ab4bc524135a13cfe6745",
+                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/696dcca217d0c9da2c40d02731526c1e25b65346",
+                "reference": "696dcca217d0c9da2c40d02731526c1e25b65346",
+                "shasum": ""
+            },
+            "require": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7",
+                "php": "^7.1 || ^8.0",
+                "phpstan/phpdoc-parser": "0.4.5 - 0.4.9",
+                "squizlabs/php_codesniffer": "^3.5.6"
+            },
+            "require-dev": {
+                "phing/phing": "2.16.3",
+                "php-parallel-lint/php-parallel-lint": "1.2.0",
+                "phpstan/phpstan": "0.12.48",
+                "phpstan/phpstan-deprecation-rules": "0.12.5",
+                "phpstan/phpstan-phpunit": "0.12.16",
+                "phpstan/phpstan-strict-rules": "0.12.5",
+                "phpunit/phpunit": "7.5.20|8.5.5|9.4.0"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "6.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "SlevomatCodingStandard\\": "SlevomatCodingStandard"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Slevomat Coding Standard for PHP_CodeSniffer complements Consistence Coding Standard by providing sniffs with additional checks.",
+            "support": {
+                "issues": "https://github.com/slevomat/coding-standard/issues",
+                "source": "https://github.com/slevomat/coding-standard/tree/6.4.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/kukulich",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/slevomat/coding-standard",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-10-05T12:39:37+00:00"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "reference": "ffced0d2c8fa8e6cdc4d695a743271fab6c38625"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/ffced0d2c8fa8e6cdc4d695a743271fab6c38625",
+                "reference": "ffced0d2c8fa8e6cdc4d695a743271fab6c38625",
                 "shasum": ""
             },
             "require": {
                 "ext-simplexml": "*",
                 "ext-tokenizer": "*",
                 "ext-xmlwriter": "*",
-                "php": ">=5.1.2"
+                "php": ">=5.4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.0"
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
             },
             "bin": [
-                "scripts/phpcs",
-                "scripts/phpcbf"
+                "bin/phpcs",
+                "bin/phpcbf"
             ],
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.x-dev"
+                    "dev-master": "3.x-dev"
                 }
-            },
-            "autoload": {
-                "classmap": [
-                    "CodeSniffer.php",
-                    "CodeSniffer/CLI.php",
-                    "CodeSniffer/Exception.php",
-                    "CodeSniffer/File.php",
-                    "CodeSniffer/Fixer.php",
-                    "CodeSniffer/Report.php",
-                    "CodeSniffer/Reporting.php",
-                    "CodeSniffer/Sniff.php",
-                    "CodeSniffer/Tokens.php",
-                    "CodeSniffer/Reports/",
-                    "CodeSniffer/Tokenizers/",
-                    "CodeSniffer/DocGenerators/",
-                    "CodeSniffer/Standards/AbstractPatternSniff.php",
-                    "CodeSniffer/Standards/AbstractScopeSniff.php",
-                    "CodeSniffer/Standards/AbstractVariableSniff.php",
-                    "CodeSniffer/Standards/IncorrectPatternException.php",
-                    "CodeSniffer/Standards/Generic/Sniffs/",
-                    "CodeSniffer/Standards/MySource/Sniffs/",
-                    "CodeSniffer/Standards/PEAR/Sniffs/",
-                    "CodeSniffer/Standards/PSR1/Sniffs/",
-                    "CodeSniffer/Standards/PSR2/Sniffs/",
-                    "CodeSniffer/Standards/Squiz/Sniffs/",
-                    "CodeSniffer/Standards/Zend/Sniffs/"
-                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -4682,7 +4881,7 @@
                 }
             ],
             "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
-            "homepage": "http://www.squizlabs.com/php-codesniffer",
+            "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
             "keywords": [
                 "phpcs",
                 "standards"
@@ -4692,31 +4891,33 @@
                 "source": "https://github.com/squizlabs/PHP_CodeSniffer",
                 "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
             },
-            "time": "2018-11-07T22:31:41+00:00"
+            "time": "2021-04-09T00:54:41+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v5.2.3",
+            "version": "v5.3.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "89d4b176d12a2946a1ae4e34906a025b7b6b135a"
+                "reference": "8b1008344647462ae6ec57559da166c2bfa5e16a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/89d4b176d12a2946a1ae4e34906a025b7b6b135a",
-                "reference": "89d4b176d12a2946a1ae4e34906a025b7b6b135a",
+                "url": "https://api.github.com/repos/symfony/console/zipball/8b1008344647462ae6ec57559da166c2bfa5e16a",
+                "reference": "8b1008344647462ae6ec57559da166c2bfa5e16a",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2.5",
+                "symfony/deprecation-contracts": "^2.1",
                 "symfony/polyfill-mbstring": "~1.0",
                 "symfony/polyfill-php73": "^1.8",
-                "symfony/polyfill-php80": "^1.15",
+                "symfony/polyfill-php80": "^1.16",
                 "symfony/service-contracts": "^1.1|^2",
                 "symfony/string": "^5.1"
             },
             "conflict": {
+                "psr/log": ">=3",
                 "symfony/dependency-injection": "<4.4",
                 "symfony/dotenv": "<5.1",
                 "symfony/event-dispatcher": "<4.4",
@@ -4724,10 +4925,10 @@
                 "symfony/process": "<4.4"
             },
             "provide": {
-                "psr/log-implementation": "1.0"
+                "psr/log-implementation": "1.0|2.0"
             },
             "require-dev": {
-                "psr/log": "~1.0",
+                "psr/log": "^1|^2",
                 "symfony/config": "^4.4|^5.0",
                 "symfony/dependency-injection": "^4.4|^5.0",
                 "symfony/event-dispatcher": "^4.4|^5.0",
@@ -4773,7 +4974,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v5.2.3"
+                "source": "https://github.com/symfony/console/tree/v5.3.7"
             },
             "funding": [
                 {
@@ -4789,20 +4990,87 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-28T22:06:19+00:00"
+            "time": "2021-08-25T20:02:16+00:00"
         },
         {
-            "name": "symfony/polyfill-ctype",
-            "version": "v1.22.0",
+            "name": "symfony/deprecation-contracts",
+            "version": "v2.4.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "c6c942b1ac76c82448322025e084cadc56048b4e"
+                "url": "https://github.com/symfony/deprecation-contracts.git",
+                "reference": "5f38c8804a9e97d23e0c8d63341088cd8a22d627"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/c6c942b1ac76c82448322025e084cadc56048b4e",
-                "reference": "c6c942b1ac76c82448322025e084cadc56048b4e",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/5f38c8804a9e97d23e0c8d63341088cd8a22d627",
+                "reference": "5f38c8804a9e97d23e0c8d63341088cd8a22d627",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "2.4-dev"
+                },
+                "thanks": {
+                    "name": "symfony/contracts",
+                    "url": "https://github.com/symfony/contracts"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "function.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "A generic function and convention to trigger deprecation notices",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v2.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-03-23T23:28:01+00:00"
+        },
+        {
+            "name": "symfony/polyfill-ctype",
+            "version": "v1.23.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "46cd95797e9df938fdd2b03693b5fca5e64b01ce"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/46cd95797e9df938fdd2b03693b5fca5e64b01ce",
+                "reference": "46cd95797e9df938fdd2b03693b5fca5e64b01ce",
                 "shasum": ""
             },
             "require": {
@@ -4814,7 +5082,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.22-dev"
+                    "dev-main": "1.23-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -4852,7 +5120,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.22.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.23.0"
             },
             "funding": [
                 {
@@ -4868,20 +5136,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-07T16:49:33+00:00"
+            "time": "2021-02-19T12:13:01+00:00"
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.22.0",
+            "version": "v1.23.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
-                "reference": "267a9adeb8ecb8071040a740930e077cdfb987af"
+                "reference": "16880ba9c5ebe3642d1995ab866db29270b36535"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/267a9adeb8ecb8071040a740930e077cdfb987af",
-                "reference": "267a9adeb8ecb8071040a740930e077cdfb987af",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/16880ba9c5ebe3642d1995ab866db29270b36535",
+                "reference": "16880ba9c5ebe3642d1995ab866db29270b36535",
                 "shasum": ""
             },
             "require": {
@@ -4893,7 +5161,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.22-dev"
+                    "dev-main": "1.23-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -4933,7 +5201,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.22.0"
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.23.1"
             },
             "funding": [
                 {
@@ -4949,20 +5217,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-07T16:49:33+00:00"
+            "time": "2021-05-27T12:26:48+00:00"
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.22.0",
+            "version": "v1.23.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
-                "reference": "6e971c891537eb617a00bb07a43d182a6915faba"
+                "reference": "8590a5f561694770bdcd3f9b5c69dde6945028e8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/6e971c891537eb617a00bb07a43d182a6915faba",
-                "reference": "6e971c891537eb617a00bb07a43d182a6915faba",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/8590a5f561694770bdcd3f9b5c69dde6945028e8",
+                "reference": "8590a5f561694770bdcd3f9b5c69dde6945028e8",
                 "shasum": ""
             },
             "require": {
@@ -4974,7 +5242,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.22-dev"
+                    "dev-main": "1.23-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -5017,7 +5285,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.22.0"
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.23.0"
             },
             "funding": [
                 {
@@ -5033,20 +5301,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-07T17:09:11+00:00"
+            "time": "2021-02-19T12:13:01+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.22.0",
+            "version": "v1.23.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "f377a3dd1fde44d37b9831d68dc8dea3ffd28e13"
+                "reference": "9174a3d80210dca8daa7f31fec659150bbeabfc6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/f377a3dd1fde44d37b9831d68dc8dea3ffd28e13",
-                "reference": "f377a3dd1fde44d37b9831d68dc8dea3ffd28e13",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/9174a3d80210dca8daa7f31fec659150bbeabfc6",
+                "reference": "9174a3d80210dca8daa7f31fec659150bbeabfc6",
                 "shasum": ""
             },
             "require": {
@@ -5058,7 +5326,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.22-dev"
+                    "dev-main": "1.23-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -5097,7 +5365,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.22.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.23.1"
             },
             "funding": [
                 {
@@ -5113,20 +5381,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-07T16:49:33+00:00"
+            "time": "2021-05-27T12:26:48+00:00"
         },
         {
             "name": "symfony/polyfill-php73",
-            "version": "v1.22.0",
+            "version": "v1.23.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php73.git",
-                "reference": "a678b42e92f86eca04b7fa4c0f6f19d097fb69e2"
+                "reference": "fba8933c384d6476ab14fb7b8526e5287ca7e010"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/a678b42e92f86eca04b7fa4c0f6f19d097fb69e2",
-                "reference": "a678b42e92f86eca04b7fa4c0f6f19d097fb69e2",
+                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/fba8933c384d6476ab14fb7b8526e5287ca7e010",
+                "reference": "fba8933c384d6476ab14fb7b8526e5287ca7e010",
                 "shasum": ""
             },
             "require": {
@@ -5135,7 +5403,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.22-dev"
+                    "dev-main": "1.23-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -5176,7 +5444,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php73/tree/v1.22.0"
+                "source": "https://github.com/symfony/polyfill-php73/tree/v1.23.0"
             },
             "funding": [
                 {
@@ -5192,20 +5460,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-07T16:49:33+00:00"
+            "time": "2021-02-19T12:13:01+00:00"
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.22.0",
+            "version": "v1.23.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "dc3063ba22c2a1fd2f45ed856374d79114998f91"
+                "reference": "1100343ed1a92e3a38f9ae122fc0eb21602547be"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/dc3063ba22c2a1fd2f45ed856374d79114998f91",
-                "reference": "dc3063ba22c2a1fd2f45ed856374d79114998f91",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/1100343ed1a92e3a38f9ae122fc0eb21602547be",
+                "reference": "1100343ed1a92e3a38f9ae122fc0eb21602547be",
                 "shasum": ""
             },
             "require": {
@@ -5214,7 +5482,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.22-dev"
+                    "dev-main": "1.23-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -5259,7 +5527,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.22.0"
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.23.1"
             },
             "funding": [
                 {
@@ -5275,25 +5543,25 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-07T16:49:33+00:00"
+            "time": "2021-07-28T13:41:28+00:00"
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v2.2.0",
+            "version": "v2.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "d15da7ba4957ffb8f1747218be9e1a121fd298a1"
+                "reference": "f040a30e04b57fbcc9c6cbcf4dbaa96bd318b9bb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/d15da7ba4957ffb8f1747218be9e1a121fd298a1",
-                "reference": "d15da7ba4957ffb8f1747218be9e1a121fd298a1",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/f040a30e04b57fbcc9c6cbcf4dbaa96bd318b9bb",
+                "reference": "f040a30e04b57fbcc9c6cbcf4dbaa96bd318b9bb",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2.5",
-                "psr/container": "^1.0"
+                "psr/container": "^1.1"
             },
             "suggest": {
                 "symfony/service-implementation": ""
@@ -5301,7 +5569,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.2-dev"
+                    "dev-main": "2.4-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -5338,7 +5606,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/master"
+                "source": "https://github.com/symfony/service-contracts/tree/v2.4.0"
             },
             "funding": [
                 {
@@ -5354,20 +5622,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-09-07T11:33:47+00:00"
+            "time": "2021-04-01T10:43:52+00:00"
         },
         {
             "name": "symfony/string",
-            "version": "v5.2.3",
+            "version": "v5.3.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "c95468897f408dd0aca2ff582074423dd0455122"
+                "reference": "8d224396e28d30f81969f083a58763b8b9ceb0a5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/c95468897f408dd0aca2ff582074423dd0455122",
-                "reference": "c95468897f408dd0aca2ff582074423dd0455122",
+                "url": "https://api.github.com/repos/symfony/string/zipball/8d224396e28d30f81969f083a58763b8b9ceb0a5",
+                "reference": "8d224396e28d30f81969f083a58763b8b9ceb0a5",
                 "shasum": ""
             },
             "require": {
@@ -5421,7 +5689,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v5.2.3"
+                "source": "https://github.com/symfony/string/tree/v5.3.7"
             },
             "funding": [
                 {
@@ -5437,20 +5705,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-25T15:14:59+00:00"
+            "time": "2021-08-26T08:00:08+00:00"
         },
         {
             "name": "theseer/tokenizer",
-            "version": "1.2.0",
+            "version": "1.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/theseer/tokenizer.git",
-                "reference": "75a63c33a8577608444246075ea0af0d052e452a"
+                "reference": "34a41e998c2183e22995f158c581e7b5e755ab9e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/75a63c33a8577608444246075ea0af0d052e452a",
-                "reference": "75a63c33a8577608444246075ea0af0d052e452a",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/34a41e998c2183e22995f158c581e7b5e755ab9e",
+                "reference": "34a41e998c2183e22995f158c581e7b5e755ab9e",
                 "shasum": ""
             },
             "require": {
@@ -5479,7 +5747,7 @@
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
             "support": {
                 "issues": "https://github.com/theseer/tokenizer/issues",
-                "source": "https://github.com/theseer/tokenizer/tree/master"
+                "source": "https://github.com/theseer/tokenizer/tree/1.2.1"
             },
             "funding": [
                 {
@@ -5487,29 +5755,30 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-07-12T23:59:07+00:00"
+            "time": "2021-07-28T10:34:58+00:00"
         },
         {
             "name": "vimeo/psalm",
-            "version": "4.4.1",
+            "version": "4.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vimeo/psalm.git",
-                "reference": "9fd7a7d885b3a216cff8dec9d8c21a132f275224"
+                "reference": "916b098b008f6de4543892b1e0651c1c3b92cbfa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vimeo/psalm/zipball/9fd7a7d885b3a216cff8dec9d8c21a132f275224",
-                "reference": "9fd7a7d885b3a216cff8dec9d8c21a132f275224",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/916b098b008f6de4543892b1e0651c1c3b92cbfa",
+                "reference": "916b098b008f6de4543892b1e0651c1c3b92cbfa",
                 "shasum": ""
             },
             "require": {
-                "amphp/amp": "^2.1",
+                "amphp/amp": "^2.4.2",
                 "amphp/byte-stream": "^1.5",
                 "composer/package-versions-deprecated": "^1.8.0",
                 "composer/semver": "^1.4 || ^2.0 || ^3.0",
-                "composer/xdebug-handler": "^1.1",
+                "composer/xdebug-handler": "^1.1 || ^2.0",
                 "dnoegel/php-xdg-base-dir": "^0.1.1",
+                "ext-ctype": "*",
                 "ext-dom": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
@@ -5517,9 +5786,9 @@
                 "ext-simplexml": "*",
                 "ext-tokenizer": "*",
                 "felixfbecker/advanced-json-rpc": "^3.0.3",
-                "felixfbecker/language-server-protocol": "^1.4",
-                "netresearch/jsonmapper": "^1.0 || ^2.0 || ^3.0",
-                "nikic/php-parser": "^4.10.1",
+                "felixfbecker/language-server-protocol": "^1.5",
+                "netresearch/jsonmapper": "^1.0 || ^2.0 || ^3.0 || ^4.0",
+                "nikic/php-parser": "^4.12",
                 "openlss/lib-array2xml": "^1.0",
                 "php": "^7.1|^8",
                 "sebastian/diff": "^3.0 || ^4.0",
@@ -5530,18 +5799,18 @@
                 "psalm/psalm": "self.version"
             },
             "require-dev": {
-                "amphp/amp": "^2.4.2",
                 "bamarni/composer-bin-plugin": "^1.2",
                 "brianium/paratest": "^4.0||^6.0",
                 "ext-curl": "*",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
                 "phpdocumentor/reflection-docblock": "^5",
                 "phpmyadmin/sql-parser": "5.1.0||dev-master",
                 "phpspec/prophecy": ">=1.9.0",
                 "phpunit/phpunit": "^9.0",
-                "psalm/plugin-phpunit": "^0.13",
-                "slevomat/coding-standard": "^6.3.11",
+                "psalm/plugin-phpunit": "^0.16",
+                "slevomat/coding-standard": "^7.0",
                 "squizlabs/php_codesniffer": "^3.5",
-                "symfony/process": "^4.3",
+                "symfony/process": "^4.3 || ^5.0",
                 "weirdan/prophecy-shim": "^1.0 || ^2.0"
             },
             "suggest": {
@@ -5589,36 +5858,96 @@
             ],
             "support": {
                 "issues": "https://github.com/vimeo/psalm/issues",
-                "source": "https://github.com/vimeo/psalm/tree/4.4.1"
+                "source": "https://github.com/vimeo/psalm/tree/4.10.0"
             },
-            "time": "2021-01-14T21:44:29+00:00"
+            "time": "2021-09-04T21:00:09+00:00"
         },
         {
-            "name": "webmozart/assert",
-            "version": "1.9.1",
+            "name": "webimpress/coding-standard",
+            "version": "1.2.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/webmozarts/assert.git",
-                "reference": "bafc69caeb4d49c39fd0779086c03a3738cbb389"
+                "url": "https://github.com/webimpress/coding-standard.git",
+                "reference": "8f4a220de33f471a8101836f7ec72b852c3f9f03"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozarts/assert/zipball/bafc69caeb4d49c39fd0779086c03a3738cbb389",
-                "reference": "bafc69caeb4d49c39fd0779086c03a3738cbb389",
+                "url": "https://api.github.com/repos/webimpress/coding-standard/zipball/8f4a220de33f471a8101836f7ec72b852c3f9f03",
+                "reference": "8f4a220de33f471a8101836f7ec72b852c3f9f03",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3 || ^7.0 || ^8.0",
+                "php": "^7.3 || ^8.0",
+                "squizlabs/php_codesniffer": "^3.6"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5.4"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "dev-master": "1.2.x-dev",
+                "dev-develop": "1.3.x-dev"
+            },
+            "autoload": {
+                "psr-4": {
+                    "WebimpressCodingStandard\\": "src/WebimpressCodingStandard/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "description": "Webimpress Coding Standard",
+            "keywords": [
+                "Coding Standard",
+                "PSR-2",
+                "phpcs",
+                "psr-12",
+                "webimpress"
+            ],
+            "support": {
+                "issues": "https://github.com/webimpress/coding-standard/issues",
+                "source": "https://github.com/webimpress/coding-standard/tree/1.2.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/michalbundyra",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-04-12T12:51:27+00:00"
+        },
+        {
+            "name": "webmozart/assert",
+            "version": "1.10.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozarts/assert.git",
+                "reference": "6964c76c7804814a842473e0c8fd15bab0f18e25"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/6964c76c7804814a842473e0c8fd15bab0f18e25",
+                "reference": "6964c76c7804814a842473e0c8fd15bab0f18e25",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0",
                 "symfony/polyfill-ctype": "^1.8"
             },
             "conflict": {
                 "phpstan/phpstan": "<0.12.20",
-                "vimeo/psalm": "<3.9.1"
+                "vimeo/psalm": "<4.6.1 || 4.6.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8.36 || ^7.5.13"
+                "phpunit/phpunit": "^8.5.13"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.10-dev"
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "Webmozart\\Assert\\": "src/"
@@ -5642,9 +5971,9 @@
             ],
             "support": {
                 "issues": "https://github.com/webmozarts/assert/issues",
-                "source": "https://github.com/webmozarts/assert/tree/1.9.1"
+                "source": "https://github.com/webmozarts/assert/tree/1.10.0"
             },
-            "time": "2020-07-08T17:02:28+00:00"
+            "time": "2021-03-09T10:59:23+00:00"
         },
         {
             "name": "webmozart/path-util",
@@ -5703,10 +6032,10 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.3 || ~8.0.0",
+        "php": "^7.3 || ~8.0.0 || ~8.1.0",
         "ext-dom": "*",
         "ext-libxml": "*"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bf58c61fa037d1454d498cdae95b28a1",
+    "content-hash": "a0d29ec7523f16eb9a27952c0d9fd8e2",
     "packages": [
         {
             "name": "laminas/laminas-escaper",
@@ -297,16 +297,16 @@
         },
         {
             "name": "composer/package-versions-deprecated",
-            "version": "1.11.99.3",
+            "version": "1.11.99.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/package-versions-deprecated.git",
-                "reference": "fff576ac850c045158a250e7e27666e146e78d18"
+                "reference": "b174585d1fe49ceed21928a945138948cb394600"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/package-versions-deprecated/zipball/fff576ac850c045158a250e7e27666e146e78d18",
-                "reference": "fff576ac850c045158a250e7e27666e146e78d18",
+                "url": "https://api.github.com/repos/composer/package-versions-deprecated/zipball/b174585d1fe49ceed21928a945138948cb394600",
+                "reference": "b174585d1fe49ceed21928a945138948cb394600",
                 "shasum": ""
             },
             "require": {
@@ -350,7 +350,7 @@
             "description": "Composer plugin that provides efficient querying for installed package versions (no runtime IO)",
             "support": {
                 "issues": "https://github.com/composer/package-versions-deprecated/issues",
-                "source": "https://github.com/composer/package-versions-deprecated/tree/1.11.99.3"
+                "source": "https://github.com/composer/package-versions-deprecated/tree/1.11.99.4"
             },
             "funding": [
                 {
@@ -366,7 +366,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-08-17T13:49:14+00:00"
+            "time": "2021-09-13T08:41:34+00:00"
         },
         {
             "name": "composer/semver",
@@ -1920,37 +1920,35 @@
         },
         {
             "name": "laminas/laminas-db",
-            "version": "2.12.0",
+            "version": "2.13.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-db.git",
-                "reference": "80cbba4e749f9eb7d8036172acb9ad41e8b6923f"
+                "reference": "e1bcf243f6e56f02590f11a149cd75403e873241"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-db/zipball/80cbba4e749f9eb7d8036172acb9ad41e8b6923f",
-                "reference": "80cbba4e749f9eb7d8036172acb9ad41e8b6923f",
+                "url": "https://api.github.com/repos/laminas/laminas-db/zipball/e1bcf243f6e56f02590f11a149cd75403e873241",
+                "reference": "e1bcf243f6e56f02590f11a149cd75403e873241",
                 "shasum": ""
             },
             "require": {
-                "laminas/laminas-stdlib": "^3.3",
-                "laminas/laminas-zendframework-bridge": "^1.0",
-                "php": "^7.3 || ~8.0.0"
+                "laminas/laminas-stdlib": "^3.6",
+                "php": "^7.3 || ~8.0.0 || ~8.1.0"
             },
-            "replace": {
-                "zendframework/zend-db": "^2.11.0"
+            "conflict": {
+                "zendframework/zend-db": "*"
             },
             "require-dev": {
-                "laminas/laminas-coding-standard": "~1.0.0",
-                "laminas/laminas-eventmanager": "^3.3",
-                "laminas/laminas-hydrator": "^3.2 || ^4.0",
-                "laminas/laminas-servicemanager": "^3.3",
-                "phpspec/prophecy-phpunit": "^2.0",
-                "phpunit/phpunit": "^9.3"
+                "laminas/laminas-coding-standard": "~2.2.1",
+                "laminas/laminas-eventmanager": "^3.4",
+                "laminas/laminas-hydrator": "^3.2 || ^4.3",
+                "laminas/laminas-servicemanager": "^3.7",
+                "phpunit/phpunit": "^9.5.5"
             },
             "suggest": {
                 "laminas/laminas-eventmanager": "Laminas\\EventManager component",
-                "laminas/laminas-hydrator": "(^3.2 || ^4.0) Laminas\\Hydrator component for using HydratingResultSets",
+                "laminas/laminas-hydrator": "(^3.2 || ^4.3) Laminas\\Hydrator component for using HydratingResultSets",
                 "laminas/laminas-servicemanager": "Laminas\\ServiceManager component"
             },
             "type": "library",
@@ -1989,7 +1987,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2021-02-22T22:27:56+00:00"
+            "time": "2021-09-19T07:38:14+00:00"
         },
         {
             "name": "laminas/laminas-eventmanager",
@@ -2587,16 +2585,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.12.0",
+            "version": "v4.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "6608f01670c3cc5079e18c1dab1104e002579143"
+                "reference": "50953a2691a922aa1769461637869a0a2faa3f53"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/6608f01670c3cc5079e18c1dab1104e002579143",
-                "reference": "6608f01670c3cc5079e18c1dab1104e002579143",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/50953a2691a922aa1769461637869a0a2faa3f53",
+                "reference": "50953a2691a922aa1769461637869a0a2faa3f53",
                 "shasum": ""
             },
             "require": {
@@ -2637,9 +2635,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.12.0"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.13.0"
             },
-            "time": "2021-07-21T10:44:31+00:00"
+            "time": "2021-09-20T12:20:58+00:00"
         },
         {
             "name": "openlss/lib-array2xml",
@@ -2916,16 +2914,16 @@
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "1.4.0",
+            "version": "1.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "6a467b8989322d92aa1c8bf2bebcc6e5c2ba55c0"
+                "reference": "30f38bffc6f24293dadd1823936372dfa9e86e2f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/6a467b8989322d92aa1c8bf2bebcc6e5c2ba55c0",
-                "reference": "6a467b8989322d92aa1c8bf2bebcc6e5c2ba55c0",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/30f38bffc6f24293dadd1823936372dfa9e86e2f",
+                "reference": "30f38bffc6f24293dadd1823936372dfa9e86e2f",
                 "shasum": ""
             },
             "require": {
@@ -2933,7 +2931,8 @@
                 "phpdocumentor/reflection-common": "^2.0"
             },
             "require-dev": {
-                "ext-tokenizer": "*"
+                "ext-tokenizer": "*",
+                "psalm/phar": "^4.8"
             },
             "type": "library",
             "extra": {
@@ -2959,9 +2958,9 @@
             "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
             "support": {
                 "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
-                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.4.0"
+                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.5.0"
             },
-            "time": "2020-09-17T18:55:26+00:00"
+            "time": "2021-09-17T15:28:14+00:00"
         },
         {
             "name": "phpspec/prophecy",
@@ -3085,23 +3084,23 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.6",
+            "version": "9.2.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "f6293e1b30a2354e8428e004689671b83871edde"
+                "reference": "d4c798ed8d51506800b441f7a13ecb0f76f12218"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/f6293e1b30a2354e8428e004689671b83871edde",
-                "reference": "f6293e1b30a2354e8428e004689671b83871edde",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/d4c798ed8d51506800b441f7a13ecb0f76f12218",
+                "reference": "d4c798ed8d51506800b441f7a13ecb0f76f12218",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-libxml": "*",
                 "ext-xmlwriter": "*",
-                "nikic/php-parser": "^4.10.2",
+                "nikic/php-parser": "^4.12.0",
                 "php": ">=7.3",
                 "phpunit/php-file-iterator": "^3.0.3",
                 "phpunit/php-text-template": "^2.0.2",
@@ -3150,7 +3149,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.6"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.7"
             },
             "funding": [
                 {
@@ -3158,7 +3157,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-03-28T07:26:59+00:00"
+            "time": "2021-09-17T05:39:03+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -4664,7 +4663,6 @@
                     "type": "github"
                 }
             ],
-            "abandoned": true,
             "time": "2020-09-28T06:45:17+00:00"
         },
         {

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,8 +1,0 @@
-﻿<?xml version="1.0"?>
-<ruleset name="Laminas coding standard">
-    <rule ref="./vendor/laminas/laminas-coding-standard/ruleset.xml"/>
-
-    <!-- Paths to check -->
-    <file>src</file>
-    <file>test</file>
-</ruleset>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0"?>
+<ruleset
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="./vendor/squizlabs/php_codesniffer/phpcs.xsd">
+
+    <arg name="basepath" value="."/>
+    <arg name="cache" value=".phpcs-cache"/>
+    <arg name="colors"/>
+    <arg name="extensions" value="php"/>
+    <arg name="parallel" value="80"/>
+
+    <!-- Show progress -->
+    <arg value="p"/>
+
+    <!-- Paths to check -->
+    <file>src</file>
+    <file>test</file>
+
+    <!-- Include all rules from Laminas Coding Standard -->
+    <rule ref="LaminasCodingStandard"/>
+</ruleset>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -487,46 +487,27 @@
   </file>
   <file src="src/Reader/Entry/Atom.php">
     <ImplementedReturnTypeMismatch occurrences="3">
+      <code>AuthorCollection</code>
       <code>null|string</code>
-      <code>string</code>
       <code>void</code>
     </ImplementedReturnTypeMismatch>
     <InvalidNullableReturnType occurrences="1">
       <code>string</code>
     </InvalidNullableReturnType>
-    <MixedArgument occurrences="1">
-      <code>$categoryCollection</code>
-    </MixedArgument>
-    <MixedAssignment occurrences="18">
-      <code>$categoryCollection</code>
-      <code>$categoryCollection</code>
-      <code>$commentcount</code>
-      <code>$commentcount</code>
-      <code>$commentfeedlink</code>
-      <code>$commentlink</code>
-      <code>$content</code>
-      <code>$dateCreated</code>
-      <code>$dateModified</code>
-      <code>$description</code>
-      <code>$enclosure</code>
+    <MixedAssignment occurrences="2">
       <code>$extension</code>
       <code>$extension</code>
-      <code>$id</code>
-      <code>$links</code>
-      <code>$people</code>
-      <code>$source</code>
-      <code>$title</code>
     </MixedAssignment>
     <MixedInferredReturnType occurrences="15">
-      <code>DateTime</code>
-      <code>DateTime</code>
+      <code>AuthorCollection</code>
       <code>Reader\Collection\Category</code>
       <code>array</code>
-      <code>array</code>
       <code>int</code>
+      <code>null|DateTime</code>
+      <code>null|DateTime</code>
       <code>null|Reader\Feed\Atom\Source</code>
+      <code>null|object{href: string, length: int, type: string}</code>
       <code>null|string</code>
-      <code>string</code>
       <code>string</code>
       <code>string</code>
       <code>string</code>
@@ -540,34 +521,20 @@
       <code>setType</code>
       <code>setXpath</code>
     </MixedMethodCall>
-    <MixedReturnStatement occurrences="29">
-      <code>$this-&gt;data['authors']</code>
+    <MixedReturnStatement occurrences="15">
       <code>$this-&gt;data['authors']</code>
       <code>$this-&gt;data['categories']</code>
-      <code>$this-&gt;data['categories']</code>
-      <code>$this-&gt;data['commentcount']</code>
       <code>$this-&gt;data['commentcount']</code>
       <code>$this-&gt;data['commentfeedlink']</code>
-      <code>$this-&gt;data['commentfeedlink']</code>
-      <code>$this-&gt;data['commentlink']</code>
       <code>$this-&gt;data['commentlink']</code>
       <code>$this-&gt;data['content']</code>
-      <code>$this-&gt;data['content']</code>
-      <code>$this-&gt;data['datecreated']</code>
       <code>$this-&gt;data['datecreated']</code>
       <code>$this-&gt;data['datemodified']</code>
-      <code>$this-&gt;data['datemodified']</code>
-      <code>$this-&gt;data['description']</code>
       <code>$this-&gt;data['description']</code>
       <code>$this-&gt;data['enclosure']</code>
-      <code>$this-&gt;data['enclosure']</code>
-      <code>$this-&gt;data['id']</code>
       <code>$this-&gt;data['id']</code>
       <code>$this-&gt;data['links']</code>
-      <code>$this-&gt;data['links']</code>
       <code>$this-&gt;data['source']</code>
-      <code>$this-&gt;data['source']</code>
-      <code>$this-&gt;data['title']</code>
       <code>$this-&gt;data['title']</code>
     </MixedReturnStatement>
     <MixedReturnTypeCoercion occurrences="2">
@@ -579,83 +546,38 @@
     <PropertyNotSetInConstructor occurrences="1">
       <code>Atom</code>
     </PropertyNotSetInConstructor>
-    <UndefinedMethod occurrences="16">
-      <code>getAuthors</code>
-      <code>getCategories</code>
-      <code>getCategories</code>
-      <code>getCommentCount</code>
-      <code>getCommentCount</code>
-      <code>getCommentFeedLink</code>
-      <code>getCommentLink</code>
-      <code>getContent</code>
-      <code>getDateCreated</code>
-      <code>getDateModified</code>
-      <code>getDescription</code>
-      <code>getEnclosure</code>
-      <code>getId</code>
-      <code>getLinks</code>
-      <code>getSource</code>
-      <code>getTitle</code>
-    </UndefinedMethod>
   </file>
   <file src="src/Reader/Entry/Rss.php">
-    <ImplementedReturnTypeMismatch occurrences="5">
+    <ImplementedReturnTypeMismatch occurrences="3">
       <code>null|string</code>
       <code>null|string</code>
-      <code>null|string</code>
-      <code>string</code>
       <code>void</code>
     </ImplementedReturnTypeMismatch>
     <InvalidNullableReturnType occurrences="1">
       <code>string</code>
     </InvalidNullableReturnType>
+    <InvalidReturnStatement occurrences="1">
+      <code>$this-&gt;data['authors']</code>
+    </InvalidReturnStatement>
     <InvalidScalarArgument occurrences="1">
       <code>$entryKey</code>
     </InvalidScalarArgument>
-    <LessSpecificReturnStatement occurrences="1">
-      <code>$this-&gt;data['datemodified']</code>
-    </LessSpecificReturnStatement>
-    <MixedArgument occurrences="4">
-      <code>$authors</code>
-      <code>$categoryCollection</code>
+    <MixedArgument occurrences="2">
       <code>$dateModified</code>
       <code>$dateModified</code>
     </MixedArgument>
     <MixedArrayAccess occurrences="1">
       <code>$author['name']</code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="33">
+    <MixedAssignment occurrences="10">
       <code>$author</code>
-      <code>$authors</code>
-      <code>$authorsDc</code>
-      <code>$categoryCollection</code>
-      <code>$categoryCollection</code>
-      <code>$commentcount</code>
-      <code>$commentcount</code>
-      <code>$commentcount</code>
-      <code>$commentfeedlink</code>
-      <code>$commentfeedlink</code>
-      <code>$commentfeedlink</code>
       <code>$commentlink</code>
-      <code>$commentlink</code>
-      <code>$content</code>
-      <code>$content</code>
-      <code>$date</code>
-      <code>$date</code>
       <code>$dateModified</code>
       <code>$description</code>
       <code>$description</code>
-      <code>$description</code>
-      <code>$description</code>
-      <code>$enclosure</code>
       <code>$extension</code>
       <code>$extension</code>
       <code>$id</code>
-      <code>$id</code>
-      <code>$id</code>
-      <code>$links</code>
-      <code>$title</code>
-      <code>$title</code>
       <code>$title</code>
       <code>$title</code>
     </MixedAssignment>
@@ -663,11 +585,11 @@
       <code>DateTime</code>
       <code>Reader\Collection\Category</code>
       <code>array</code>
-      <code>array</code>
+      <code>int</code>
+      <code>null|array</code>
+      <code>null|object{url?: string, href?: string, length: int, type: string}</code>
       <code>null|string</code>
       <code>null|string</code>
-      <code>null|string</code>
-      <code>string</code>
       <code>string</code>
       <code>string</code>
       <code>string</code>
@@ -680,34 +602,26 @@
       <code>setType</code>
       <code>setXpath</code>
     </MixedMethodCall>
-    <MixedReturnStatement occurrences="22">
-      <code>$this-&gt;data['authors']</code>
+    <MixedReturnStatement occurrences="15">
       <code>$this-&gt;data['authors']</code>
       <code>$this-&gt;data['categories']</code>
-      <code>$this-&gt;data['categories']</code>
       <code>$this-&gt;data['commentcount']</code>
-      <code>$this-&gt;data['commentcount']</code>
-      <code>$this-&gt;data['commentfeedlink']</code>
       <code>$this-&gt;data['commentfeedlink']</code>
       <code>$this-&gt;data['commentlink']</code>
       <code>$this-&gt;data['commentlink']</code>
-      <code>$this-&gt;data['content']</code>
       <code>$this-&gt;data['content']</code>
       <code>$this-&gt;data['datemodified']</code>
       <code>$this-&gt;data['description']</code>
       <code>$this-&gt;data['enclosure']</code>
-      <code>$this-&gt;data['enclosure']</code>
       <code>$this-&gt;data['id']</code>
       <code>$this-&gt;data['id']</code>
-      <code>$this-&gt;data['links']</code>
       <code>$this-&gt;data['links']</code>
       <code>$this-&gt;data['title']</code>
     </MixedReturnStatement>
     <MixedReturnTypeCoercion occurrences="2">
       <code>null|array&lt;string, string&gt;</code>
     </MixedReturnTypeCoercion>
-    <NullableReturnStatement occurrences="7">
-      <code>$this-&gt;data['authors']</code>
+    <NullableReturnStatement occurrences="6">
       <code>$this-&gt;data['commentfeedlink']</code>
       <code>$this-&gt;data['commentlink']</code>
       <code>$this-&gt;data['datemodified']</code>
@@ -721,31 +635,8 @@
     <PropertyNotSetInConstructor occurrences="1">
       <code>Rss</code>
     </PropertyNotSetInConstructor>
-    <UndefinedMethod occurrences="24">
+    <UndefinedMethod occurrences="1">
       <code>getAttribute</code>
-      <code>getAuthors</code>
-      <code>getAuthors</code>
-      <code>getCategories</code>
-      <code>getCategories</code>
-      <code>getCommentCount</code>
-      <code>getCommentCount</code>
-      <code>getCommentCount</code>
-      <code>getCommentFeedLink</code>
-      <code>getCommentFeedLink</code>
-      <code>getCommentFeedLink</code>
-      <code>getCommentLink</code>
-      <code>getContent</code>
-      <code>getContent</code>
-      <code>getDate</code>
-      <code>getDateModified</code>
-      <code>getDescription</code>
-      <code>getDescription</code>
-      <code>getEnclosure</code>
-      <code>getId</code>
-      <code>getId</code>
-      <code>getLinks</code>
-      <code>getTitle</code>
-      <code>getTitle</code>
     </UndefinedMethod>
     <UnusedVariable occurrences="2">
       <code>$description</code>
@@ -859,11 +750,6 @@
       <code>$author</code>
       <code>$element</code>
     </ArgumentTypeCoercion>
-    <InvalidReturnStatement occurrences="3">
-      <code>$this-&gt;data['datecreated']</code>
-      <code>$this-&gt;data['datemodified']</code>
-      <code>$this-&gt;data['enclosure']</code>
-    </InvalidReturnStatement>
     <InvalidScalarArgument occurrences="1">
       <code>$deep</code>
     </InvalidScalarArgument>
@@ -896,11 +782,11 @@
       <code>Collection\Category</code>
       <code>array</code>
       <code>int</code>
+      <code>null|DateTime</code>
+      <code>null|DateTime</code>
       <code>null|Reader\Feed\Atom\Source</code>
+      <code>null|object{href: string, length: int, type: string}</code>
       <code>null|string</code>
-      <code>string</code>
-      <code>string</code>
-      <code>string</code>
       <code>string</code>
       <code>string</code>
       <code>string</code>
@@ -929,13 +815,10 @@
       <code>$this-&gt;data['source']</code>
       <code>$this-&gt;data['title']</code>
     </MixedReturnStatement>
-    <NullableReturnStatement occurrences="8">
+    <NullableReturnStatement occurrences="5">
       <code>$this-&gt;data['commentfeedlink']</code>
       <code>$this-&gt;data['commentlink']</code>
-      <code>$this-&gt;data['datecreated']</code>
-      <code>$this-&gt;data['datemodified']</code>
       <code>$this-&gt;data['description']</code>
-      <code>$this-&gt;data['enclosure']</code>
       <code>$this-&gt;data['id']</code>
       <code>$this-&gt;data['title']</code>
     </NullableReturnStatement>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -116,33 +116,22 @@
     <FalsableReturnStatement occurrences="1">
       <code>false</code>
     </FalsableReturnStatement>
-    <MixedArgument occurrences="4">
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-    </MixedArgument>
-    <MixedAssignment occurrences="5">
+    <MixedArgumentTypeCoercion occurrences="2">
+      <code>$data</code>
+      <code>$data</code>
+    </MixedArgumentTypeCoercion>
+    <MixedAssignment occurrences="1">
       <code>$data['created_time']</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
-      <code>$result</code>
     </MixedAssignment>
     <MixedInferredReturnType occurrences="1">
       <code>array</code>
     </MixedInferredReturnType>
-    <MixedMethodCall occurrences="3">
-      <code>current</code>
-      <code>current</code>
+    <MixedMethodCall occurrences="1">
       <code>getArrayCopy</code>
     </MixedMethodCall>
     <MixedOperand occurrences="1">
       <code>$data['lease_seconds']</code>
     </MixedOperand>
-    <MixedPropertyFetch occurrences="1">
-      <code>$result-&gt;current()-&gt;created_time</code>
-    </MixedPropertyFetch>
     <MixedReturnStatement occurrences="1">
       <code>$result-&gt;current()-&gt;getArrayCopy()</code>
     </MixedReturnStatement>
@@ -879,7 +868,7 @@
       <code>$deep</code>
     </InvalidScalarArgument>
     <MixedArgument occurrences="6">
-      <code>$content</code>
+      <code>$content ?? ''</code>
       <code>$dateCreated</code>
       <code>$dateModified</code>
       <code>$link</code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="4.4.1@9fd7a7d885b3a216cff8dec9d8c21a132f275224">
+<files psalm-version="4.10.0@916b098b008f6de4543892b1e0651c1c3b92cbfa">
   <file src="src/PubSubHubbub/AbstractCallback.php">
     <DocblockTypeContradiction occurrences="4">
       <code>! $httpResponse instanceof HttpResponse &amp;&amp; ! $httpResponse instanceof PhpResponse</code>
@@ -101,9 +101,6 @@
       <code>(string) $name</code>
       <code>(string) $value</code>
     </RedundantCastGivenDocblockType>
-    <RedundantCondition occurrences="1">
-      <code>200 == $this-&gt;statusCode</code>
-    </RedundantCondition>
   </file>
   <file src="src/PubSubHubbub/Model/AbstractModel.php">
     <NullArgument occurrences="1">
@@ -171,7 +168,7 @@
     </UndefinedInterfaceMethod>
   </file>
   <file src="src/PubSubHubbub/Publisher.php">
-    <DocblockTypeContradiction occurrences="11">
+    <DocblockTypeContradiction occurrences="10">
       <code>! is_string($name)</code>
       <code>! is_string($name)</code>
       <code>! is_string($url)</code>
@@ -181,11 +178,9 @@
       <code>empty($url) || ! is_string($url)</code>
       <code>empty($url) || ! is_string($url)</code>
       <code>empty($url) || ! is_string($url)</code>
-      <code>is_array($name)</code>
       <code>is_array($options)</code>
     </DocblockTypeContradiction>
-    <MixedArgument occurrences="10">
-      <code>$name</code>
+    <MixedArgument occurrences="9">
       <code>$options['hubUrls']</code>
       <code>$options['parameters']</code>
       <code>$options['updatedTopicUrls']</code>
@@ -213,7 +208,7 @@
     </MixedOperand>
   </file>
   <file src="src/PubSubHubbub/Subscriber.php">
-    <DocblockTypeContradiction occurrences="14">
+    <DocblockTypeContradiction occurrences="13">
       <code>! is_string($name)</code>
       <code>! is_string($name)</code>
       <code>! is_string($url)</code>
@@ -226,7 +221,6 @@
       <code>empty($url) || ! is_string($url)</code>
       <code>empty($url) || ! is_string($url)</code>
       <code>empty($url) || ! is_string($url)</code>
-      <code>is_array($name)</code>
       <code>is_array($options)</code>
     </DocblockTypeContradiction>
     <InvalidPropertyAssignmentValue occurrences="1">
@@ -235,18 +229,14 @@
     <InvalidScalarArgument occurrences="1">
       <code>rand()</code>
     </InvalidScalarArgument>
-    <MissingPropertyType occurrences="1">
-      <code>$testStaticToken</code>
-    </MissingPropertyType>
     <MissingReturnType occurrences="1">
       <code>setTestStaticToken</code>
     </MissingReturnType>
-    <MixedArgument occurrences="21">
+    <MixedArgument occurrences="19">
       <code>$auth[0]</code>
       <code>$auth[1]</code>
       <code>$authentication</code>
       <code>$duplicateKey</code>
-      <code>$name</code>
       <code>$options['authentications']</code>
       <code>$options['callbackUrl']</code>
       <code>$options['hubUrls']</code>
@@ -256,7 +246,6 @@
       <code>$options['storage']</code>
       <code>$options['topicUrl']</code>
       <code>$options['usePathParameter']</code>
-      <code>$params['hub.verify_token']</code>
       <code>$url</code>
       <code>$url</code>
       <code>$url</code>
@@ -288,24 +277,18 @@
       <code>$value</code>
       <code>$value</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="1">
-      <code>string</code>
-    </MixedInferredReturnType>
     <MixedOperand occurrences="4">
       <code>$keyduplicate</code>
       <code>$params['hub.lease_seconds']</code>
       <code>$params['hub.topic']</code>
       <code>$value</code>
     </MixedOperand>
-    <MixedReturnStatement occurrences="1">
-      <code>$this-&gt;testStaticToken</code>
-    </MixedReturnStatement>
     <PossiblyFalsePropertyAssignmentValue occurrences="1">
       <code>false</code>
     </PossiblyFalsePropertyAssignmentValue>
-    <PossiblyInvalidArgument occurrences="1">
+    <PossiblyInvalidCast occurrences="1">
       <code>$params['hub.verify_token']</code>
-    </PossiblyInvalidArgument>
+    </PossiblyInvalidCast>
     <PropertyNotSetInConstructor occurrences="2">
       <code>$leaseSeconds</code>
       <code>$storage</code>
@@ -419,21 +402,15 @@
     <InvalidScalarArgument occurrences="1">
       <code>$this-&gt;key()</code>
     </InvalidScalarArgument>
-    <MissingParamType occurrences="2">
-      <code>$args</code>
-      <code>$method</code>
-    </MissingParamType>
-    <MissingReturnType occurrences="4">
-      <code>getExtensions</code>
+    <MissingReturnType occurrences="3">
       <code>indexEntries</code>
       <code>loadExtensions</code>
       <code>registerNamespaces</code>
     </MissingReturnType>
-    <MixedArgument occurrences="6">
+    <MixedArgument occurrences="5">
       <code>$all['core']</code>
       <code>$extension</code>
       <code>$extension</code>
-      <code>$method</code>
       <code>$this-&gt;entries[$this-&gt;key()]</code>
       <code>$this-&gt;entries[$this-&gt;key()]</code>
     </MixedArgument>
@@ -446,8 +423,7 @@
       <code>$feed</code>
       <code>$plugin</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="2">
-      <code>Extension\AbstractFeed</code>
+    <MixedInferredReturnType occurrences="1">
       <code>string</code>
     </MixedInferredReturnType>
     <MixedMethodCall occurrences="3">
@@ -455,12 +431,8 @@
       <code>setType</code>
       <code>setXpath</code>
     </MixedMethodCall>
-    <MixedOperand occurrences="1">
-      <code>$method</code>
-    </MixedOperand>
-    <MixedReturnStatement occurrences="2">
+    <MixedReturnStatement occurrences="1">
       <code>$this-&gt;data['type']</code>
-      <code>$this-&gt;extensions[$name . '\Feed']</code>
     </MixedReturnStatement>
     <PropertyNotSetInConstructor occurrences="1">
       <code>$originalSourceUri</code>
@@ -506,8 +478,7 @@
       <code>$feed</code>
       <code>$plugin</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="2">
-      <code>Reader\Extension\AbstractEntry</code>
+    <MixedInferredReturnType occurrences="1">
       <code>string</code>
     </MixedInferredReturnType>
     <MixedMethodCall occurrences="3">
@@ -515,9 +486,8 @@
       <code>setEntryKey</code>
       <code>setType</code>
     </MixedMethodCall>
-    <MixedReturnStatement occurrences="2">
+    <MixedReturnStatement occurrences="1">
       <code>$this-&gt;data['type']</code>
-      <code>$this-&gt;extensions[$name . '\\Entry']</code>
     </MixedReturnStatement>
     <PossiblyNullPropertyAssignmentValue occurrences="1">
       <code>$entry-&gt;ownerDocument</code>
@@ -527,10 +497,14 @@
     </PropertyNotSetInConstructor>
   </file>
   <file src="src/Reader/Entry/Atom.php">
-    <ImplementedReturnTypeMismatch occurrences="2">
+    <ImplementedReturnTypeMismatch occurrences="3">
+      <code>null|string</code>
       <code>string</code>
       <code>void</code>
     </ImplementedReturnTypeMismatch>
+    <InvalidNullableReturnType occurrences="1">
+      <code>string</code>
+    </InvalidNullableReturnType>
     <MixedArgument occurrences="1">
       <code>$categoryCollection</code>
     </MixedArgument>
@@ -554,16 +528,15 @@
       <code>$source</code>
       <code>$title</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="16">
+    <MixedInferredReturnType occurrences="15">
       <code>DateTime</code>
       <code>DateTime</code>
       <code>Reader\Collection\Category</code>
       <code>array</code>
       <code>array</code>
-      <code>getAuthor</code>
       <code>int</code>
       <code>null|Reader\Feed\Atom\Source</code>
-      <code>string</code>
+      <code>null|string</code>
       <code>string</code>
       <code>string</code>
       <code>string</code>
@@ -578,8 +551,7 @@
       <code>setType</code>
       <code>setXpath</code>
     </MixedMethodCall>
-    <MixedReturnStatement occurrences="30">
-      <code>$authors[$index]</code>
+    <MixedReturnStatement occurrences="29">
       <code>$this-&gt;data['authors']</code>
       <code>$this-&gt;data['authors']</code>
       <code>$this-&gt;data['categories']</code>
@@ -604,12 +576,17 @@
       <code>$this-&gt;data['id']</code>
       <code>$this-&gt;data['links']</code>
       <code>$this-&gt;data['links']</code>
-      <code>$this-&gt;data['links'][$index]</code>
       <code>$this-&gt;data['source']</code>
       <code>$this-&gt;data['source']</code>
       <code>$this-&gt;data['title']</code>
       <code>$this-&gt;data['title']</code>
     </MixedReturnStatement>
+    <MixedReturnTypeCoercion occurrences="2">
+      <code>null|array&lt;string, string&gt;</code>
+    </MixedReturnTypeCoercion>
+    <NullableReturnStatement occurrences="1">
+      <code>$this-&gt;getLink(0)</code>
+    </NullableReturnStatement>
     <PropertyNotSetInConstructor occurrences="1">
       <code>Atom</code>
     </PropertyNotSetInConstructor>
@@ -633,20 +610,27 @@
     </UndefinedMethod>
   </file>
   <file src="src/Reader/Entry/Rss.php">
-    <ImplementedReturnTypeMismatch occurrences="3">
+    <ImplementedReturnTypeMismatch occurrences="5">
+      <code>null|string</code>
+      <code>null|string</code>
       <code>null|string</code>
       <code>string</code>
       <code>void</code>
     </ImplementedReturnTypeMismatch>
+    <InvalidNullableReturnType occurrences="1">
+      <code>string</code>
+    </InvalidNullableReturnType>
     <InvalidScalarArgument occurrences="1">
       <code>$entryKey</code>
     </InvalidScalarArgument>
-    <MixedArgument occurrences="5">
+    <LessSpecificReturnStatement occurrences="1">
+      <code>$this-&gt;data['datemodified']</code>
+    </LessSpecificReturnStatement>
+    <MixedArgument occurrences="4">
       <code>$authors</code>
       <code>$categoryCollection</code>
       <code>$dateModified</code>
       <code>$dateModified</code>
-      <code>Reader\Reader::arrayUnique($authors)</code>
     </MixedArgument>
     <MixedArrayAccess occurrences="1">
       <code>$author['name']</code>
@@ -686,15 +670,14 @@
       <code>$title</code>
       <code>$title</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="14">
+    <MixedInferredReturnType occurrences="13">
       <code>DateTime</code>
       <code>Reader\Collection\Category</code>
       <code>array</code>
       <code>array</code>
-      <code>getAuthor</code>
       <code>null|string</code>
-      <code>string</code>
-      <code>string</code>
+      <code>null|string</code>
+      <code>null|string</code>
       <code>string</code>
       <code>string</code>
       <code>string</code>
@@ -708,8 +691,7 @@
       <code>setType</code>
       <code>setXpath</code>
     </MixedMethodCall>
-    <MixedReturnStatement occurrences="26">
-      <code>$authors[$index]</code>
+    <MixedReturnStatement occurrences="22">
       <code>$this-&gt;data['authors']</code>
       <code>$this-&gt;data['authors']</code>
       <code>$this-&gt;data['categories']</code>
@@ -723,8 +705,6 @@
       <code>$this-&gt;data['content']</code>
       <code>$this-&gt;data['content']</code>
       <code>$this-&gt;data['datemodified']</code>
-      <code>$this-&gt;data['datemodified']</code>
-      <code>$this-&gt;data['description']</code>
       <code>$this-&gt;data['description']</code>
       <code>$this-&gt;data['enclosure']</code>
       <code>$this-&gt;data['enclosure']</code>
@@ -732,10 +712,11 @@
       <code>$this-&gt;data['id']</code>
       <code>$this-&gt;data['links']</code>
       <code>$this-&gt;data['links']</code>
-      <code>$this-&gt;data['links'][$index]</code>
-      <code>$this-&gt;data['title']</code>
       <code>$this-&gt;data['title']</code>
     </MixedReturnStatement>
+    <MixedReturnTypeCoercion occurrences="2">
+      <code>null|array&lt;string, string&gt;</code>
+    </MixedReturnTypeCoercion>
     <NullableReturnStatement occurrences="7">
       <code>$this-&gt;data['authors']</code>
       <code>$this-&gt;data['commentfeedlink']</code>
@@ -743,7 +724,7 @@
       <code>$this-&gt;data['datemodified']</code>
       <code>$this-&gt;data['description']</code>
       <code>$this-&gt;data['id']</code>
-      <code>$this-&gt;data['title']</code>
+      <code>$this-&gt;getLink(0)</code>
     </NullableReturnStatement>
     <PossiblyNullArgument occurrences="1">
       <code>$standard</code>
@@ -751,10 +732,7 @@
     <PropertyNotSetInConstructor occurrences="1">
       <code>Rss</code>
     </PropertyNotSetInConstructor>
-    <UndefinedMethod occurrences="27">
-      <code>getAttribute</code>
-      <code>getAttribute</code>
-      <code>getAttribute</code>
+    <UndefinedMethod occurrences="24">
       <code>getAttribute</code>
       <code>getAuthors</code>
       <code>getAuthors</code>
@@ -780,6 +758,10 @@
       <code>getTitle</code>
       <code>getTitle</code>
     </UndefinedMethod>
+    <UnusedVariable occurrences="2">
+      <code>$description</code>
+      <code>$title</code>
+    </UnusedVariable>
   </file>
   <file src="src/Reader/Extension/AbstractEntry.php">
     <DocblockTypeContradiction occurrences="2">
@@ -896,14 +878,13 @@
     <InvalidScalarArgument occurrences="1">
       <code>$deep</code>
     </InvalidScalarArgument>
-    <MixedArgument occurrences="7">
+    <MixedArgument occurrences="6">
       <code>$content</code>
       <code>$dateCreated</code>
       <code>$dateModified</code>
       <code>$link</code>
       <code>$link</code>
       <code>$link-&gt;value</code>
-      <code>Reader\Reader::arrayUnique($authors)</code>
     </MixedArgument>
     <MixedAssignment occurrences="14">
       <code>$baseUrl</code>
@@ -921,15 +902,13 @@
       <code>$title</code>
       <code>$type</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="17">
+    <MixedInferredReturnType occurrences="15">
       <code>Collection\Author</code>
       <code>Collection\Category</code>
       <code>array</code>
       <code>int</code>
       <code>null|Reader\Feed\Atom\Source</code>
       <code>null|string</code>
-      <code>null|string</code>
-      <code>string</code>
       <code>string</code>
       <code>string</code>
       <code>string</code>
@@ -940,8 +919,7 @@
       <code>string</code>
       <code>string</code>
     </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="22">
-      <code>$authors[$index]</code>
+    <MixedReturnStatement occurrences="19">
       <code>$this-&gt;data['authors']</code>
       <code>$this-&gt;data['baseUrl']</code>
       <code>$this-&gt;data['baseUrl']</code>
@@ -959,9 +937,7 @@
       <code>$this-&gt;data['id']</code>
       <code>$this-&gt;data['id']</code>
       <code>$this-&gt;data['links']</code>
-      <code>$this-&gt;data['links'][$index]</code>
       <code>$this-&gt;data['source']</code>
-      <code>$this-&gt;data['title']</code>
       <code>$this-&gt;data['title']</code>
     </MixedReturnStatement>
     <NullableReturnStatement occurrences="8">
@@ -977,10 +953,7 @@
     <PossiblyNullOperand occurrences="1">
       <code>$this-&gt;getBaseUrl()</code>
     </PossiblyNullOperand>
-    <UndefinedMethod occurrences="7">
-      <code>getAttribute</code>
-      <code>getAttribute</code>
-      <code>getAttribute</code>
+    <UndefinedMethod occurrences="4">
       <code>getAttribute</code>
       <code>getAttribute</code>
       <code>getAttribute</code>
@@ -997,11 +970,10 @@
     <ArgumentTypeCoercion occurrences="1">
       <code>$author</code>
     </ArgumentTypeCoercion>
-    <MixedArgument occurrences="4">
+    <MixedArgument occurrences="3">
       <code>$dateCreated</code>
       <code>$dateModified</code>
       <code>$link</code>
-      <code>Reader\Reader::arrayUnique($authors)</code>
     </MixedArgument>
     <MixedAssignment occurrences="16">
       <code>$baseUrl</code>
@@ -1021,7 +993,7 @@
       <code>$link</code>
       <code>$title</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="16">
+    <MixedInferredReturnType occurrences="15">
       <code>Collection\Author</code>
       <code>Collection\Category</code>
       <code>null|DateTime</code>
@@ -1037,10 +1009,8 @@
       <code>null|string</code>
       <code>null|string</code>
       <code>null|string</code>
-      <code>null|string</code>
     </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="23">
-      <code>$authors[$index]</code>
+    <MixedReturnStatement occurrences="22">
       <code>$this-&gt;data['authors']</code>
       <code>$this-&gt;data['baseUrl']</code>
       <code>$this-&gt;data['baseUrl']</code>
@@ -1072,32 +1042,28 @@
       <code>getAttribute</code>
       <code>getAttribute</code>
     </UndefinedMethod>
+    <UnusedVariable occurrences="2">
+      <code>$copyright</code>
+      <code>$description</code>
+    </UnusedVariable>
   </file>
   <file src="src/Reader/Extension/Content/Entry.php">
-    <MissingReturnType occurrences="1">
-      <code>getContent</code>
-    </MissingReturnType>
-    <MixedAssignment occurrences="2">
-      <code>$content</code>
-      <code>$content</code>
-    </MixedAssignment>
+    <MixedInferredReturnType occurrences="1">
+      <code>string</code>
+    </MixedInferredReturnType>
+    <MixedReturnStatement occurrences="2">
+      <code>$this-&gt;xpath-&gt;evaluate('string(' . $this-&gt;getXpathPrefix() . '/content:encoded)')</code>
+      <code>$this-&gt;xpath-&gt;evaluate('string(' . $this-&gt;getXpathPrefix() . '/content:encoded)')</code>
+    </MixedReturnStatement>
   </file>
   <file src="src/Reader/Extension/CreativeCommons/Entry.php">
-    <MixedAssignment occurrences="3">
-      <code>$license</code>
-      <code>$licenses[]</code>
+    <MixedAssignment occurrences="1">
       <code>$list</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="2">
+    <MixedInferredReturnType occurrences="1">
       <code>array</code>
-      <code>null|string</code>
     </MixedInferredReturnType>
-    <MixedPropertyFetch occurrences="2">
-      <code>$license-&gt;nodeValue</code>
-      <code>$list-&gt;length</code>
-    </MixedPropertyFetch>
-    <MixedReturnStatement occurrences="2">
-      <code>$licenses[$index]</code>
+    <MixedReturnStatement occurrences="1">
       <code>$this-&gt;data[$name]</code>
     </MixedReturnStatement>
   </file>
@@ -1107,16 +1073,14 @@
       <code>$licenses[]</code>
       <code>$list</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="2">
+    <MixedInferredReturnType occurrences="1">
       <code>array</code>
-      <code>null|string</code>
     </MixedInferredReturnType>
     <MixedPropertyFetch occurrences="2">
       <code>$license-&gt;nodeValue</code>
       <code>$list-&gt;length</code>
     </MixedPropertyFetch>
-    <MixedReturnStatement occurrences="2">
-      <code>$licenses[$index]</code>
+    <MixedReturnStatement occurrences="1">
       <code>$this-&gt;data[$name]</code>
     </MixedReturnStatement>
   </file>
@@ -1124,13 +1088,10 @@
     <InvalidReturnStatement occurrences="1">
       <code>$this-&gt;data['authors']</code>
     </InvalidReturnStatement>
-    <MixedArgument occurrences="2">
+    <MixedArgument occurrences="1">
       <code>$date</code>
-      <code>Reader\Reader::arrayUnique($authors)</code>
     </MixedArgument>
-    <MixedAssignment occurrences="16">
-      <code>$author</code>
-      <code>$category</code>
+    <MixedAssignment occurrences="14">
       <code>$date</code>
       <code>$date</code>
       <code>$description</code>
@@ -1146,24 +1107,15 @@
       <code>$title</code>
       <code>$title</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="7">
+    <MixedInferredReturnType occurrences="6">
       <code>Collection\Category</code>
       <code>array</code>
       <code>null|DateTime</code>
       <code>string</code>
       <code>string</code>
       <code>string</code>
-      <code>string</code>
     </MixedInferredReturnType>
-    <MixedPropertyFetch occurrences="5">
-      <code>$author-&gt;nodeValue</code>
-      <code>$category-&gt;nodeValue</code>
-      <code>$list-&gt;length</code>
-      <code>$list-&gt;length</code>
-      <code>$list-&gt;length</code>
-    </MixedPropertyFetch>
-    <MixedReturnStatement occurrences="10">
-      <code>$authors[$index]</code>
+    <MixedReturnStatement occurrences="9">
       <code>$this-&gt;data['authors']</code>
       <code>$this-&gt;data['categories']</code>
       <code>$this-&gt;data['date']</code>
@@ -1174,6 +1126,9 @@
       <code>$this-&gt;data['title']</code>
       <code>$this-&gt;data['title']</code>
     </MixedReturnStatement>
+    <MixedReturnTypeCoercion occurrences="2">
+      <code>null|array&lt;string, string&gt;</code>
+    </MixedReturnTypeCoercion>
     <NullableReturnStatement occurrences="3">
       <code>$this-&gt;data['authors']</code>
       <code>$this-&gt;data['description']</code>
@@ -1184,12 +1139,10 @@
     <InvalidReturnStatement occurrences="1">
       <code>$this-&gt;data['authors']</code>
     </InvalidReturnStatement>
-    <MixedArgument occurrences="2">
+    <MixedArgument occurrences="1">
       <code>$date</code>
-      <code>Reader\Reader::arrayUnique($authors)</code>
     </MixedArgument>
-    <MixedAssignment occurrences="15">
-      <code>$category</code>
+    <MixedAssignment occurrences="14">
       <code>$copyright</code>
       <code>$copyright</code>
       <code>$date</code>
@@ -1205,7 +1158,7 @@
       <code>$title</code>
       <code>$title</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="9">
+    <MixedInferredReturnType occurrences="8">
       <code>Collection\Category</code>
       <code>array</code>
       <code>null|DateTime</code>
@@ -1214,14 +1167,8 @@
       <code>null|string</code>
       <code>null|string</code>
       <code>null|string</code>
-      <code>null|string</code>
     </MixedInferredReturnType>
-    <MixedPropertyFetch occurrences="2">
-      <code>$category-&gt;nodeValue</code>
-      <code>$list-&gt;length</code>
-    </MixedPropertyFetch>
-    <MixedReturnStatement occurrences="14">
-      <code>$authors[$index]</code>
+    <MixedReturnStatement occurrences="13">
       <code>$this-&gt;data['authors']</code>
       <code>$this-&gt;data['categories']</code>
       <code>$this-&gt;data['copyright']</code>
@@ -1305,6 +1252,10 @@
       <code>getAttribute</code>
       <code>getAttribute</code>
     </UndefinedMethod>
+    <UnusedVariable occurrences="2">
+      <code>$children</code>
+      <code>$children</code>
+    </UnusedVariable>
   </file>
   <file src="src/Reader/Extension/Podcast/Entry.php">
     <MixedAssignment occurrences="13">
@@ -1445,6 +1396,10 @@
       <code>getAttribute</code>
       <code>getAttribute</code>
     </UndefinedMethod>
+    <UnusedVariable occurrences="2">
+      <code>$children</code>
+      <code>$children</code>
+    </UnusedVariable>
   </file>
   <file src="src/Reader/Extension/PodcastIndex/Entry.php">
     <MismatchingDocblockReturnType occurrences="2">
@@ -1557,46 +1512,28 @@
     </MixedReturnStatement>
   </file>
   <file src="src/Reader/ExtensionManager.php">
-    <MissingPropertyType occurrences="1">
-      <code>$pluginManager</code>
-    </MissingPropertyType>
-    <MixedArgument occurrences="1">
-      <code>$this-&gt;pluginManager</code>
-    </MixedArgument>
-    <MixedInferredReturnType occurrences="2">
+    <MixedInferredReturnType occurrences="1">
       <code>Extension\AbstractEntry|Extension\AbstractFeed</code>
-      <code>bool</code>
     </MixedInferredReturnType>
-    <MixedMethodCall occurrences="2">
-      <code>get</code>
-      <code>has</code>
-    </MixedMethodCall>
-    <MixedReturnStatement occurrences="2">
-      <code>$this-&gt;pluginManager-&gt;get($name)</code>
-      <code>$this-&gt;pluginManager-&gt;has($name)</code>
+    <MixedReturnStatement occurrences="1">
+      <code>$this-&gt;pluginManager-&gt;get($extension)</code>
     </MixedReturnStatement>
   </file>
   <file src="src/Reader/Feed/AbstractFeed.php">
     <InvalidScalarArgument occurrences="1">
       <code>$this-&gt;key()</code>
     </InvalidScalarArgument>
-    <MissingParamType occurrences="2">
-      <code>$args</code>
-      <code>$method</code>
-    </MissingParamType>
-    <MissingReturnType occurrences="4">
-      <code>getExtensions</code>
+    <MissingReturnType occurrences="3">
       <code>indexEntries</code>
       <code>loadExtensions</code>
       <code>registerNamespaces</code>
     </MissingReturnType>
-    <MixedArgument occurrences="8">
+    <MixedArgument occurrences="7">
       <code>$all['core']</code>
       <code>$extension</code>
       <code>$extension</code>
       <code>$extension</code>
       <code>$extension</code>
-      <code>$method</code>
       <code>$this-&gt;entries[$this-&gt;key()]</code>
       <code>$this-&gt;entries[$this-&gt;key()]</code>
     </MixedArgument>
@@ -1618,9 +1555,6 @@
       <code>setType</code>
       <code>setXpath</code>
     </MixedMethodCall>
-    <MixedOperand occurrences="1">
-      <code>$method</code>
-    </MixedOperand>
     <MixedReturnStatement occurrences="2">
       <code>$this-&gt;data['type']</code>
       <code>$this-&gt;extensions[$name . '\\Feed']</code>
@@ -1630,6 +1564,9 @@
     </PropertyNotSetInConstructor>
   </file>
   <file src="src/Reader/Feed/Atom.php">
+    <ImplementedReturnTypeMismatch occurrences="1">
+      <code>null|array&lt;string, string&gt;</code>
+    </ImplementedReturnTypeMismatch>
     <MixedArgument occurrences="1">
       <code>$categoryCollection</code>
     </MixedArgument>
@@ -1661,14 +1598,13 @@
       <code>$link</code>
       <code>$title</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="16">
+    <MixedInferredReturnType occurrences="15">
       <code>Reader\Collection\Category</code>
       <code>array</code>
       <code>null|DateTime</code>
       <code>null|DateTime</code>
       <code>null|array</code>
       <code>null|array</code>
-      <code>null|string</code>
       <code>null|string</code>
       <code>null|string</code>
       <code>null|string</code>
@@ -1688,8 +1624,7 @@
       <code>setXpath</code>
       <code>setXpathPrefix</code>
     </MixedMethodCall>
-    <MixedReturnStatement occurrences="31">
-      <code>$authors[$index]</code>
+    <MixedReturnStatement occurrences="30">
       <code>$this-&gt;data['authors']</code>
       <code>$this-&gt;data['authors']</code>
       <code>$this-&gt;data['baseUrl']</code>
@@ -1721,6 +1656,9 @@
       <code>$this-&gt;data['title']</code>
       <code>$this-&gt;data['title']</code>
     </MixedReturnStatement>
+    <MixedReturnTypeCoercion occurrences="2">
+      <code>null|array&lt;string, string&gt;</code>
+    </MixedReturnTypeCoercion>
     <PossiblyNullReference occurrences="16">
       <code>getAuthors</code>
       <code>getBaseUrl</code>
@@ -1789,17 +1727,19 @@
     </PropertyNotSetInConstructor>
   </file>
   <file src="src/Reader/Feed/Rss.php">
+    <ImplementedReturnTypeMismatch occurrences="1">
+      <code>null|array&lt;string, string&gt;</code>
+    </ImplementedReturnTypeMismatch>
     <InvalidScalarArgument occurrences="1">
       <code>$lastBuildDateParsed</code>
     </InvalidScalarArgument>
-    <MixedArgument occurrences="7">
+    <MixedArgument occurrences="6">
       <code>$authors</code>
       <code>$categoryCollection</code>
       <code>$dateModified</code>
       <code>$dateModified</code>
       <code>$hubs</code>
       <code>$lastBuildDate</code>
-      <code>Reader\Reader::arrayUnique($authors)</code>
     </MixedArgument>
     <MixedArrayAccess occurrences="1">
       <code>$author['name']</code>
@@ -1865,14 +1805,13 @@
       <code>$value</code>
       <code>$value</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="15">
+    <MixedInferredReturnType occurrences="14">
       <code>DateTime</code>
       <code>DateTime</code>
       <code>Reader\Collection\Category</code>
       <code>array</code>
       <code>null|array</code>
       <code>null|array</code>
-      <code>null|string</code>
       <code>null|string</code>
       <code>null|string</code>
       <code>null|string</code>
@@ -1891,8 +1830,7 @@
       <code>setXpath</code>
       <code>setXpathPrefix</code>
     </MixedMethodCall>
-    <MixedReturnStatement occurrences="26">
-      <code>$authors[$index]</code>
+    <MixedReturnStatement occurrences="25">
       <code>$this-&gt;data['authors']</code>
       <code>$this-&gt;data['authors']</code>
       <code>$this-&gt;data['categories']</code>
@@ -1919,6 +1857,9 @@
       <code>$this-&gt;data['title']</code>
       <code>$this-&gt;data['title']</code>
     </MixedReturnStatement>
+    <MixedReturnTypeCoercion occurrences="2">
+      <code>null|array&lt;string, string&gt;</code>
+    </MixedReturnTypeCoercion>
     <NullableReturnStatement occurrences="3">
       <code>$this-&gt;data['authors']</code>
       <code>$this-&gt;data['datemodified']</code>
@@ -1977,39 +1918,18 @@
     </UndefinedMethod>
   </file>
   <file src="src/Reader/FeedSet.php">
-    <MissingPropertyType occurrences="3">
-      <code>$atom</code>
-      <code>$rdf</code>
-      <code>$rss</code>
-    </MissingPropertyType>
-    <MixedArgument occurrences="6">
-      <code>$link-&gt;getAttribute('href')</code>
-      <code>$link-&gt;getAttribute('href')</code>
-      <code>$link-&gt;getAttribute('href')</code>
-      <code>$link-&gt;getAttribute('href')</code>
-      <code>$link-&gt;getAttribute('rel')</code>
+    <MixedArgument occurrences="1">
       <code>$this-&gt;offsetGet('href')</code>
     </MixedArgument>
-    <UndefinedMethod occurrences="12">
-      <code>getAttribute</code>
-      <code>getAttribute</code>
-      <code>getAttribute</code>
-      <code>getAttribute</code>
-      <code>getAttribute</code>
-      <code>getAttribute</code>
-      <code>getAttribute</code>
-      <code>getAttribute</code>
-      <code>getAttribute</code>
-      <code>getAttribute</code>
-      <code>getAttribute</code>
-      <code>getAttribute</code>
-    </UndefinedMethod>
     <UnsafeInstantiation occurrences="1"/>
   </file>
   <file src="src/Reader/Http/LaminasHttpClientDecorator.php">
     <InvalidScalarArgument occurrences="1">
       <code>$value</code>
     </InvalidScalarArgument>
+    <MixedArgumentTypeCoercion occurrences="1">
+      <code>$value</code>
+    </MixedArgumentTypeCoercion>
     <MixedAssignment occurrences="3">
       <code>$normalized[$name]</code>
       <code>$value</code>
@@ -2053,8 +1973,12 @@
     <MixedInferredReturnType occurrences="1">
       <code>getHeaderLine</code>
     </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="1"/>
-    <NullableReturnStatement occurrences="1"/>
+    <MixedReturnStatement occurrences="1">
+      <code>$this-&gt;headers[$normalizedName] ?? $default</code>
+    </MixedReturnStatement>
+    <NullableReturnStatement occurrences="1">
+      <code>$this-&gt;headers[$normalizedName] ?? $default</code>
+    </NullableReturnStatement>
     <PossiblyInvalidCast occurrences="1">
       <code>$body</code>
     </PossiblyInvalidCast>
@@ -2075,9 +1999,9 @@
     <ImplementedReturnTypeMismatch occurrences="1">
       <code>Feed\FeedInterface</code>
     </ImplementedReturnTypeMismatch>
-    <InvalidDocblock occurrences="1">
-      <code>public static function arrayUnique(array $array)</code>
-    </InvalidDocblock>
+    <InvalidNullableReturnType occurrences="1">
+      <code>ExtensionManagerInterface</code>
+    </InvalidNullableReturnType>
     <InvalidReturnStatement occurrences="1">
       <code>$reader</code>
     </InvalidReturnStatement>
@@ -2087,36 +2011,12 @@
     <InvalidScalarArgument occurrences="1">
       <code>1</code>
     </InvalidScalarArgument>
-    <MissingParamType occurrences="1">
-      <code>$flag</code>
-    </MissingParamType>
-    <MissingPropertyType occurrences="3">
-      <code>$extensionManager</code>
-      <code>$extensions</code>
-      <code>$httpConditionalGet</code>
-    </MissingPropertyType>
-    <MissingReturnType occurrences="1">
-      <code>arrayUnique</code>
-    </MissingReturnType>
-    <MixedArgument occurrences="7">
+    <MixedArgument occurrences="4">
       <code>$data</code>
-      <code>$flag</code>
       <code>$responseXml</code>
       <code>$value</code>
       <code>$version</code>
-      <code>static::$extensions['entry']</code>
-      <code>static::$extensions['feed']</code>
     </MixedArgument>
-    <MixedArrayAccess occurrences="4">
-      <code>static::$extensions['entry']</code>
-      <code>static::$extensions['entry']</code>
-      <code>static::$extensions['feed']</code>
-      <code>static::$extensions['feed']</code>
-    </MixedArrayAccess>
-    <MixedArrayAssignment occurrences="2">
-      <code>static::$extensions['entry']</code>
-      <code>static::$extensions['feed']</code>
-    </MixedArrayAssignment>
     <MixedAssignment occurrences="9">
       <code>$data</code>
       <code>$data</code>
@@ -2128,16 +2028,9 @@
       <code>$value</code>
       <code>$version</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="3">
-      <code>ExtensionManagerInterface</code>
-      <code>array</code>
-      <code>bool</code>
-    </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="3">
-      <code>$flag</code>
+    <NullableReturnStatement occurrences="1">
       <code>static::$extensionManager</code>
-      <code>static::$extensions</code>
-    </MixedReturnStatement>
+    </NullableReturnStatement>
     <RedundantCastGivenDocblockType occurrences="3">
       <code>(int) $response-&gt;getStatusCode()</code>
       <code>(int) $response-&gt;getStatusCode()</code>
@@ -2162,22 +2055,6 @@
     <LessSpecificReturnStatement occurrences="1">
       <code>new $class()</code>
     </LessSpecificReturnStatement>
-    <MissingPropertyType occurrences="1">
-      <code>$extensions</code>
-    </MissingPropertyType>
-    <MixedArgument occurrences="1">
-      <code>$this-&gt;extensions</code>
-    </MixedArgument>
-    <MixedArrayAccess occurrences="2">
-      <code>$this-&gt;extensions[$extension]</code>
-      <code>$this-&gt;extensions[$name]</code>
-    </MixedArrayAccess>
-    <MixedArrayAssignment occurrences="1">
-      <code>$this-&gt;extensions[$name]</code>
-    </MixedArrayAssignment>
-    <MixedAssignment occurrences="1">
-      <code>$class</code>
-    </MixedAssignment>
     <MixedMethodCall occurrences="1">
       <code>new $class()</code>
     </MixedMethodCall>
@@ -2189,36 +2066,16 @@
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="src/Uri.php">
-    <MissingPropertyType occurrences="1">
-      <code>$validSchemes</code>
-    </MissingPropertyType>
-    <MixedArgument occurrences="1">
-      <code>$this-&gt;validSchemes</code>
-    </MixedArgument>
-    <PossiblyNullPropertyAssignmentValue occurrences="8">
-      <code>isset($parsed['fragment']) ? $parsed['fragment'] : null</code>
-      <code>isset($parsed['host']) ? $parsed['host'] : null</code>
-      <code>isset($parsed['pass']) ? $parsed['pass'] : null</code>
-      <code>isset($parsed['path']) ? $parsed['path'] : null</code>
-      <code>isset($parsed['port']) ? $parsed['port'] : null</code>
-      <code>isset($parsed['query']) ? $parsed['query'] : null</code>
-      <code>isset($parsed['scheme']) ? $parsed['scheme'] : null</code>
-      <code>isset($parsed['user']) ? $parsed['user'] : null</code>
-    </PossiblyNullPropertyAssignmentValue>
-    <PropertyNotSetInConstructor occurrences="9">
-      <code>$fragment</code>
-      <code>$host</code>
-      <code>$pass</code>
-      <code>$path</code>
-      <code>$port</code>
-      <code>$query</code>
-      <code>$scheme</code>
-      <code>$user</code>
-      <code>$valid</code>
-    </PropertyNotSetInConstructor>
-    <RedundantConditionGivenDocblockType occurrences="1">
-      <code>$this-&gt;scheme !== null</code>
-    </RedundantConditionGivenDocblockType>
+    <InvalidNullableReturnType occurrences="3">
+      <code>string</code>
+      <code>string</code>
+      <code>string</code>
+    </InvalidNullableReturnType>
+    <NullableReturnStatement occurrences="3">
+      <code>$this-&gt;host</code>
+      <code>$this-&gt;path</code>
+      <code>$this-&gt;scheme</code>
+    </NullableReturnStatement>
     <UnsafeInstantiation occurrences="1">
       <code>new static($uri)</code>
     </UnsafeInstantiation>
@@ -2245,21 +2102,6 @@
       <code>empty($url) || ! is_string($url)</code>
       <code>empty($url) || ! is_string($url)</code>
     </DocblockTypeContradiction>
-    <InvalidDocblock occurrences="3">
-      <code>public function setDateCreated($date = null)</code>
-      <code>public function setDateModified($date = null)</code>
-      <code>public function setLastBuildDate($date = null)</code>
-    </InvalidDocblock>
-    <MissingParamType occurrences="3">
-      <code>$date</code>
-      <code>$date</code>
-      <code>$date</code>
-    </MissingParamType>
-    <MissingReturnType occurrences="3">
-      <code>setDateCreated</code>
-      <code>setDateModified</code>
-      <code>setLastBuildDate</code>
-    </MissingReturnType>
     <MixedArgument occurrences="6">
       <code>$author</code>
       <code>$category</code>
@@ -2340,18 +2182,9 @@
       <code>! is_string($reference)</code>
       <code>$date instanceof DateTimeInterface</code>
     </DocblockTypeContradiction>
-    <InvalidDocblock occurrences="1">
-      <code>public function setEncoding($encoding)</code>
-    </InvalidDocblock>
     <MissingConstructor occurrences="1">
       <code>$type</code>
     </MissingConstructor>
-    <MissingParamType occurrences="1">
-      <code>$encoding</code>
-    </MissingParamType>
-    <MissingReturnType occurrences="1">
-      <code>setEncoding</code>
-    </MissingReturnType>
     <MixedInferredReturnType occurrences="5">
       <code>DateTime</code>
       <code>null|string</code>
@@ -2368,8 +2201,7 @@
     </MixedReturnStatement>
   </file>
   <file src="src/Writer/Entry.php">
-    <DocblockTypeContradiction occurrences="13">
-      <code>! is_numeric($count)</code>
+    <DocblockTypeContradiction occurrences="12">
       <code>! is_string($content)</code>
       <code>! is_string($copyright)</code>
       <code>! is_string($description)</code>
@@ -2406,8 +2238,7 @@
       <code>$exts</code>
       <code>$link</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="18">
-      <code>Source</code>
+    <MixedInferredReturnType occurrences="16">
       <code>array</code>
       <code>array</code>
       <code>array</code>
@@ -2415,7 +2246,6 @@
       <code>null|string</code>
       <code>null|string</code>
       <code>null|string</code>
-      <code>object</code>
       <code>string</code>
       <code>string</code>
       <code>string</code>
@@ -2429,7 +2259,7 @@
     <MixedMethodCall occurrences="1">
       <code>setEncoding</code>
     </MixedMethodCall>
-    <MixedReturnStatement occurrences="18">
+    <MixedReturnStatement occurrences="16">
       <code>$this-&gt;data['authors']</code>
       <code>$this-&gt;data['categories']</code>
       <code>$this-&gt;data['commentCount']</code>
@@ -2445,9 +2275,7 @@
       <code>$this-&gt;data['id']</code>
       <code>$this-&gt;data['link']</code>
       <code>$this-&gt;data['links']</code>
-      <code>$this-&gt;data['source']</code>
       <code>$this-&gt;data['title']</code>
-      <code>$this-&gt;extensions[$name . '\\Entry']</code>
     </MixedReturnStatement>
     <PossiblyNullArgument occurrences="1">
       <code>$this-&gt;getEncoding()</code>
@@ -2455,11 +2283,6 @@
     <PropertyNotSetInConstructor occurrences="1">
       <code>$type</code>
     </PropertyNotSetInConstructor>
-    <RedundantCastGivenDocblockType occurrences="3">
-      <code>(int) $count</code>
-      <code>(int) $count</code>
-      <code>(int) $count</code>
-    </RedundantCastGivenDocblockType>
   </file>
   <file src="src/Writer/Extension/AbstractRenderer.php">
     <ImplementedReturnTypeMismatch occurrences="2">
@@ -2594,20 +2417,6 @@
     </ParadoxicalCondition>
   </file>
   <file src="src/Writer/Extension/GooglePlayPodcast/Entry.php">
-    <InvalidDocblock occurrences="1">
-      <code>public function setPlayPodcastBlock($value)</code>
-    </InvalidDocblock>
-    <MissingParamType occurrences="1">
-      <code>$value</code>
-    </MissingParamType>
-    <MissingReturnType occurrences="1">
-      <code>setPlayPodcastBlock</code>
-    </MissingReturnType>
-    <MixedArgument occurrences="3">
-      <code>$value</code>
-      <code>$value</code>
-      <code>$value</code>
-    </MixedArgument>
     <RedundantConditionGivenDocblockType occurrences="3">
       <code>in_array($value, ['yes', 'no', 'clean'], true)</code>
       <code>in_array($value, ['yes', 'no', 'clean'], true)</code>
@@ -2618,20 +2427,8 @@
     <DocblockTypeContradiction occurrences="1">
       <code>! is_string($value)</code>
     </DocblockTypeContradiction>
-    <InvalidDocblock occurrences="1">
-      <code>public function setPlayPodcastBlock($value)</code>
-    </InvalidDocblock>
-    <MissingParamType occurrences="1">
-      <code>$value</code>
-    </MissingParamType>
-    <MissingReturnType occurrences="1">
-      <code>setPlayPodcastBlock</code>
-    </MissingReturnType>
-    <MixedArgument occurrences="6">
+    <MixedArgument occurrences="3">
       <code>$val</code>
-      <code>$value</code>
-      <code>$value</code>
-      <code>$value</code>
       <code>$value</code>
       <code>$value</code>
     </MixedArgument>
@@ -2721,22 +2518,10 @@
       <code>is_object($number)</code>
       <code>is_object($type)</code>
     </DocblockTypeContradiction>
-    <InvalidDocblock occurrences="1">
-      <code>public function setItunesBlock($value)</code>
-    </InvalidDocblock>
-    <MissingParamType occurrences="1">
-      <code>$value</code>
-    </MissingParamType>
-    <MissingReturnType occurrences="1">
-      <code>setItunesBlock</code>
-    </MissingReturnType>
-    <MixedArgument occurrences="7">
+    <MixedArgument occurrences="4">
       <code>$number</code>
       <code>$number</code>
       <code>$type</code>
-      <code>$value</code>
-      <code>$value</code>
-      <code>$value</code>
       <code>$value</code>
     </MixedArgument>
     <MixedArrayAssignment occurrences="1">
@@ -2762,21 +2547,9 @@
       <code>is_bool($status)</code>
       <code>is_object($type)</code>
     </DocblockTypeContradiction>
-    <InvalidDocblock occurrences="1">
-      <code>public function setItunesBlock($value)</code>
-    </InvalidDocblock>
-    <MissingParamType occurrences="1">
-      <code>$value</code>
-    </MissingParamType>
-    <MissingReturnType occurrences="1">
-      <code>setItunesBlock</code>
-    </MissingReturnType>
-    <MixedArgument occurrences="10">
+    <MixedArgument occurrences="7">
       <code>$type</code>
       <code>$val</code>
-      <code>$value</code>
-      <code>$value</code>
-      <code>$value</code>
       <code>$value</code>
       <code>$value</code>
       <code>$value</code>
@@ -3011,30 +2784,23 @@
     </ParadoxicalCondition>
   </file>
   <file src="src/Writer/ExtensionManager.php">
-    <MissingPropertyType occurrences="1">
-      <code>$pluginManager</code>
-    </MissingPropertyType>
-    <MixedArgument occurrences="1">
-      <code>$this-&gt;pluginManager</code>
-    </MixedArgument>
-    <MixedInferredReturnType occurrences="2">
+    <MixedInferredReturnType occurrences="1">
       <code>Extension\AbstractRenderer</code>
-      <code>bool</code>
     </MixedInferredReturnType>
-    <MixedMethodCall occurrences="2">
-      <code>get</code>
-      <code>has</code>
-    </MixedMethodCall>
-    <MixedReturnStatement occurrences="2">
-      <code>$this-&gt;pluginManager-&gt;get($name)</code>
-      <code>$this-&gt;pluginManager-&gt;has($name)</code>
+    <MixedReturnStatement occurrences="1">
+      <code>$this-&gt;pluginManager-&gt;get($extension)</code>
     </MixedReturnStatement>
   </file>
   <file src="src/Writer/ExtensionPluginManager.php">
-    <MixedArgument occurrences="2">
-      <code>$plugin</code>
+    <DocblockTypeContradiction occurrences="1">
+      <code>gettype($instance)</code>
+    </DocblockTypeContradiction>
+    <MixedArgument occurrences="1">
       <code>$plugin</code>
     </MixedArgument>
+    <RedundantConditionGivenDocblockType occurrences="1">
+      <code>is_object($instance)</code>
+    </RedundantConditionGivenDocblockType>
   </file>
   <file src="src/Writer/Feed.php">
     <InvalidStringClass occurrences="1">
@@ -3088,9 +2854,10 @@
       <code>$value['link']</code>
       <code>$value['type']</code>
     </MixedArgument>
-    <MixedAssignment occurrences="3">
+    <MixedAssignment occurrences="4">
       <code>$key</code>
       <code>$key</code>
+      <code>$value</code>
       <code>$value</code>
     </MixedAssignment>
   </file>
@@ -3713,22 +3480,6 @@
     </PropertyNotSetInConstructor>
   </file>
   <file src="src/Writer/StandaloneExtensionManager.php">
-    <MissingPropertyType occurrences="1">
-      <code>$extensions</code>
-    </MissingPropertyType>
-    <MixedArgument occurrences="1">
-      <code>$this-&gt;extensions</code>
-    </MixedArgument>
-    <MixedArrayAccess occurrences="2">
-      <code>$this-&gt;extensions[$extension]</code>
-      <code>$this-&gt;extensions[$name]</code>
-    </MixedArrayAccess>
-    <MixedArrayAssignment occurrences="1">
-      <code>$this-&gt;extensions[$name]</code>
-    </MixedArrayAssignment>
-    <MixedAssignment occurrences="1">
-      <code>$class</code>
-    </MixedAssignment>
     <MixedMethodCall occurrences="1">
       <code>new $class()</code>
     </MixedMethodCall>
@@ -3737,12 +3488,6 @@
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="src/Writer/Writer.php">
-    <InvalidDocblock occurrences="1">
-      <code>public static function setExtensionManager(ExtensionManagerInterface $extensionManager)</code>
-    </InvalidDocblock>
-    <MissingReturnType occurrences="1">
-      <code>setExtensionManager</code>
-    </MissingReturnType>
     <MixedArgument occurrences="4">
       <code>static::$extensions['entry']</code>
       <code>static::$extensions['entryRenderer']</code>
@@ -3760,12 +3505,6 @@
     </RedundantPropertyInitializationCheck>
   </file>
   <file src="test/PubSubHubbub/ClientNotReset.php">
-    <InvalidReturnType occurrences="1">
-      <code>resetParameters</code>
-    </InvalidReturnType>
-    <MissingParamType occurrences="1">
-      <code>$clearAuth</code>
-    </MissingParamType>
     <PropertyNotSetInConstructor occurrences="6">
       <code>ClientNotReset</code>
       <code>ClientNotReset</code>
@@ -3776,17 +3515,9 @@
     </PropertyNotSetInConstructor>
   </file>
   <file src="test/PubSubHubbub/Model/SubscriptionTest.php">
-    <MissingReturnType occurrences="2">
+    <MissingReturnType occurrences="1">
       <code>createTable</code>
-      <code>initDb</code>
     </MissingReturnType>
-    <MixedArgument occurrences="2">
-      <code>$adapter</code>
-      <code>$this-&gt;initDb()</code>
-    </MixedArgument>
-    <MixedAssignment occurrences="1">
-      <code>$adapter</code>
-    </MixedAssignment>
     <PossiblyUndefinedMethod occurrences="1">
       <code>execute</code>
     </PossiblyUndefinedMethod>
@@ -3800,7 +3531,7 @@
     </ArgumentTypeCoercion>
   </file>
   <file src="test/PubSubHubbub/PublisherTest.php">
-    <InvalidArgument occurrences="7">
+    <InvalidArgument occurrences="6">
       <code>ExceptionInterface::class</code>
       <code>ExceptionInterface::class</code>
       <code>ExceptionInterface::class</code>
@@ -3826,7 +3557,7 @@
       <code>setMethods</code>
     </DeprecatedMethod>
     <InvalidArgument occurrences="8">
-      <code>$this-&gt;_tableGateway</code>
+      <code>$this-&gt;tableGateway</code>
       <code>''</code>
       <code>ExceptionInterface::class</code>
       <code>ExceptionInterface::class</code>
@@ -3839,116 +3570,13 @@
     <MissingReturnType occurrences="1">
       <code>mockInputStream</code>
     </MissingReturnType>
-    <MixedMethodCall occurrences="54">
-      <code>method</code>
-      <code>method</code>
-      <code>method</code>
-      <code>method</code>
-      <code>method</code>
-      <code>method</code>
-      <code>method</code>
-      <code>method</code>
-      <code>method</code>
-      <code>method</code>
-      <code>method</code>
-      <code>method</code>
-      <code>method</code>
-      <code>method</code>
-      <code>method</code>
-      <code>method</code>
-      <code>method</code>
-      <code>method</code>
-      <code>method</code>
-      <code>method</code>
-      <code>method</code>
-      <code>method</code>
-      <code>method</code>
-      <code>will</code>
-      <code>will</code>
-      <code>will</code>
-      <code>will</code>
-      <code>will</code>
-      <code>will</code>
-      <code>will</code>
-      <code>will</code>
-      <code>will</code>
-      <code>will</code>
-      <code>will</code>
-      <code>will</code>
-      <code>will</code>
-      <code>will</code>
-      <code>will</code>
-      <code>will</code>
-      <code>will</code>
-      <code>will</code>
-      <code>will</code>
-      <code>will</code>
-      <code>will</code>
-      <code>will</code>
-      <code>with</code>
-      <code>with</code>
-      <code>with</code>
-      <code>with</code>
-      <code>with</code>
-      <code>with</code>
-      <code>with</code>
-      <code>with</code>
-      <code>with</code>
-    </MixedMethodCall>
-    <PossiblyInvalidArgument occurrences="1">
-      <code>$this-&gt;_tableGateway</code>
-    </PossiblyInvalidArgument>
     <PossiblyUndefinedMethod occurrences="1">
       <code>getHeader</code>
     </PossiblyUndefinedMethod>
-    <UndefinedClass occurrences="4">
-      <code>$this-&gt;_tableGateway</code>
-      <code>$this-&gt;_tableGateway</code>
+    <UndefinedClass occurrences="2">
       <code>'Result'</code>
       <code>'Result'</code>
     </UndefinedClass>
-    <UndefinedDocblockClass occurrences="24">
-      <code>$this-&gt;_rowset</code>
-      <code>$this-&gt;_rowset</code>
-      <code>$this-&gt;_rowset</code>
-      <code>$this-&gt;_rowset</code>
-      <code>$this-&gt;_rowset</code>
-      <code>$this-&gt;_rowset</code>
-      <code>$this-&gt;_rowset</code>
-      <code>$this-&gt;_rowset</code>
-      <code>$this-&gt;_rowset</code>
-      <code>$this-&gt;_rowset</code>
-      <code>$this-&gt;_rowset</code>
-      <code>$this-&gt;_rowset</code>
-      <code>$this-&gt;_rowset</code>
-      <code>$this-&gt;_rowset</code>
-      <code>$this-&gt;_tableGateway</code>
-      <code>$this-&gt;_tableGateway</code>
-      <code>$this-&gt;_tableGateway</code>
-      <code>$this-&gt;_tableGateway</code>
-      <code>$this-&gt;_tableGateway</code>
-      <code>$this-&gt;_tableGateway</code>
-      <code>$this-&gt;_tableGateway</code>
-      <code>\Laminas\Db\Adapter\Adapter|\PHPUnit_Framework_MockObject_MockObject</code>
-      <code>\Laminas\Db\ResultSet\ResultSet|\PHPUnit_Framework_MockObject_MockObject</code>
-      <code>\Laminas\Db\TableGateway\TableGateway|\PHPUnit_Framework_MockObject_MockObject</code>
-    </UndefinedDocblockClass>
-    <UndefinedMethod occurrences="14">
-      <code>expects</code>
-      <code>expects</code>
-      <code>expects</code>
-      <code>expects</code>
-      <code>expects</code>
-      <code>expects</code>
-      <code>expects</code>
-      <code>expects</code>
-      <code>expects</code>
-      <code>expects</code>
-      <code>expects</code>
-      <code>expects</code>
-      <code>expects</code>
-      <code>expects</code>
-    </UndefinedMethod>
   </file>
   <file src="test/PubSubHubbub/SubscriberHttpTest.php">
     <ArgumentTypeCoercion occurrences="2">
@@ -3964,9 +3592,6 @@
     <InvalidArgument occurrences="1">
       <code>$this-&gt;storage</code>
     </InvalidArgument>
-    <MissingPropertyType occurrences="1">
-      <code>$storage</code>
-    </MissingPropertyType>
     <PossiblyFalsePropertyAssignmentValue occurrences="1">
       <code>getenv('TESTS_LAMINAS_FEED_PUBSUBHUBBUB_BASEURI')</code>
     </PossiblyFalsePropertyAssignmentValue>
@@ -3982,7 +3607,7 @@
     <DeprecatedMethod occurrences="1">
       <code>setMethods</code>
     </DeprecatedMethod>
-    <InvalidArgument occurrences="17">
+    <InvalidArgument occurrences="16">
       <code>ExceptionInterface::class</code>
       <code>ExceptionInterface::class</code>
       <code>ExceptionInterface::class</code>
@@ -4007,13 +3632,6 @@
       <code>123</code>
       <code>123</code>
     </InvalidScalarArgument>
-    <MissingPropertyType occurrences="2">
-      <code>$adapter</code>
-      <code>$tableGateway</code>
-    </MissingPropertyType>
-    <MixedArgument occurrences="1">
-      <code>$this-&gt;tableGateway</code>
-    </MixedArgument>
   </file>
   <file src="test/PubSubHubbub/TestAsset/Callback.php">
     <MissingParamType occurrences="1">
@@ -4025,29 +3643,6 @@
     </PropertyNotSetInConstructor>
   </file>
   <file src="test/Reader/Entry/AtomStandaloneEntryTest.php">
-    <MissingPropertyType occurrences="3">
-      <code>$expectedCats</code>
-      <code>$expectedCatsDc</code>
-      <code>$feedSamplePath</code>
-    </MissingPropertyType>
-    <MixedOperand occurrences="16">
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-    </MixedOperand>
     <RedundantCastGivenDocblockType occurrences="1">
       <code>(array) $entry-&gt;getAuthors()</code>
     </RedundantCastGivenDocblockType>
@@ -4061,11 +3656,6 @@
     </UndefinedInterfaceMethod>
   </file>
   <file src="test/Reader/Entry/AtomTest.php">
-    <MissingPropertyType occurrences="3">
-      <code>$expectedCats</code>
-      <code>$expectedCatsDc</code>
-      <code>$feedSamplePath</code>
-    </MissingPropertyType>
     <MixedArgument occurrences="6">
       <code>$entry-&gt;getCategories()-&gt;getValues()</code>
       <code>$entry-&gt;getCategories()-&gt;getValues()</code>
@@ -4168,52 +3758,8 @@
       <code>getValues</code>
       <code>getValues</code>
     </MixedMethodCall>
-    <MixedOperand occurrences="39">
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-    </MixedOperand>
   </file>
   <file src="test/Reader/Entry/CommonTest.php">
-    <MissingPropertyType occurrences="1">
-      <code>$feedSamplePath</code>
-    </MissingPropertyType>
     <MixedArgument occurrences="1">
       <code>$entry-&gt;getElement()-&gt;tagName</code>
     </MixedArgument>
@@ -4246,20 +3792,6 @@
       <code>getXpathPrefix</code>
       <code>saveXml</code>
     </MixedMethodCall>
-    <MixedOperand occurrences="12">
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-    </MixedOperand>
     <MixedPropertyFetch occurrences="1">
       <code>$entry-&gt;getElement()-&gt;tagName</code>
     </MixedPropertyFetch>
@@ -4268,16 +3800,6 @@
     <InvalidDocblock occurrences="1">
       <code>public function dateModifiedProvider(): array</code>
     </InvalidDocblock>
-    <MissingParamType occurrences="2">
-      <code>$edate</code>
-      <code>$path</code>
-    </MissingParamType>
-    <MissingPropertyType occurrences="4">
-      <code>$expectedCats</code>
-      <code>$expectedCatsAtom</code>
-      <code>$expectedCatsRdf</code>
-      <code>$feedSamplePath</code>
-    </MissingPropertyType>
     <MixedArgument occurrences="26">
       <code>$entry-&gt;getCategories()-&gt;getValues()</code>
       <code>$entry-&gt;getCategories()-&gt;getValues()</code>
@@ -4953,287 +4475,6 @@
       <code>getValues</code>
       <code>getValues</code>
     </MixedMethodCall>
-    <MixedOperand occurrences="279">
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-    </MixedOperand>
   </file>
   <file src="test/Reader/ExtensionPluginManagerCompatibilityTest.php">
     <InvalidReturnType occurrences="1">
@@ -5241,17 +4482,10 @@
     </InvalidReturnType>
   </file>
   <file src="test/Reader/Feed/AtomSourceTest.php">
-    <MissingPropertyType occurrences="4">
-      <code>$expectedCats</code>
-      <code>$expectedCatsDc</code>
-      <code>$feedSamplePath</code>
-      <code>$options</code>
-    </MissingPropertyType>
     <MixedArgument occurrences="1">
       <code>$source-&gt;getCategories()-&gt;getValues()</code>
     </MixedArgument>
-    <MixedAssignment occurrences="14">
-      <code>$source</code>
+    <MixedAssignment occurrences="13">
       <code>$source</code>
       <code>$source</code>
       <code>$source</code>
@@ -5298,87 +4532,8 @@
       <code>getTitle</code>
       <code>getValues</code>
     </MixedMethodCall>
-    <MixedOperand occurrences="15">
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-    </MixedOperand>
   </file>
   <file src="test/Reader/Feed/AtomTest.php">
-    <MissingPropertyType occurrences="4">
-      <code>$expectedCats</code>
-      <code>$expectedCatsDc</code>
-      <code>$feedSamplePath</code>
-      <code>$options</code>
-    </MissingPropertyType>
-    <MixedOperand occurrences="54">
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-    </MixedOperand>
     <RedundantCastGivenDocblockType occurrences="2">
       <code>(array) $feed-&gt;getAuthors()</code>
       <code>(array) $feed-&gt;getAuthors()</code>
@@ -5396,21 +4551,6 @@
     </UndefinedInterfaceMethod>
   </file>
   <file src="test/Reader/Feed/CommonTest.php">
-    <MissingPropertyType occurrences="1">
-      <code>$feedSamplePath</code>
-    </MissingPropertyType>
-    <MixedOperand occurrences="10">
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-    </MixedOperand>
     <UndefinedInterfaceMethod occurrences="9">
       <code>getDomDocument</code>
       <code>getElement</code>
@@ -5454,11 +4594,6 @@
       <code>getValues</code>
       <code>getValues</code>
     </InvalidMethodCall>
-    <MissingPropertyType occurrences="3">
-      <code>$expectedCats</code>
-      <code>$expectedCatsAtom</code>
-      <code>$expectedCatsRdf</code>
-    </MissingPropertyType>
     <RedundantCastGivenDocblockType occurrences="28">
       <code>(array) $feed-&gt;getAuthors()</code>
       <code>(array) $feed-&gt;getAuthors()</code>
@@ -5533,17 +4668,13 @@
       <code>$argument</code>
       <code>$parameter</code>
     </MissingClosureParamType>
-    <MissingParamType occurrences="1">
-      <code>$uri</code>
-    </MissingParamType>
     <MixedArgument occurrences="3">
       <code>$this-&gt;client</code>
       <code>$this-&gt;client</code>
       <code>$this-&gt;client</code>
     </MixedArgument>
-    <MixedInferredReturnType occurrences="2">
+    <MixedInferredReturnType occurrences="1">
       <code>MockObject&lt;Headers&gt;</code>
-      <code>\Generator</code>
     </MixedInferredReturnType>
     <MixedMethodCall occurrences="31">
       <code>expects</code>
@@ -5601,70 +4732,17 @@
     </TooManyTemplateParams>
   </file>
   <file src="test/Reader/Http/ResponseTest.php">
-    <MissingParamType occurrences="5">
-      <code>$body</code>
-      <code>$contains</code>
-      <code>$contains</code>
-      <code>$headers</code>
-      <code>$statusCode</code>
-    </MissingParamType>
-    <MissingReturnType occurrences="6">
-      <code>invalidBodies</code>
-      <code>invalidHeaders</code>
-      <code>invalidStatusCodes</code>
+    <MissingReturnType occurrences="3">
       <code>testConstructorRaisesExceptionForInvalidBody</code>
       <code>testConstructorRaisesExceptionForInvalidHeaderStructures</code>
       <code>testConstructorRaisesExceptionForInvalidStatusCode</code>
     </MissingReturnType>
-    <MixedArgument occurrences="5">
+    <MixedArgument occurrences="2">
       <code>$body</code>
-      <code>$contains</code>
-      <code>$contains</code>
-      <code>$headers</code>
       <code>$statusCode</code>
     </MixedArgument>
   </file>
   <file src="test/Reader/Integration/GooglePlayPodcastRss2Test.php">
-    <MissingPropertyType occurrences="1">
-      <code>$feedSamplePath</code>
-    </MissingPropertyType>
-    <MixedArgument occurrences="35">
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-    </MixedArgument>
     <MixedAssignment occurrences="20">
       <code>$entry</code>
       <code>$entry</code>
@@ -5727,30 +4805,6 @@
     </UndefinedInterfaceMethod>
   </file>
   <file src="test/Reader/Integration/HOnlineComAtom10Test.php">
-    <MissingPropertyType occurrences="1">
-      <code>$feedSamplePath</code>
-    </MissingPropertyType>
-    <MixedArgument occurrences="19">
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-    </MixedArgument>
     <MixedAssignment occurrences="10">
       <code>$entry</code>
       <code>$entry</code>
@@ -5783,29 +4837,6 @@
     </UndefinedInterfaceMethod>
   </file>
   <file src="test/Reader/Integration/LautDeRdfTest.php">
-    <MissingPropertyType occurrences="1">
-      <code>$feedSamplePath</code>
-    </MissingPropertyType>
-    <MixedArgument occurrences="18">
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-    </MixedArgument>
     <MixedAssignment occurrences="10">
       <code>$entry</code>
       <code>$entry</code>
@@ -5837,80 +4868,7 @@
       <code>getEncoding</code>
     </UndefinedInterfaceMethod>
   </file>
-  <file src="test/Reader/Integration/PodcastIndexRss2Test.php">
-    <MissingPropertyType occurrences="1">
-      <code>$feedSamplePath</code>
-    </MissingPropertyType>
-    <MixedArgument occurrences="6">
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-    </MixedArgument>
-    <MixedAssignment occurrences="3">
-      <code>$entry</code>
-      <code>$entry</code>
-      <code>$entry</code>
-    </MixedAssignment>
-    <MixedMethodCall occurrences="3">
-      <code>getChapters</code>
-      <code>getSoundbites</code>
-      <code>getTranscript</code>
-    </MixedMethodCall>
-    <UndefinedInterfaceMethod occurrences="3">
-      <code>getFunding</code>
-      <code>getLockOwner</code>
-      <code>isLocked</code>
-    </UndefinedInterfaceMethod>
-  </file>
   <file src="test/Reader/Integration/PodcastRss2Test.php">
-    <MissingClosureParamType occurrences="2">
-      <code>$errno</code>
-      <code>$errstr</code>
-    </MissingClosureParamType>
-    <MissingPropertyType occurrences="1">
-      <code>$feedSamplePath</code>
-    </MissingPropertyType>
-    <MixedArgument occurrences="36">
-      <code>$errstr</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-    </MixedArgument>
     <MixedAssignment occurrences="22">
       <code>$entry</code>
       <code>$entry</code>
@@ -5975,30 +4933,8 @@
     </UndefinedInterfaceMethod>
   </file>
   <file src="test/Reader/Integration/WordpressAtom10Test.php">
-    <MissingPropertyType occurrences="1">
-      <code>$feedSamplePath</code>
-    </MissingPropertyType>
-    <MixedArgument occurrences="20">
+    <MixedArgument occurrences="1">
       <code>$entry-&gt;getContent()</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
     </MixedArgument>
     <MixedAssignment occurrences="10">
       <code>$entry</code>
@@ -6032,30 +4968,6 @@
     </UndefinedInterfaceMethod>
   </file>
   <file src="test/Reader/Integration/WordpressRss2DcAtomTest.php">
-    <MissingPropertyType occurrences="1">
-      <code>$feedSamplePath</code>
-    </MissingPropertyType>
-    <MixedArgument occurrences="19">
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-    </MixedArgument>
     <MixedAssignment occurrences="10">
       <code>$entry</code>
       <code>$entry</code>
@@ -6107,19 +5019,10 @@
     <InvalidArgument occurrences="2">
       <code>new stdClass()</code>
     </InvalidArgument>
-    <MissingClosureParamType occurrences="4">
-      <code>$errno</code>
-      <code>$errstr</code>
+    <MissingClosureParamType occurrences="2">
       <code>$message</code>
       <code>$toReturn</code>
     </MissingClosureParamType>
-    <MissingPropertyType occurrences="5">
-      <code>$feedSamplePath</code>
-      <code>$links-&gt;atom</code>
-      <code>$links-&gt;atom</code>
-      <code>$links-&gt;atom</code>
-      <code>$links-&gt;rss</code>
-    </MissingPropertyType>
     <MixedArgument occurrences="2">
       <code>$message</code>
       <code>$notices-&gt;messages</code>
@@ -6136,65 +5039,14 @@
     <MixedMethodCall occurrences="1">
       <code>getEncoding</code>
     </MixedMethodCall>
-    <MixedOperand occurrences="13">
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-      <code>$this-&gt;feedSamplePath</code>
-    </MixedOperand>
     <UndefinedInterfaceMethod occurrences="1">
       <code>getEncoding</code>
     </UndefinedInterfaceMethod>
-  </file>
-  <file src="test/Reader/StandaloneExtensionManagerTest.php">
-    <ArgumentTypeCoercion occurrences="1">
-      <code>$pluginClass</code>
-    </ArgumentTypeCoercion>
-    <MissingParamType occurrences="6">
-      <code>$pluginClass</code>
-      <code>$pluginClass</code>
-      <code>$pluginClass</code>
-      <code>$pluginName</code>
-      <code>$pluginName</code>
-      <code>$pluginName</code>
-    </MissingParamType>
-    <MixedArgument occurrences="6">
-      <code>$pluginClass</code>
-      <code>$pluginClass</code>
-      <code>$pluginName</code>
-      <code>$pluginName</code>
-      <code>$pluginName</code>
-      <code>$pluginName</code>
-    </MixedArgument>
-    <MixedInferredReturnType occurrences="1">
-      <code>array</code>
-    </MixedInferredReturnType>
   </file>
   <file src="test/Reader/TestAsset/CustomExtensionManager.php">
     <LessSpecificReturnStatement occurrences="1">
       <code>new $class()</code>
     </LessSpecificReturnStatement>
-    <MissingPropertyType occurrences="1">
-      <code>$extensions</code>
-    </MissingPropertyType>
-    <MixedArgument occurrences="1">
-      <code>$this-&gt;extensions</code>
-    </MixedArgument>
-    <MixedArrayAccess occurrences="1">
-      <code>$this-&gt;extensions[$extension]</code>
-    </MixedArrayAccess>
-    <MixedAssignment occurrences="1">
-      <code>$class</code>
-    </MixedAssignment>
     <MixedMethodCall occurrences="1">
       <code>new $class()</code>
     </MixedMethodCall>
@@ -6202,32 +5054,21 @@
       <code>Extension\AbstractEntry|Extension\AbstractFeed</code>
     </MoreSpecificReturnType>
   </file>
-  <file src="test/Reader/TestAsset/Psr7Stream.php">
-    <MissingParamType occurrences="1">
-      <code>$streamValue</code>
-    </MissingParamType>
-    <MissingPropertyType occurrences="1">
-      <code>$streamValue</code>
-    </MissingPropertyType>
-  </file>
   <file src="test/Reader/_files/My/Extension/JungleBooks/Entry.php">
-    <MissingReturnType occurrences="1">
-      <code>getIsbn</code>
-    </MissingReturnType>
     <MixedAssignment occurrences="1">
       <code>$isbn</code>
     </MixedAssignment>
-    <UndefinedVariable occurrences="1">
-      <code>$title</code>
-    </UndefinedVariable>
   </file>
   <file src="test/Reader/_files/My/Extension/JungleBooks/Feed.php">
-    <MissingReturnType occurrences="1">
-      <code>getDaysPopularBookLink</code>
-    </MissingReturnType>
     <MixedAssignment occurrences="1">
       <code>$dayPopular</code>
     </MixedAssignment>
+    <MixedInferredReturnType occurrences="1">
+      <code>null|string</code>
+    </MixedInferredReturnType>
+    <MixedReturnStatement occurrences="1">
+      <code>$this-&gt;data['dayPopular']</code>
+    </MixedReturnStatement>
   </file>
   <file src="test/Writer/DeletedTest.php">
     <DocblockTypeContradiction occurrences="1">
@@ -6244,19 +5085,8 @@
     <InvalidScalarArgument occurrences="1">
       <code>'abc'</code>
     </InvalidScalarArgument>
-    <MixedAssignment occurrences="1">
-      <code>$result</code>
-    </MixedAssignment>
-    <MixedMethodCall occurrences="2">
-      <code>setReference</code>
-      <code>setWhen</code>
-    </MixedMethodCall>
   </file>
   <file src="test/Writer/EntryTest.php">
-    <DocblockTypeContradiction occurrences="2">
-      <code>assertNull</code>
-      <code>assertNull</code>
-    </DocblockTypeContradiction>
     <InvalidArgument occurrences="20">
       <code>ExceptionInterface::class</code>
       <code>ExceptionInterface::class</code>
@@ -6278,29 +5108,15 @@
       <code>Writer\Exception\ExceptionInterface::class</code>
       <code>Writer\Exception\ExceptionInterface::class</code>
     </InvalidArgument>
-    <InvalidScalarArgument occurrences="5">
-      <code>''</code>
-      <code>'10'</code>
-      <code>'a'</code>
+    <InvalidScalarArgument occurrences="2">
       <code>'abc'</code>
       <code>'abc'</code>
     </InvalidScalarArgument>
-    <MissingClosureParamType occurrences="4">
-      <code>$errno</code>
-      <code>$errstr</code>
+    <MissingClosureParamType occurrences="2">
       <code>$message</code>
       <code>$toReturn</code>
     </MissingClosureParamType>
-    <MissingParamType occurrences="3">
-      <code>$count</code>
-      <code>$count</code>
-      <code>$expected</code>
-    </MissingParamType>
-    <MissingPropertyType occurrences="1">
-      <code>$feedSamplePath</code>
-    </MissingPropertyType>
-    <MixedArgument occurrences="4">
-      <code>$count</code>
+    <MixedArgument occurrences="3">
       <code>$count</code>
       <code>$message</code>
       <code>$notices-&gt;messages</code>
@@ -6308,10 +5124,6 @@
     <MixedArrayAssignment occurrences="1">
       <code>$notices-&gt;messages[]</code>
     </MixedArrayAssignment>
-    <MixedInferredReturnType occurrences="2">
-      <code>array</code>
-      <code>array</code>
-    </MixedInferredReturnType>
     <NullArgument occurrences="1">
       <code>null</code>
     </NullArgument>
@@ -6335,11 +5147,9 @@
       <code>ExceptionInterface::class</code>
       <code>ExceptionInterface::class</code>
     </InvalidArgument>
-    <MissingReturnType occurrences="4">
-      <code>invalidImageUrls</code>
+    <MissingReturnType occurrences="2">
       <code>testSetPlayPodcastImageRaisesExceptionForInvalidUrl</code>
       <code>testSetPlayPodcastImageSetsInternalDataWithValidUrl</code>
-      <code>validImageUrls</code>
     </MissingReturnType>
   </file>
   <file src="test/Writer/Extension/ITunes/EntryTest.php">
@@ -6362,20 +5172,7 @@
       <code>ExceptionInterface::class</code>
       <code>ExceptionInterface::class</code>
     </InvalidArgument>
-    <MissingClosureParamType occurrences="6">
-      <code>$errno</code>
-      <code>$errno</code>
-      <code>$errno</code>
-      <code>$errstr</code>
-      <code>$errstr</code>
-      <code>$errstr</code>
-    </MissingClosureParamType>
-    <MissingReturnType occurrences="15">
-      <code>dataProviderForSetExplicit</code>
-      <code>invalidClosedCaptioningFlags</code>
-      <code>invalidEpisodeTypes</code>
-      <code>invalidImageUrls</code>
-      <code>nonNumericEpisodeNumbers</code>
+    <MissingReturnType occurrences="8">
       <code>testEpisodeTypeMaybeMutatedWithAcceptedValues</code>
       <code>testSetEpisodeRaisesExceptionForNonNumericEpisodeNumbers</code>
       <code>testSetEpisodeTypeRaisesExceptionForInvalidTypes</code>
@@ -6384,14 +5181,7 @@
       <code>testSetItunesImageSetsInternalDataWithValidUrl</code>
       <code>testSetSeasonRaisesExceptionForNonNumericSeasonNumbers</code>
       <code>testSettingClosedCaptioningToNonBooleanRaisesException</code>
-      <code>validEpisodeTypes</code>
-      <code>validImageUrls</code>
     </MissingReturnType>
-    <MixedArgument occurrences="3">
-      <code>$errstr</code>
-      <code>$errstr</code>
-      <code>$errstr</code>
-    </MixedArgument>
   </file>
   <file src="test/Writer/Extension/ITunes/FeedTest.php">
     <InvalidArgument occurrences="18">
@@ -6414,58 +5204,14 @@
       <code>ExceptionInterface::class</code>
       <code>ExceptionInterface::class</code>
     </InvalidArgument>
-    <MissingClosureParamType occurrences="6">
-      <code>$errno</code>
-      <code>$errno</code>
-      <code>$errno</code>
-      <code>$errstr</code>
-      <code>$errstr</code>
-      <code>$errstr</code>
-    </MissingClosureParamType>
-    <MissingReturnType occurrences="12">
-      <code>dataProviderForSetExplicit</code>
-      <code>invalidCompleteStatuses</code>
-      <code>invalidImageUrls</code>
-      <code>invalidPodcastTypes</code>
+    <MissingReturnType occurrences="6">
       <code>testSetExplicit</code>
       <code>testSetItunesCompleteRaisesExceptionForInvalidStatus</code>
       <code>testSetItunesImageRaisesExceptionForInvalidUrl</code>
       <code>testSetItunesImageSetsInternalDataWithValidUrl</code>
       <code>testSetItunesTypeMutatesTypeWithValidData</code>
       <code>testSetItunesTypeWithInvalidTypeRaisesException</code>
-      <code>validImageUrls</code>
-      <code>validPodcastTypes</code>
     </MissingReturnType>
-    <MixedArgument occurrences="3">
-      <code>$errstr</code>
-      <code>$errstr</code>
-      <code>$errstr</code>
-    </MixedArgument>
-  </file>
-  <file src="test/Writer/Extension/PodcastIndex/EntryTest.php">
-    <InvalidArgument occurrences="8">
-      <code>ExceptionInterface::class</code>
-      <code>ExceptionInterface::class</code>
-      <code>ExceptionInterface::class</code>
-      <code>ExceptionInterface::class</code>
-      <code>ExceptionInterface::class</code>
-      <code>ExceptionInterface::class</code>
-      <code>ExceptionInterface::class</code>
-      <code>ExceptionInterface::class</code>
-    </InvalidArgument>
-    <MixedInferredReturnType occurrences="1">
-      <code>array</code>
-    </MixedInferredReturnType>
-  </file>
-  <file src="test/Writer/Extension/PodcastIndex/FeedTest.php">
-    <InvalidArgument occurrences="3">
-      <code>ExceptionInterface::class</code>
-      <code>ExceptionInterface::class</code>
-      <code>ExceptionInterface::class</code>
-    </InvalidArgument>
-    <MixedInferredReturnType occurrences="1">
-      <code>array</code>
-    </MixedInferredReturnType>
   </file>
   <file src="test/Writer/FeedFactoryTest.php">
     <InvalidArgument occurrences="1">
@@ -6514,15 +5260,10 @@
       <code>getTimestamp</code>
       <code>getTimestamp</code>
     </InvalidMethodCall>
-    <MissingClosureParamType occurrences="4">
-      <code>$errno</code>
-      <code>$errstr</code>
+    <MissingClosureParamType occurrences="2">
       <code>$message</code>
       <code>$toReturn</code>
     </MissingClosureParamType>
-    <MissingPropertyType occurrences="1">
-      <code>$feedSamplePath</code>
-    </MissingPropertyType>
     <MixedArgument occurrences="2">
       <code>$message</code>
       <code>$notices-&gt;messages</code>
@@ -6530,21 +5271,6 @@
     <MixedArrayAssignment occurrences="1">
       <code>$notices-&gt;messages[]</code>
     </MixedArrayAssignment>
-    <MixedAssignment occurrences="1">
-      <code>$return</code>
-    </MixedAssignment>
-    <MixedMethodCall occurrences="10">
-      <code>setDateModified</code>
-      <code>setDescription</code>
-      <code>setEncoding</code>
-      <code>setId</code>
-      <code>setImage</code>
-      <code>setLanguage</code>
-      <code>setLastBuildDate</code>
-      <code>setLink</code>
-      <code>setTitle</code>
-      <code>setType</code>
-    </MixedMethodCall>
   </file>
   <file src="test/Writer/Renderer/Entry/AtomTest.php">
     <InvalidArgument occurrences="6">
@@ -6554,50 +5280,18 @@
       <code>ExceptionInterface::class</code>
       <code>ExceptionInterface::class</code>
     </InvalidArgument>
-    <MissingClosureParamType occurrences="4">
-      <code>$errno</code>
-      <code>$errstr</code>
+    <MissingClosureParamType occurrences="2">
       <code>$message</code>
       <code>$toReturn</code>
     </MissingClosureParamType>
-    <MissingPropertyType occurrences="2">
-      <code>$validEntry</code>
-      <code>$validWriter</code>
-    </MissingPropertyType>
-    <MixedArgument occurrences="27">
+    <MixedArgument occurrences="2">
       <code>$message</code>
       <code>$notices-&gt;messages</code>
-      <code>$this-&gt;validEntry</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
     </MixedArgument>
     <MixedArrayAssignment occurrences="1">
       <code>$notices-&gt;messages[]</code>
     </MixedArrayAssignment>
-    <MixedAssignment occurrences="20">
-      <code>$author</code>
+    <MixedAssignment occurrences="19">
       <code>$enc</code>
       <code>$entry</code>
       <code>$entry</code>
@@ -6618,9 +5312,7 @@
       <code>$entry</code>
       <code>$entry</code>
     </MixedAssignment>
-    <MixedMethodCall occurrences="40">
-      <code>addCategories</code>
-      <code>getAuthor</code>
+    <MixedMethodCall occurrences="21">
       <code>getAuthor</code>
       <code>getCategories</code>
       <code>getCommentCount</code>
@@ -6642,23 +5334,6 @@
       <code>getTimestamp</code>
       <code>getTimestamp</code>
       <code>getTitle</code>
-      <code>remove</code>
-      <code>remove</code>
-      <code>remove</code>
-      <code>remove</code>
-      <code>remove</code>
-      <code>remove</code>
-      <code>remove</code>
-      <code>remove</code>
-      <code>setCommentCount</code>
-      <code>setCommentFeedLinks</code>
-      <code>setCommentLink</code>
-      <code>setEnclosure</code>
-      <code>setEncoding</code>
-      <code>setId</code>
-      <code>setId</code>
-      <code>setId</code>
-      <code>setId</code>
     </MixedMethodCall>
     <MixedPropertyFetch occurrences="3">
       <code>$enc-&gt;length</code>
@@ -6675,60 +5350,18 @@
       <code>ExceptionInterface::class</code>
       <code>ExceptionInterface::class</code>
     </InvalidArgument>
-    <MissingClosureParamType occurrences="4">
-      <code>$errno</code>
-      <code>$errstr</code>
+    <MissingClosureParamType occurrences="2">
       <code>$message</code>
       <code>$toReturn</code>
     </MissingClosureParamType>
-    <MissingPropertyType occurrences="2">
-      <code>$validEntry</code>
-      <code>$validWriter</code>
-    </MissingPropertyType>
-    <MixedArgument occurrences="36">
+    <MixedArgument occurrences="2">
       <code>$message</code>
       <code>$notices-&gt;messages</code>
-      <code>$this-&gt;validEntry</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
     </MixedArgument>
     <MixedArrayAssignment occurrences="1">
       <code>$notices-&gt;messages[]</code>
     </MixedArrayAssignment>
-    <MixedAssignment occurrences="24">
-      <code>$author</code>
-      <code>$author</code>
+    <MixedAssignment occurrences="22">
       <code>$enc</code>
       <code>$entry</code>
       <code>$entry</code>
@@ -6752,13 +5385,7 @@
       <code>$entry</code>
       <code>$entry</code>
     </MixedAssignment>
-    <MixedMethodCall occurrences="56">
-      <code>addAuthor</code>
-      <code>addAuthor</code>
-      <code>addCategories</code>
-      <code>addCategories</code>
-      <code>getAuthor</code>
-      <code>getAuthor</code>
+    <MixedMethodCall occurrences="24">
       <code>getAuthor</code>
       <code>getAuthor</code>
       <code>getCategories</code>
@@ -6779,36 +5406,10 @@
       <code>getId</code>
       <code>getLink</code>
       <code>getLink</code>
-      <code>getLink</code>
       <code>getTimestamp</code>
       <code>getTimestamp</code>
       <code>getTitle</code>
       <code>getTitle</code>
-      <code>remove</code>
-      <code>remove</code>
-      <code>remove</code>
-      <code>remove</code>
-      <code>remove</code>
-      <code>setCommentCount</code>
-      <code>setCommentFeedLinks</code>
-      <code>setCommentLink</code>
-      <code>setContent</code>
-      <code>setContent</code>
-      <code>setDateCreated</code>
-      <code>setDateModified</code>
-      <code>setDescription</code>
-      <code>setEnclosure</code>
-      <code>setEnclosure</code>
-      <code>setEnclosure</code>
-      <code>setEnclosure</code>
-      <code>setEnclosure</code>
-      <code>setEnclosure</code>
-      <code>setEnclosure</code>
-      <code>setEnclosure</code>
-      <code>setEncoding</code>
-      <code>setId</code>
-      <code>setId</code>
-      <code>setTitle</code>
     </MixedMethodCall>
     <MixedPropertyFetch occurrences="3">
       <code>$enc-&gt;length</code>
@@ -6823,73 +5424,17 @@
       <code>ExceptionInterface::class</code>
       <code>ExceptionInterface::class</code>
     </InvalidArgument>
-    <MissingClosureParamType occurrences="4">
-      <code>$errno</code>
-      <code>$errstr</code>
+    <MissingClosureParamType occurrences="2">
       <code>$message</code>
       <code>$toReturn</code>
     </MissingClosureParamType>
-    <MissingPropertyType occurrences="1">
-      <code>$validWriter</code>
-    </MissingPropertyType>
-    <MixedArgument occurrences="38">
+    <MixedArgument occurrences="2">
       <code>$message</code>
       <code>$notices-&gt;messages</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
     </MixedArgument>
     <MixedArrayAssignment occurrences="1">
       <code>$notices-&gt;messages[]</code>
     </MixedArrayAssignment>
-    <MixedMethodCall occurrences="13">
-      <code>addCategories</code>
-      <code>addCategories</code>
-      <code>addHubs</code>
-      <code>setBaseUrl</code>
-      <code>setCopyright</code>
-      <code>setCopyright</code>
-      <code>setDateModified</code>
-      <code>setEncoding</code>
-      <code>setGenerator</code>
-      <code>setGenerator</code>
-      <code>setId</code>
-      <code>setImage</code>
-      <code>setLanguage</code>
-    </MixedMethodCall>
     <PossiblyNullReference occurrences="1">
       <code>getTimestamp</code>
     </PossiblyNullReference>
@@ -6918,100 +5463,20 @@
       <code>ExceptionInterface::class</code>
       <code>ExceptionInterface::class</code>
     </InvalidArgument>
-    <MissingClosureParamType occurrences="4">
-      <code>$errno</code>
-      <code>$errstr</code>
+    <MissingClosureParamType occurrences="2">
       <code>$message</code>
       <code>$toReturn</code>
     </MissingClosureParamType>
-    <MissingPropertyType occurrences="1">
-      <code>$validWriter</code>
-    </MissingPropertyType>
-    <MixedArgument occurrences="48">
+    <MixedArgument occurrences="3">
       <code>$feed-&gt;getDomDocument()</code>
       <code>$message</code>
       <code>$notices-&gt;messages</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
-      <code>$this-&gt;validWriter</code>
     </MixedArgument>
     <MixedArrayAssignment occurrences="1">
       <code>$notices-&gt;messages[]</code>
     </MixedArrayAssignment>
-    <MixedMethodCall occurrences="31">
-      <code>addAuthor</code>
-      <code>addAuthor</code>
-      <code>addCategories</code>
-      <code>addCategories</code>
-      <code>addHubs</code>
+    <MixedMethodCall occurrences="1">
       <code>getTimestamp</code>
-      <code>setBaseUrl</code>
-      <code>setCopyright</code>
-      <code>setCopyright</code>
-      <code>setDateCreated</code>
-      <code>setDateModified</code>
-      <code>setEncoding</code>
-      <code>setFeedLink</code>
-      <code>setFeedLink</code>
-      <code>setFeedLink</code>
-      <code>setGenerator</code>
-      <code>setImage</code>
-      <code>setImage</code>
-      <code>setImage</code>
-      <code>setImage</code>
-      <code>setImage</code>
-      <code>setImage</code>
-      <code>setImage</code>
-      <code>setImage</code>
-      <code>setImage</code>
-      <code>setImage</code>
-      <code>setImage</code>
-      <code>setImage</code>
-      <code>setImage</code>
-      <code>setLanguage</code>
-      <code>setLastBuildDate</code>
     </MixedMethodCall>
     <MixedPropertyFetch occurrences="1">
       <code>$xpath-&gt;evaluate('/rss/channel/atom:link[@rel="self"]')-&gt;length</code>
@@ -7031,53 +5496,15 @@
     </UndefinedInterfaceMethod>
   </file>
   <file src="test/Writer/StandaloneExtensionManagerTest.php">
-    <ArgumentTypeCoercion occurrences="1">
-      <code>$pluginClass</code>
-    </ArgumentTypeCoercion>
-    <MissingParamType occurrences="6">
-      <code>$pluginClass</code>
-      <code>$pluginClass</code>
-      <code>$pluginClass</code>
-      <code>$pluginName</code>
-      <code>$pluginName</code>
-      <code>$pluginName</code>
-    </MissingParamType>
-    <MixedArgument occurrences="6">
-      <code>$pluginClass</code>
-      <code>$pluginClass</code>
-      <code>$pluginName</code>
-      <code>$pluginName</code>
-      <code>$pluginName</code>
-      <code>$pluginName</code>
-    </MixedArgument>
     <MixedAssignment occurrences="3">
       <code>$extension</code>
       <code>$extension</code>
       <code>$test</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="1">
-      <code>array</code>
-    </MixedInferredReturnType>
   </file>
   <file src="test/Writer/TestAsset/CustomExtensionManager.php">
-    <MissingPropertyType occurrences="1">
-      <code>$extensions</code>
-    </MissingPropertyType>
-    <MixedArgument occurrences="2">
-      <code>$class</code>
-      <code>$this-&gt;extensions</code>
-    </MixedArgument>
-    <MixedArrayAccess occurrences="1">
-      <code>$this-&gt;extensions[$extension]</code>
-    </MixedArrayAccess>
-    <MixedAssignment occurrences="1">
-      <code>$class</code>
-    </MixedAssignment>
     <MixedMethodCall occurrences="1">
       <code>new $class()</code>
     </MixedMethodCall>
-    <PossiblyFalseArgument occurrences="1">
-      <code>$class</code>
-    </PossiblyFalseArgument>
   </file>
 </files>

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <psalm
-    cacheDirectory="./psalm-cache"
+    cacheDirectory="./.psalm-cache"
     totallyTyped="true"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"

--- a/src/Exception/BadMethodCallException.php
+++ b/src/Exception/BadMethodCallException.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Exception;
 
 class BadMethodCallException extends \BadMethodCallException implements ExceptionInterface

--- a/src/Exception/ExceptionInterface.php
+++ b/src/Exception/ExceptionInterface.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Exception;
 
 interface ExceptionInterface

--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Exception;
 
 class InvalidArgumentException extends \InvalidArgumentException implements ExceptionInterface

--- a/src/Exception/RuntimeException.php
+++ b/src/Exception/RuntimeException.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Exception;
 
 class RuntimeException extends \RuntimeException implements ExceptionInterface

--- a/src/PubSubHubbub/AbstractCallback.php
+++ b/src/PubSubHubbub/AbstractCallback.php
@@ -1,16 +1,26 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\PubSubHubbub;
 
 use Laminas\Http\PhpEnvironment\Response as PhpResponse;
 use Laminas\Stdlib\ArrayUtils;
 use Traversable;
+
+use function array_key_exists;
+use function file_get_contents;
+use function function_exists;
+use function gettype;
+use function intval;
+use function is_array;
+use function is_resource;
+use function sprintf;
+use function str_replace;
+use function stream_get_contents;
+use function strlen;
+use function strpos;
+use function strtoupper;
+use function substr;
+use function trim;
 
 abstract class AbstractCallback implements CallbackInterface
 {
@@ -208,22 +218,22 @@ abstract class AbstractCallback implements CallbackInterface
         return $this->subscriberCount;
     }
 
+    // phpcs:disable PSR2.Methods.MethodDeclaration.Underscore
+
     /**
      * Attempt to detect the callback URL (specifically the path forward)
      *
      * @return string
      */
-    // @codingStandardsIgnoreStart
     protected function _detectCallbackUrl()
     {
-        // @codingStandardsIgnoreEnd
         $callbackUrl = null;
 
         // IIS7 with URL Rewrite: make sure we get the unencoded url
         // (double slash problem).
-        $iisUrlRewritten = isset($_SERVER['IIS_WasUrlRewritten']) ? $_SERVER['IIS_WasUrlRewritten'] : null;
-        $unencodedUrl    = isset($_SERVER['UNENCODED_URL']) ? $_SERVER['UNENCODED_URL'] : null;
-        if ('1' == $iisUrlRewritten && ! empty($unencodedUrl)) {
+        $iisUrlRewritten = $_SERVER['IIS_WasUrlRewritten'] ?? null;
+        $unencodedUrl    = $_SERVER['UNENCODED_URL'] ?? null;
+        if ('1' === $iisUrlRewritten && ! empty($unencodedUrl)) {
             return $unencodedUrl;
         }
 
@@ -249,20 +259,19 @@ abstract class AbstractCallback implements CallbackInterface
      *
      * @return string
      */
-    // @codingStandardsIgnoreStart
     protected function _getHttpHost()
     {
-        // @codingStandardsIgnoreEnd
         if (! empty($_SERVER['HTTP_HOST'])) {
             return $_SERVER['HTTP_HOST'];
         }
 
-        $https  = isset($_SERVER['HTTPS']) ? $_SERVER['HTTPS'] : null;
+        $https  = $_SERVER['HTTPS'] ?? null;
         $scheme = $https === 'on' ? 'https' : 'http';
-        $name   = isset($_SERVER['SERVER_NAME']) ? $_SERVER['SERVER_NAME'] : '';
+        $name   = $_SERVER['SERVER_NAME'] ?? '';
         $port   = isset($_SERVER['SERVER_PORT']) ? (int) $_SERVER['SERVER_PORT'] : 80;
 
-        if (($scheme === 'http' && $port === 80)
+        if (
+            ($scheme === 'http' && $port === 80)
             || ($scheme === 'https' && $port === 443)
         ) {
             return $name;
@@ -277,10 +286,8 @@ abstract class AbstractCallback implements CallbackInterface
      * @param  string $header
      * @return bool|string
      */
-    // @codingStandardsIgnoreStart
     protected function _getHeader($header)
     {
-        // @codingStandardsIgnoreEnd
         $temp = strtoupper(str_replace('-', '_', $header));
         if (! empty($_SERVER[$temp])) {
             return $_SERVER[$temp];
@@ -303,16 +310,16 @@ abstract class AbstractCallback implements CallbackInterface
      *
      * @return false|string Raw body, or false if not present
      */
-    // @codingStandardsIgnoreStart
     protected function _getRawBody()
     {
-        // @codingStandardsIgnoreEnd
         $body = is_resource($this->inputStream)
             ? stream_get_contents($this->inputStream)
             : file_get_contents($this->inputStream);
 
         return strlen(trim($body)) > 0 ? $body : false;
     }
+
+    // phpcs:enable PSR2.Methods.MethodDeclaration.Underscore
 
     /**
      * Build the callback URL from the REQUEST_URI server parameter.
@@ -322,7 +329,7 @@ abstract class AbstractCallback implements CallbackInterface
     private function buildCallbackUrlFromRequestUri()
     {
         $callbackUrl = $_SERVER['REQUEST_URI'];
-        $https       = isset($_SERVER['HTTPS']) ? $_SERVER['HTTPS'] : null;
+        $https       = $_SERVER['HTTPS'] ?? null;
         $scheme      = $https === 'on' ? 'https' : 'http';
         if ($https === 'on') {
             $scheme = 'https';

--- a/src/PubSubHubbub/CallbackInterface.php
+++ b/src/PubSubHubbub/CallbackInterface.php
@@ -1,12 +1,8 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\PubSubHubbub;
+
+use Laminas\Http\PhpEnvironment\Response;
 
 interface CallbackInterface
 {
@@ -18,7 +14,7 @@ interface CallbackInterface
      * @param null|array $httpData GET/POST data if available and not in $_GET/POST
      * @param bool $sendResponseNow Whether to send response now or when asked
      */
-    public function handle(array $httpData = null, $sendResponseNow = false);
+    public function handle(?array $httpData = null, $sendResponseNow = false);
 
     /**
      * Send the response, including all headers.
@@ -35,7 +31,7 @@ interface CallbackInterface
      * Laminas\Feed\Pubsubhubbub\HttpResponse which shares an unenforced interface with
      * (i.e. not inherited from) Laminas\Feed\Pubsubhubbub\AbstractCallback.
      *
-     * @param HttpResponse|\Laminas\Http\PhpEnvironment\Response $httpResponse
+     * @param HttpResponse|Response $httpResponse
      */
     public function setHttpResponse($httpResponse);
 
@@ -44,7 +40,7 @@ interface CallbackInterface
      * Laminas\Feed\Pubsubhubbub\HttpResponse which shares an unenforced interface with
      * (i.e. not inherited from) Laminas\Feed\Pubsubhubbub\AbstractCallback.
      *
-     * @return HttpResponse|\Laminas\Http\PhpEnvironment\Response
+     * @return HttpResponse|Response
      */
     public function getHttpResponse();
 }

--- a/src/PubSubHubbub/Exception/ExceptionInterface.php
+++ b/src/PubSubHubbub/Exception/ExceptionInterface.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\PubSubHubbub\Exception;
 
 use Laminas\Feed\Exception\ExceptionInterface as Exception;

--- a/src/PubSubHubbub/Exception/InvalidArgumentException.php
+++ b/src/PubSubHubbub/Exception/InvalidArgumentException.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\PubSubHubbub\Exception;
 
 use Laminas\Feed\Exception;

--- a/src/PubSubHubbub/Exception/RuntimeException.php
+++ b/src/PubSubHubbub/Exception/RuntimeException.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\PubSubHubbub\Exception;
 
 use Laminas\Feed\Exception;

--- a/src/PubSubHubbub/HttpResponse.php
+++ b/src/PubSubHubbub/HttpResponse.php
@@ -1,12 +1,14 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\PubSubHubbub;
+
+use function header;
+use function headers_sent;
+use function is_int;
+use function str_replace;
+use function strlen;
+use function strtolower;
+use function ucwords;
 
 class HttpResponse
 {
@@ -52,11 +54,14 @@ class HttpResponse
      */
     public function sendHeaders()
     {
-        if ($this->headers || (200 != $this->statusCode)) {
-            $this->canSendHeaders(true);
-        } elseif (200 == $this->statusCode) {
+        if (200 === $this->statusCode) {
             return;
         }
+
+        if ($this->headers || (200 !== $this->statusCode)) {
+            $this->canSendHeaders(true);
+        }
+
         $httpCodeSent = false;
         foreach ($this->headers as $header) {
             if (! $httpCodeSent && $this->statusCode) {
@@ -88,7 +93,7 @@ class HttpResponse
         $value = (string) $value;
         if ($replace) {
             foreach ($this->headers as $key => $header) {
-                if ($name == $header['name']) {
+                if ($name === $header['name']) {
                     unset($this->headers[$key]);
                 }
             }
@@ -112,7 +117,7 @@ class HttpResponse
     {
         $name = $this->_normalizeHeader($name);
         foreach ($this->headers as $header) {
-            if ($header['name'] == $name) {
+            if ($header['name'] === $name) {
                 return $header['value'];
             }
         }
@@ -201,10 +206,9 @@ class HttpResponse
      * @param  string $name
      * @return string
      */
-    // @codingStandardsIgnoreStart
+    // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     protected function _normalizeHeader($name)
     {
-        // @codingStandardsIgnoreEnd
         $filtered = str_replace(['-', '_'], ' ', (string) $name);
         $filtered = ucwords(strtolower($filtered));
         $filtered = str_replace(' ', '-', $filtered);

--- a/src/PubSubHubbub/Model/AbstractModel.php
+++ b/src/PubSubHubbub/Model/AbstractModel.php
@@ -1,15 +1,13 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\PubSubHubbub\Model;
 
 use Laminas\Db\TableGateway\TableGateway;
 use Laminas\Db\TableGateway\TableGatewayInterface;
+
+use function array_pop;
+use function explode;
+use function strtolower;
 
 class AbstractModel
 {
@@ -20,10 +18,10 @@ class AbstractModel
      */
     protected $db;
 
-    public function __construct(TableGatewayInterface $tableGateway = null)
+    public function __construct(?TableGatewayInterface $tableGateway = null)
     {
         if ($tableGateway === null) {
-            $parts    = explode('\\', get_class($this));
+            $parts    = explode('\\', static::class);
             $table    = strtolower(array_pop($parts));
             $this->db = new TableGateway($table, null);
         } else {

--- a/src/PubSubHubbub/Model/Subscription.php
+++ b/src/PubSubHubbub/Model/Subscription.php
@@ -33,7 +33,8 @@ class Subscription extends AbstractModel implements SubscriptionPersistenceInter
             );
         }
         $result = $this->db->select(['id' => $data['id']]);
-        if ($result && (0 < count($result))) {
+        if (0 < count($result)) {
+            /** @psalm-suppress UndefinedInterfaceMethod */
             $data['created_time'] = $result->current()->created_time;
             $now                  = $this->getNow();
             if (
@@ -69,7 +70,8 @@ class Subscription extends AbstractModel implements SubscriptionPersistenceInter
             );
         }
         $result = $this->db->select(['id' => $key]);
-        if ($result && count($result)) {
+        if (count($result)) {
+            /** @psalm-suppress UndefinedInterfaceMethod */
             return $result->current()->getArrayCopy();
         }
         return false;
@@ -90,7 +92,7 @@ class Subscription extends AbstractModel implements SubscriptionPersistenceInter
             );
         }
         $result = $this->db->select(['id' => $key]);
-        if ($result && count($result)) {
+        if (count($result)) {
             return true;
         }
         return false;
@@ -105,7 +107,7 @@ class Subscription extends AbstractModel implements SubscriptionPersistenceInter
     public function deleteSubscription($key)
     {
         $result = $this->db->select(['id' => $key]);
-        if ($result && count($result)) {
+        if (count($result)) {
             $this->db->delete(
                 ['id' => $key]
             );

--- a/src/PubSubHubbub/Model/Subscription.php
+++ b/src/PubSubHubbub/Model/Subscription.php
@@ -1,16 +1,14 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\PubSubHubbub\Model;
 
 use DateInterval;
 use DateTime;
 use Laminas\Feed\PubSubHubbub;
+
+use function array_key_exists;
+use function count;
+use function is_string;
 
 class Subscription extends AbstractModel implements SubscriptionPersistenceInterface
 {
@@ -38,7 +36,8 @@ class Subscription extends AbstractModel implements SubscriptionPersistenceInter
         if ($result && (0 < count($result))) {
             $data['created_time'] = $result->current()->created_time;
             $now                  = $this->getNow();
-            if (array_key_exists('lease_seconds', $data)
+            if (
+                array_key_exists('lease_seconds', $data)
                 && $data['lease_seconds']
             ) {
                 $data['expiration_time'] = $now->add(new DateInterval('PT' . $data['lease_seconds'] . 'S'))

--- a/src/PubSubHubbub/Model/SubscriptionPersistenceInterface.php
+++ b/src/PubSubHubbub/Model/SubscriptionPersistenceInterface.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\PubSubHubbub\Model;
 
 interface SubscriptionPersistenceInterface

--- a/src/PubSubHubbub/PubSubHubbub.php
+++ b/src/PubSubHubbub/PubSubHubbub.php
@@ -1,35 +1,30 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\PubSubHubbub;
 
 use Laminas\Escaper\Escaper;
 use Laminas\Feed\Reader;
 use Laminas\Http;
 
+use function is_string;
+use function str_replace;
+
 class PubSubHubbub
 {
     /**
      * Verification Modes
      */
-    const VERIFICATION_MODE_SYNC  = 'sync';
-    const VERIFICATION_MODE_ASYNC = 'async';
+    public const VERIFICATION_MODE_SYNC  = 'sync';
+    public const VERIFICATION_MODE_ASYNC = 'async';
 
     /**
      * Subscription States
      */
-    const SUBSCRIPTION_VERIFIED    = 'verified';
-    const SUBSCRIPTION_NOTVERIFIED = 'not_verified';
-    const SUBSCRIPTION_TODELETE    = 'to_delete';
+    public const SUBSCRIPTION_VERIFIED    = 'verified';
+    public const SUBSCRIPTION_NOTVERIFIED = 'not_verified';
+    public const SUBSCRIPTION_TODELETE    = 'to_delete';
 
-    /**
-     * @var Escaper
-     */
+    /** @var Escaper */
     protected static $escaper;
 
     /**
@@ -111,7 +106,7 @@ class PubSubHubbub
      *
      * @return void
      */
-    public static function setEscaper(Escaper $escaper = null)
+    public static function setEscaper(?Escaper $escaper = null)
     {
         static::$escaper = $escaper;
     }
@@ -141,7 +136,6 @@ class PubSubHubbub
     {
         $escaper    = static::getEscaper();
         $rawencoded = $escaper->escapeUrl($string);
-        $rfcencoded = str_replace('%7E', '~', $rawencoded);
-        return $rfcencoded;
+        return str_replace('%7E', '~', $rawencoded);
     }
 }

--- a/src/PubSubHubbub/Publisher.php
+++ b/src/PubSubHubbub/Publisher.php
@@ -1,17 +1,22 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\PubSubHubbub;
 
 use Laminas\Feed\Uri;
+use Laminas\Http\Client;
 use Laminas\Http\Request as HttpRequest;
 use Laminas\Stdlib\ArrayUtils;
 use Traversable;
+
+use function array_key_exists;
+use function array_search;
+use function array_unique;
+use function gettype;
+use function implode;
+use function in_array;
+use function is_array;
+use function is_string;
+use function urlencode;
 
 class Publisher
 {
@@ -270,7 +275,7 @@ class Publisher
     /**
      * Add an optional parameter to the update notification requests
      *
-     * @param  string $name
+     * @param  string|array<string, string> $name
      * @param  null|string $value
      * @return $this
      * @throws Exception\InvalidArgumentException
@@ -368,13 +373,12 @@ class Publisher
     /**
      * Get a basic prepared HTTP client for use
      *
-     * @return \Laminas\Http\Client
+     * @return Client
      * @throws Exception\RuntimeException
      */
-    // @codingStandardsIgnoreStart
+    // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     protected function _getHttpClient()
     {
-        // @codingStandardsIgnoreEnd
         $client = PubSubHubbub::getHttpClient();
         $client->setMethod(HttpRequest::METHOD_POST);
         $client->setOptions([

--- a/src/PubSubHubbub/Subscriber/Callback.php
+++ b/src/PubSubHubbub/Subscriber/Callback.php
@@ -1,16 +1,19 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\PubSubHubbub\Subscriber;
 
 use Laminas\Feed\PubSubHubbub;
 use Laminas\Feed\PubSubHubbub\Exception;
 use Laminas\Feed\Uri;
+
+use function array_key_exists;
+use function explode;
+use function hash;
+use function is_array;
+use function rawurldecode;
+use function sprintf;
+use function stripos;
+use function strtolower;
 
 class Callback extends PubSubHubbub\AbstractCallback
 {
@@ -60,7 +63,7 @@ class Callback extends PubSubHubbub\AbstractCallback
      * @param  bool       $sendResponseNow Whether to send response now or when asked
      * @return void
      */
-    public function handle(array $httpGetData = null, $sendResponseNow = false)
+    public function handle(?array $httpGetData = null, $sendResponseNow = false)
     {
         if ($httpGetData === null) {
             $httpGetData = $_GET;
@@ -74,7 +77,8 @@ class Callback extends PubSubHubbub\AbstractCallback
          * to avoid holding up responses to the Hub.
          */
         $contentType = $this->_getHeader('Content-Type');
-        if (strtolower($_SERVER['REQUEST_METHOD']) === 'post'
+        if (
+            strtolower($_SERVER['REQUEST_METHOD']) === 'post'
             && $this->_hasValidVerifyToken(null, false)
             && (stripos($contentType, 'application/atom+xml') === 0
                 || stripos($contentType, 'application/rss+xml') === 0
@@ -149,12 +153,14 @@ class Callback extends PubSubHubbub\AbstractCallback
                 return false;
             }
         }
-        if ($httpGetData['hub_mode'] !== 'subscribe'
+        if (
+            $httpGetData['hub_mode'] !== 'subscribe'
             && $httpGetData['hub_mode'] !== 'unsubscribe'
         ) {
             return false;
         }
-        if ($httpGetData['hub_mode'] === 'subscribe'
+        if (
+            $httpGetData['hub_mode'] === 'subscribe'
             && ! array_key_exists('hub_lease_seconds', $httpGetData)
         ) {
             return false;
@@ -210,6 +216,8 @@ class Callback extends PubSubHubbub\AbstractCallback
         return $this->feedUpdate;
     }
 
+    // phpcs:disable PSR2.Methods.MethodDeclaration.Underscore
+
     /**
      * Check for a valid verify_token. By default attempts to compare values
      * with that sent from Hub, otherwise merely ascertains its existence.
@@ -218,10 +226,8 @@ class Callback extends PubSubHubbub\AbstractCallback
      * @param  bool $checkValue
      * @return bool
      */
-    // @codingStandardsIgnoreStart
-    protected function _hasValidVerifyToken(array $httpGetData = null, $checkValue = true)
+    protected function _hasValidVerifyToken(?array $httpGetData = null, $checkValue = true)
     {
-        // @codingStandardsIgnoreEnd
         $verifyTokenKey = $this->_detectVerifyTokenKey($httpGetData);
         if (empty($verifyTokenKey)) {
             return false;
@@ -250,10 +256,8 @@ class Callback extends PubSubHubbub\AbstractCallback
      * @param  null|array $httpGetData
      * @return false|string
      */
-    // @codingStandardsIgnoreStart
-    protected function _detectVerifyTokenKey(array $httpGetData = null)
+    protected function _detectVerifyTokenKey(?array $httpGetData = null)
     {
-        // @codingStandardsIgnoreEnd
         /**
          * Available when sub keys encoding in Callback URL path
          */
@@ -264,7 +268,8 @@ class Callback extends PubSubHubbub\AbstractCallback
         /**
          * Available only if allowed by PuSH 0.2 Hubs
          */
-        if (is_array($httpGetData)
+        if (
+            is_array($httpGetData)
             && isset($httpGetData['xhub_subscription'])
         ) {
             return $httpGetData['xhub_subscription'];
@@ -288,10 +293,8 @@ class Callback extends PubSubHubbub\AbstractCallback
      *
      * @return array|void
      */
-    // @codingStandardsIgnoreStart
     protected function _parseQueryString()
     {
-        // @codingStandardsIgnoreEnd
         $params      = [];
         $queryString = '';
         if (isset($_SERVER['QUERY_STRING'])) {
@@ -317,4 +320,6 @@ class Callback extends PubSubHubbub\AbstractCallback
         }
         return $params;
     }
+
+    // phpcs:enable PSR2.Methods.MethodDeclaration.Underscore
 }

--- a/src/PubSubHubbub/Version.php
+++ b/src/PubSubHubbub/Version.php
@@ -1,14 +1,9 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\PubSubHubbub;
 
+// phpcs:ignore WebimpressCodingStandard.NamingConventions.AbstractClass.Prefix
 abstract class Version
 {
-    const VERSION = '2';
+    public const VERSION = '2';
 }

--- a/src/Reader/AbstractEntry.php
+++ b/src/Reader/AbstractEntry.php
@@ -1,16 +1,15 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Reader;
 
 use DOMDocument;
 use DOMElement;
 use DOMXPath;
+
+use function array_key_exists;
+use function call_user_func_array;
+use function in_array;
+use function method_exists;
 
 /**
  * @deprecated This (abstract) class is deprecated. Use Laminas\Feed\Reader\Entry\AbstractEntry instead.
@@ -188,7 +187,7 @@ abstract class AbstractEntry
      * @param  string $method
      * @param  array $args
      * @return mixed
-     * @throws Exception\BadMethodCallException if no extensions implements the method
+     * @throws Exception\BadMethodCallException If no extensions implements the method.
      */
     public function __call($method, $args)
     {
@@ -207,10 +206,9 @@ abstract class AbstractEntry
      *
      * @return void
      */
-    // @codingStandardsIgnoreStart
+    // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     protected function _loadExtensions()
     {
-        // @codingStandardsIgnoreEnd
         $all  = Reader::getExtensions();
         $feed = $all['entry'];
         foreach ($feed as $extension) {

--- a/src/Reader/AbstractFeed.php
+++ b/src/Reader/AbstractFeed.php
@@ -1,16 +1,16 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Reader;
 
 use DOMDocument;
 use DOMElement;
 use DOMXPath;
+
+use function call_user_func_array;
+use function count;
+use function in_array;
+use function method_exists;
+use function strpos;
 
 /**
  * @deprecated This (abstract) class is deprecated. Use \Laminas\Feed\Reader\Feed\AbstractFeed instead.
@@ -238,11 +238,17 @@ abstract class AbstractFeed implements Feed\FeedInterface
         return 0 <= $this->entriesKey && $this->entriesKey < $this->count();
     }
 
+    /** @return array */
     public function getExtensions()
     {
         return $this->extensions;
     }
 
+    /**
+     * @param string $method
+     * @param mixed[] $args
+     * @return mixed
+     */
     public function __call($method, $args)
     {
         foreach ($this->extensions as $extension) {
@@ -259,14 +265,15 @@ abstract class AbstractFeed implements Feed\FeedInterface
      * Return an Extension object with the matching name (postfixed with _Feed)
      *
      * @param  string $name
-     * @return Extension\AbstractFeed
+     * @return null|Extension\AbstractFeed
      */
     public function getExtension($name)
     {
-        if (array_key_exists($name . '\Feed', $this->extensions)) {
-            return $this->extensions[$name . '\Feed'];
-        }
-        return;
+        $extensionClass = $name . '\\Feed';
+        return isset($this->extensions[$extensionClass])
+            && $this->extensions[$extensionClass] instanceof Extension\AbstractFeed
+            ? $this->extensions[$extensionClass]
+            : null;
     }
 
     protected function loadExtensions()

--- a/src/Reader/Collection.php
+++ b/src/Reader/Collection.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Reader;
 
 use ArrayObject;

--- a/src/Reader/Collection/AbstractCollection.php
+++ b/src/Reader/Collection/AbstractCollection.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Reader\Collection;
 
 use ArrayObject;

--- a/src/Reader/Collection/Author.php
+++ b/src/Reader/Collection/Author.php
@@ -1,12 +1,8 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Reader\Collection;
+
+use function array_unique;
 
 class Author extends AbstractCollection
 {

--- a/src/Reader/Collection/Category.php
+++ b/src/Reader/Collection/Category.php
@@ -1,12 +1,8 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Reader\Collection;
+
+use function array_unique;
 
 class Category extends AbstractCollection
 {

--- a/src/Reader/Collection/Collection.php
+++ b/src/Reader/Collection/Collection.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Reader\Collection;
 
 use ArrayObject;

--- a/src/Reader/Entry/AbstractEntry.php
+++ b/src/Reader/Entry/AbstractEntry.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Reader\Entry;
 
 use DOMDocument;
@@ -13,6 +7,14 @@ use DOMElement;
 use DOMXPath;
 use Laminas\Feed\Reader;
 use Laminas\Feed\Reader\Exception;
+
+use function call_user_func_array;
+use function in_array;
+use function method_exists;
+use function sprintf;
+use function version_compare;
+
+use const PHP_VERSION;
 
 abstract class AbstractEntry
 {
@@ -173,14 +175,15 @@ abstract class AbstractEntry
      * Return an Extension object with the matching name (postfixed with _Entry)
      *
      * @param  string $name
-     * @return Reader\Extension\AbstractEntry
+     * @return null|Reader\Extension\AbstractEntry
      */
     public function getExtension($name)
     {
-        if (array_key_exists($name . '\\Entry', $this->extensions)) {
-            return $this->extensions[$name . '\\Entry'];
-        }
-        return;
+        $extensionClass = $name . '\\Entry';
+        return isset($this->extensions[$extensionClass])
+            && $this->extensions[$extensionClass] instanceof Reader\Extension\AbstractEntry
+            ? $this->extensions[$extensionClass]
+            : null;
     }
 
     /**
@@ -189,7 +192,7 @@ abstract class AbstractEntry
      * @param  string $method
      * @param  array $args
      * @return mixed
-     * @throws Exception\RuntimeException if no extensions implements the method
+     * @throws Exception\RuntimeException If no extensions implements the method.
      */
     public function __call($method, $args)
     {

--- a/src/Reader/Entry/Atom.php
+++ b/src/Reader/Entry/Atom.php
@@ -6,6 +6,11 @@ use DateTime;
 use DOMElement;
 use DOMXPath;
 use Laminas\Feed\Reader;
+use Laminas\Feed\Reader\Collection\Author as AuthorCollection;
+use Laminas\Feed\Reader\Exception\RuntimeException;
+use Laminas\Feed\Reader\Extension\Atom\Entry;
+use Laminas\Feed\Reader\Extension\DublinCore\Entry as DublinCoreEntry;
+use Laminas\Feed\Reader\Extension\Thread\Entry as ThreadEntry;
 
 use function array_key_exists;
 use function count;
@@ -61,7 +66,7 @@ class Atom extends AbstractEntry implements EntryInterface
     /**
      * Get an array with feed authors
      *
-     * @return array
+     * @return AuthorCollection
      */
     public function getAuthors()
     {
@@ -69,8 +74,7 @@ class Atom extends AbstractEntry implements EntryInterface
             return $this->data['authors'];
         }
 
-        /** @psalm-suppress PossiblyNullReference */
-        $people = $this->getExtension('Atom')->getAuthors();
+        $people = $this->getAtomExtension()->getAuthors();
 
         $this->data['authors'] = $people;
 
@@ -88,8 +92,7 @@ class Atom extends AbstractEntry implements EntryInterface
             return $this->data['content'];
         }
 
-        /** @psalm-suppress PossiblyNullReference */
-        $content = $this->getExtension('Atom')->getContent();
+        $content = $this->getAtomExtension()->getContent();
 
         $this->data['content'] = $content;
 
@@ -99,7 +102,7 @@ class Atom extends AbstractEntry implements EntryInterface
     /**
      * Get the entry creation date
      *
-     * @return DateTime
+     * @return null|DateTime
      */
     public function getDateCreated()
     {
@@ -107,8 +110,7 @@ class Atom extends AbstractEntry implements EntryInterface
             return $this->data['datecreated'];
         }
 
-        /** @psalm-suppress PossiblyNullReference */
-        $dateCreated = $this->getExtension('Atom')->getDateCreated();
+        $dateCreated = $this->getAtomExtension()->getDateCreated();
 
         $this->data['datecreated'] = $dateCreated;
 
@@ -118,7 +120,7 @@ class Atom extends AbstractEntry implements EntryInterface
     /**
      * Get the entry modification date
      *
-     * @return DateTime
+     * @return null|DateTime
      */
     public function getDateModified()
     {
@@ -126,8 +128,7 @@ class Atom extends AbstractEntry implements EntryInterface
             return $this->data['datemodified'];
         }
 
-        /** @psalm-suppress PossiblyNullReference */
-        $dateModified = $this->getExtension('Atom')->getDateModified();
+        $dateModified = $this->getAtomExtension()->getDateModified();
 
         $this->data['datemodified'] = $dateModified;
 
@@ -145,8 +146,7 @@ class Atom extends AbstractEntry implements EntryInterface
             return $this->data['description'];
         }
 
-        /** @psalm-suppress PossiblyNullReference */
-        $description = $this->getExtension('Atom')->getDescription();
+        $description = $this->getAtomExtension()->getDescription();
 
         $this->data['description'] = $description;
 
@@ -156,7 +156,7 @@ class Atom extends AbstractEntry implements EntryInterface
     /**
      * Get the entry enclosure
      *
-     * @return string
+     * @return null|object{href: string, length: int, type: string}
      */
     public function getEnclosure()
     {
@@ -164,8 +164,7 @@ class Atom extends AbstractEntry implements EntryInterface
             return $this->data['enclosure'];
         }
 
-        /** @psalm-suppress PossiblyNullReference */
-        $enclosure = $this->getExtension('Atom')->getEnclosure();
+        $enclosure = $this->getAtomExtension()->getEnclosure();
 
         $this->data['enclosure'] = $enclosure;
 
@@ -183,8 +182,7 @@ class Atom extends AbstractEntry implements EntryInterface
             return $this->data['id'];
         }
 
-        /** @psalm-suppress PossiblyNullReference */
-        $id = $this->getExtension('Atom')->getId();
+        $id = $this->getAtomExtension()->getId();
 
         $this->data['id'] = $id;
 
@@ -219,8 +217,7 @@ class Atom extends AbstractEntry implements EntryInterface
             return $this->data['links'];
         }
 
-        /** @psalm-suppress PossiblyNullReference */
-        $links = $this->getExtension('Atom')->getLinks();
+        $links = $this->getAtomExtension()->getLinks();
 
         $this->data['links'] = $links;
 
@@ -248,8 +245,7 @@ class Atom extends AbstractEntry implements EntryInterface
             return $this->data['title'];
         }
 
-        /** @psalm-suppress PossiblyNullReference */
-        $title = $this->getExtension('Atom')->getTitle();
+        $title = $this->getAtomExtension()->getTitle();
 
         $this->data['title'] = $title;
 
@@ -267,12 +263,10 @@ class Atom extends AbstractEntry implements EntryInterface
             return $this->data['commentcount'];
         }
 
-        /** @psalm-suppress PossiblyNullReference */
-        $commentcount = $this->getExtension('Thread')->getCommentCount();
+        $commentcount = $this->getThreadExtension()->getCommentCount();
 
         if (! $commentcount) {
-            /** @psalm-suppress PossiblyNullReference */
-            $commentcount = $this->getExtension('Atom')->getCommentCount();
+            $commentcount = $this->getAtomExtension()->getCommentCount();
         }
 
         $this->data['commentcount'] = $commentcount;
@@ -291,8 +285,7 @@ class Atom extends AbstractEntry implements EntryInterface
             return $this->data['commentlink'];
         }
 
-        /** @psalm-suppress PossiblyNullReference */
-        $commentlink = $this->getExtension('Atom')->getCommentLink();
+        $commentlink = $this->getAtomExtension()->getCommentLink();
 
         $this->data['commentlink'] = $commentlink;
 
@@ -310,8 +303,7 @@ class Atom extends AbstractEntry implements EntryInterface
             return $this->data['commentfeedlink'];
         }
 
-        /** @psalm-suppress PossiblyNullReference */
-        $commentfeedlink = $this->getExtension('Atom')->getCommentFeedLink();
+        $commentfeedlink = $this->getAtomExtension()->getCommentFeedLink();
 
         $this->data['commentfeedlink'] = $commentfeedlink;
 
@@ -329,12 +321,10 @@ class Atom extends AbstractEntry implements EntryInterface
             return $this->data['categories'];
         }
 
-        /** @psalm-suppress PossiblyNullReference */
-        $categoryCollection = $this->getExtension('Atom')->getCategories();
+        $categoryCollection = $this->getAtomExtension()->getCategories();
 
         if (count($categoryCollection) === 0) {
-            /** @psalm-suppress PossiblyNullReference */
-            $categoryCollection = $this->getExtension('DublinCore')->getCategories();
+            $categoryCollection = $this->getDublinCoreExtension()->getCategories();
         }
 
         $this->data['categories'] = $categoryCollection;
@@ -353,8 +343,7 @@ class Atom extends AbstractEntry implements EntryInterface
             return $this->data['source'];
         }
 
-        /** @psalm-suppress PossiblyNullReference */
-        $source = $this->getExtension('Atom')->getSource();
+        $source = $this->getAtomExtension()->getSource();
 
         $this->data['source'] = $source;
 
@@ -372,5 +361,38 @@ class Atom extends AbstractEntry implements EntryInterface
         foreach ($this->extensions as $extension) {
             $extension->setXpath($this->xpath);
         }
+    }
+
+    private function getAtomExtension(): Entry
+    {
+        $extension = $this->getExtension('Atom');
+
+        if (! $extension instanceof Entry) {
+            throw new RuntimeException('Unable to retrieve Atom entry extension');
+        }
+
+        return $extension;
+    }
+
+    private function getDublinCoreExtension(): DublinCoreEntry
+    {
+        $extension = $this->getExtension('DublinCore');
+
+        if (! $extension instanceof DublinCoreEntry) {
+            throw new RuntimeException('Unable to retrieve DublinCore entry extension');
+        }
+
+        return $extension;
+    }
+
+    private function getThreadExtension(): ThreadEntry
+    {
+        $extension = $this->getExtension('Thread');
+
+        if (! $extension instanceof ThreadEntry) {
+            throw new RuntimeException('Unable to retrieve Thread entry extension');
+        }
+
+        return $extension;
     }
 }

--- a/src/Reader/Entry/Atom.php
+++ b/src/Reader/Entry/Atom.php
@@ -1,17 +1,16 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Reader\Entry;
 
 use DateTime;
 use DOMElement;
 use DOMXPath;
 use Laminas\Feed\Reader;
+
+use function array_key_exists;
+use function count;
+use function is_array;
+use function is_string;
 
 class Atom extends AbstractEntry implements EntryInterface
 {
@@ -46,17 +45,17 @@ class Atom extends AbstractEntry implements EntryInterface
     }
 
     /**
-     * @inheritdoc
+     * @inheritDoc
+     * @param int $index
+     * @return null|array<string, string>
      */
     public function getAuthor($index = 0)
     {
         $authors = $this->getAuthors();
 
-        if (isset($authors[$index])) {
-            return $authors[$index];
-        }
-
-        return;
+        return isset($authors[$index]) && is_array($authors[$index])
+            ? $authors[$index]
+            : null;
     }
 
     /**
@@ -70,6 +69,7 @@ class Atom extends AbstractEntry implements EntryInterface
             return $this->data['authors'];
         }
 
+        /** @psalm-suppress PossiblyNullReference */
         $people = $this->getExtension('Atom')->getAuthors();
 
         $this->data['authors'] = $people;
@@ -88,6 +88,7 @@ class Atom extends AbstractEntry implements EntryInterface
             return $this->data['content'];
         }
 
+        /** @psalm-suppress PossiblyNullReference */
         $content = $this->getExtension('Atom')->getContent();
 
         $this->data['content'] = $content;
@@ -106,6 +107,7 @@ class Atom extends AbstractEntry implements EntryInterface
             return $this->data['datecreated'];
         }
 
+        /** @psalm-suppress PossiblyNullReference */
         $dateCreated = $this->getExtension('Atom')->getDateCreated();
 
         $this->data['datecreated'] = $dateCreated;
@@ -124,6 +126,7 @@ class Atom extends AbstractEntry implements EntryInterface
             return $this->data['datemodified'];
         }
 
+        /** @psalm-suppress PossiblyNullReference */
         $dateModified = $this->getExtension('Atom')->getDateModified();
 
         $this->data['datemodified'] = $dateModified;
@@ -142,6 +145,7 @@ class Atom extends AbstractEntry implements EntryInterface
             return $this->data['description'];
         }
 
+        /** @psalm-suppress PossiblyNullReference */
         $description = $this->getExtension('Atom')->getDescription();
 
         $this->data['description'] = $description;
@@ -160,6 +164,7 @@ class Atom extends AbstractEntry implements EntryInterface
             return $this->data['enclosure'];
         }
 
+        /** @psalm-suppress PossiblyNullReference */
         $enclosure = $this->getExtension('Atom')->getEnclosure();
 
         $this->data['enclosure'] = $enclosure;
@@ -178,6 +183,7 @@ class Atom extends AbstractEntry implements EntryInterface
             return $this->data['id'];
         }
 
+        /** @psalm-suppress PossiblyNullReference */
         $id = $this->getExtension('Atom')->getId();
 
         $this->data['id'] = $id;
@@ -189,7 +195,7 @@ class Atom extends AbstractEntry implements EntryInterface
      * Get a specific link
      *
      * @param  int $index
-     * @return string
+     * @return null|string
      */
     public function getLink($index = 0)
     {
@@ -197,11 +203,9 @@ class Atom extends AbstractEntry implements EntryInterface
             $this->getLinks();
         }
 
-        if (isset($this->data['links'][$index])) {
-            return $this->data['links'][$index];
-        }
-
-        return;
+        return isset($this->data['links'][$index]) && is_string($this->data['links'][$index])
+            ? $this->data['links'][$index]
+            : null;
     }
 
     /**
@@ -215,6 +219,7 @@ class Atom extends AbstractEntry implements EntryInterface
             return $this->data['links'];
         }
 
+        /** @psalm-suppress PossiblyNullReference */
         $links = $this->getExtension('Atom')->getLinks();
 
         $this->data['links'] = $links;
@@ -243,6 +248,7 @@ class Atom extends AbstractEntry implements EntryInterface
             return $this->data['title'];
         }
 
+        /** @psalm-suppress PossiblyNullReference */
         $title = $this->getExtension('Atom')->getTitle();
 
         $this->data['title'] = $title;
@@ -261,9 +267,11 @@ class Atom extends AbstractEntry implements EntryInterface
             return $this->data['commentcount'];
         }
 
+        /** @psalm-suppress PossiblyNullReference */
         $commentcount = $this->getExtension('Thread')->getCommentCount();
 
         if (! $commentcount) {
+            /** @psalm-suppress PossiblyNullReference */
             $commentcount = $this->getExtension('Atom')->getCommentCount();
         }
 
@@ -283,6 +291,7 @@ class Atom extends AbstractEntry implements EntryInterface
             return $this->data['commentlink'];
         }
 
+        /** @psalm-suppress PossiblyNullReference */
         $commentlink = $this->getExtension('Atom')->getCommentLink();
 
         $this->data['commentlink'] = $commentlink;
@@ -301,6 +310,7 @@ class Atom extends AbstractEntry implements EntryInterface
             return $this->data['commentfeedlink'];
         }
 
+        /** @psalm-suppress PossiblyNullReference */
         $commentfeedlink = $this->getExtension('Atom')->getCommentFeedLink();
 
         $this->data['commentfeedlink'] = $commentfeedlink;
@@ -319,9 +329,11 @@ class Atom extends AbstractEntry implements EntryInterface
             return $this->data['categories'];
         }
 
+        /** @psalm-suppress PossiblyNullReference */
         $categoryCollection = $this->getExtension('Atom')->getCategories();
 
         if (count($categoryCollection) === 0) {
+            /** @psalm-suppress PossiblyNullReference */
             $categoryCollection = $this->getExtension('DublinCore')->getCategories();
         }
 
@@ -341,6 +353,7 @@ class Atom extends AbstractEntry implements EntryInterface
             return $this->data['source'];
         }
 
+        /** @psalm-suppress PossiblyNullReference */
         $source = $this->getExtension('Atom')->getSource();
 
         $this->data['source'] = $source;

--- a/src/Reader/Entry/EntryInterface.php
+++ b/src/Reader/Entry/EntryInterface.php
@@ -4,7 +4,6 @@ namespace Laminas\Feed\Reader\Entry;
 
 use DateTime;
 use Laminas\Feed\Reader\Collection\Category;
-use stdClass;
 
 interface EntryInterface
 {
@@ -19,7 +18,7 @@ interface EntryInterface
     /**
      * Get an array with feed authors
      *
-     * @return array
+     * @return null|array|iterable
      */
     public function getAuthors();
 
@@ -33,14 +32,14 @@ interface EntryInterface
     /**
      * Get the entry creation date
      *
-     * @return DateTime
+     * @return null|DateTime
      */
     public function getDateCreated();
 
     /**
      * Get the entry modification date
      *
-     * @return DateTime
+     * @return null|DateTime
      */
     public function getDateModified();
 
@@ -54,7 +53,7 @@ interface EntryInterface
     /**
      * Get the entry enclosure
      *
-     * @return stdClass
+     * @return null|object{url?: string, href?: string, length: int, type: string}
      */
     public function getEnclosure();
 

--- a/src/Reader/Entry/EntryInterface.php
+++ b/src/Reader/Entry/EntryInterface.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Reader\Entry;
 
 use DateTime;

--- a/src/Reader/Exception/BadMethodCallException.php
+++ b/src/Reader/Exception/BadMethodCallException.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Reader\Exception;
 
 use Laminas\Feed\Exception;

--- a/src/Reader/Exception/ExceptionInterface.php
+++ b/src/Reader/Exception/ExceptionInterface.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Reader\Exception;
 
 use Laminas\Feed\Exception\ExceptionInterface as Exception;

--- a/src/Reader/Exception/InvalidArgumentException.php
+++ b/src/Reader/Exception/InvalidArgumentException.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Reader\Exception;
 
 use Laminas\Feed\Exception;

--- a/src/Reader/Exception/InvalidHttpClientException.php
+++ b/src/Reader/Exception/InvalidHttpClientException.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Reader\Exception;
 
 use Laminas\Feed\Exception;

--- a/src/Reader/Exception/RuntimeException.php
+++ b/src/Reader/Exception/RuntimeException.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Reader\Exception;
 
 use Laminas\Feed\Exception;

--- a/src/Reader/Extension/AbstractEntry.php
+++ b/src/Reader/Extension/AbstractEntry.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Reader\Extension;
 
 use DOMDocument;
@@ -110,8 +104,7 @@ abstract class AbstractEntry
      */
     public function getEncoding()
     {
-        $assumed = $this->getDomDocument()->encoding;
-        return $assumed;
+        return $this->getDomDocument()->encoding;
     }
 
     /**
@@ -130,14 +123,16 @@ abstract class AbstractEntry
         }
 
         $this->data['type'] = $type;
-        if ($type === Reader\Reader::TYPE_RSS_10
+        if (
+            $type === Reader\Reader::TYPE_RSS_10
             || $type === Reader\Reader::TYPE_RSS_090
         ) {
             $this->setXpathPrefix('//rss:item[' . ((int) $this->entryKey + 1) . ']');
             return $this;
         }
 
-        if ($type === Reader\Reader::TYPE_ATOM_10
+        if (
+            $type === Reader\Reader::TYPE_ATOM_10
             || $type === Reader\Reader::TYPE_ATOM_03
         ) {
             $this->setXpathPrefix('//atom:entry[' . ((int) $this->entryKey + 1) . ']');

--- a/src/Reader/Extension/AbstractFeed.php
+++ b/src/Reader/Extension/AbstractFeed.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Reader\Extension;
 
 use DOMDocument;
@@ -70,8 +64,7 @@ abstract class AbstractFeed
      */
     public function getEncoding()
     {
-        $assumed = $this->getDomDocument()->encoding;
-        return $assumed;
+        return $this->getDomDocument()->encoding;
     }
 
     /**
@@ -118,7 +111,7 @@ abstract class AbstractFeed
      *
      * @return $this
      */
-    public function setXpath(DOMXPath $xpath = null)
+    public function setXpath(?DOMXPath $xpath = null)
     {
         if (null === $xpath) {
             $this->xpath = null;

--- a/src/Reader/Extension/Atom/Entry.php
+++ b/src/Reader/Extension/Atom/Entry.php
@@ -158,7 +158,7 @@ class Entry extends Extension\AbstractEntry
     /**
      * Get the entry creation date
      *
-     * @return string
+     * @return null|DateTime
      */
     public function getDateCreated()
     {
@@ -186,7 +186,7 @@ class Entry extends Extension\AbstractEntry
     /**
      * Get the entry modification date
      *
-     * @return string
+     * @return null|DateTime
      */
     public function getDateModified()
     {
@@ -236,7 +236,7 @@ class Entry extends Extension\AbstractEntry
     /**
      * Get the entry enclosure
      *
-     * @return string
+     * @return null|object{href: string, length: int, type: string}
      */
     public function getEnclosure()
     {

--- a/src/Reader/Extension/Atom/Entry.php
+++ b/src/Reader/Extension/Atom/Entry.php
@@ -1,21 +1,26 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Reader\Extension\Atom;
 
 use DateTime;
 use DOMDocument;
 use DOMElement;
+use DOMNodeList;
 use Laminas\Feed\Reader;
 use Laminas\Feed\Reader\Collection;
 use Laminas\Feed\Reader\Extension;
 use Laminas\Feed\Uri;
 use stdClass;
+
+use function array_key_exists;
+use function count;
+use function is_string;
+use function preg_replace;
+use function strlen;
+use function trim;
+use function version_compare;
+
+use const PHP_VERSION;
 
 class Entry extends Extension\AbstractEntry
 {
@@ -29,11 +34,9 @@ class Entry extends Extension\AbstractEntry
     {
         $authors = $this->getAuthors();
 
-        if (isset($authors[$index])) {
-            return $authors[$index];
-        }
-
-        return;
+        return isset($authors[$index]) && is_string($authors[$index])
+            ? $authors[$index]
+            : null;
     }
 
     /**
@@ -50,14 +53,14 @@ class Entry extends Extension\AbstractEntry
         $authors = [];
         $list    = $this->getXpath()->query($this->getXpathPrefix() . '//atom:author');
 
-        if (! $list->length) {
+        if (! $list instanceof DOMNodeList || ! $list->length) {
             /**
              * TODO: Limit query to feed level els only!
              */
             $list = $this->getXpath()->query('//atom:author');
         }
 
-        if ($list->length) {
+        if ($list instanceof DOMNodeList && $list->length) {
             foreach ($list as $author) {
                 $author = $this->getAuthorFromElement($author);
                 if (! empty($author)) {
@@ -139,7 +142,7 @@ class Entry extends Extension\AbstractEntry
     protected function collectXhtml($xhtml, $prefix)
     {
         if (! empty($prefix)) {
-            $prefix = $prefix . ':';
+            $prefix .= ':';
         }
         $matches = [
             '/<\?xml[^<]*>[^<]*<' . $prefix . 'div[^>]*>/',
@@ -245,11 +248,13 @@ class Entry extends Extension\AbstractEntry
 
         $nodeList = $this->getXpath()->query($this->getXpathPrefix() . '/atom:link[@rel="enclosure"]');
 
-        if ($nodeList->length > 0) {
+        if ($nodeList instanceof DOMNodeList && $nodeList->length > 0) {
+            /** @var DOMElement $node */
+            $node              = $nodeList->item(0);
             $enclosure         = new stdClass();
-            $enclosure->url    = $nodeList->item(0)->getAttribute('href');
-            $enclosure->length = $nodeList->item(0)->getAttribute('length');
-            $enclosure->type   = $nodeList->item(0)->getAttribute('type');
+            $enclosure->url    = $node->getAttribute('href');
+            $enclosure->length = $node->getAttribute('length');
+            $enclosure->type   = $node->getAttribute('type');
         }
 
         $this->data['enclosure'] = $enclosure;
@@ -317,7 +322,7 @@ class Entry extends Extension\AbstractEntry
      * Get a specific link
      *
      * @param  int $index
-     * @return string
+     * @return null|string
      */
     public function getLink($index = 0)
     {
@@ -325,11 +330,9 @@ class Entry extends Extension\AbstractEntry
             $this->getLinks();
         }
 
-        if (isset($this->data['links'][$index])) {
-            return $this->data['links'][$index];
-        }
-
-        return;
+        return isset($this->data['links']) && is_string($this->data['links'])
+            ? $this->data['links']
+            : null;
     }
 
     /**
@@ -346,11 +349,13 @@ class Entry extends Extension\AbstractEntry
         $links = [];
 
         $list = $this->getXpath()->query(
-            $this->getXpathPrefix() . '//atom:link[@rel="alternate"]/@href' . '|'
-            . $this->getXpathPrefix() . '//atom:link[not(@rel)]/@href'
+            $this->getXpathPrefix()
+            . '//atom:link[@rel="alternate"]/@href|'
+            . $this->getXpathPrefix()
+            . '//atom:link[not(@rel)]/@href'
         );
 
-        if ($list->length) {
+        if ($list instanceof DOMNodeList && $list->length) {
             foreach ($list as $link) {
                 $links[] = $this->absolutiseUri($link->value);
             }
@@ -368,7 +373,8 @@ class Entry extends Extension\AbstractEntry
      */
     public function getPermalink()
     {
-        return $this->getLink(0);
+        $permalink = $this->getLink(0);
+        return is_string($permalink) ? $permalink : '';
     }
 
     /**
@@ -384,7 +390,7 @@ class Entry extends Extension\AbstractEntry
 
         $title = $this->getXpath()->evaluate('string(' . $this->getXpathPrefix() . '/atom:title)');
 
-        if (! $title) {
+        if (! is_string($title)) {
             $title = null;
         }
 
@@ -411,7 +417,7 @@ class Entry extends Extension\AbstractEntry
             $this->getXpathPrefix() . '//atom:link[@rel="replies"]/@thread10:count'
         );
 
-        if ($list->length) {
+        if ($list instanceof DOMNodeList && $list->length) {
             $count = $list->item(0)->value;
         }
 
@@ -437,7 +443,7 @@ class Entry extends Extension\AbstractEntry
             $this->getXpathPrefix() . '//atom:link[@rel="replies" and @type="text/html"]/@href'
         );
 
-        if ($list->length) {
+        if ($list instanceof DOMNodeList && $list->length) {
             $link = $list->item(0)->value;
             $link = $this->absolutiseUri($link);
         }
@@ -465,7 +471,7 @@ class Entry extends Extension\AbstractEntry
             $this->getXpathPrefix() . '//atom:link[@rel="replies" and @type="application/' . $type . '+xml"]/@href'
         );
 
-        if ($list->length) {
+        if ($list instanceof DOMNodeList && $list->length) {
             $link = $list->item(0)->value;
             $link = $this->absolutiseUri($link);
         }
@@ -498,7 +504,7 @@ class Entry extends Extension\AbstractEntry
             $list = $this->getXpath()->query($this->getXpathPrefix() . '//atom10:category');
         }
 
-        if ($list->length) {
+        if ($list instanceof DOMNodeList && $list->length) {
             $categoryCollection = new Collection\Category();
             foreach ($list as $category) {
                 $categoryCollection[] = [
@@ -531,7 +537,7 @@ class Entry extends Extension\AbstractEntry
         // TODO: Investigate why _getAtomType() fails here. Is it even needed?
         if ($this->getType() === Reader\Reader::TYPE_ATOM_10) {
             $list = $this->getXpath()->query($this->getXpathPrefix() . '/atom:source[1]');
-            if ($list->length) {
+            if ($list instanceof DOMNodeList && $list->length) {
                 $element = $list->item(0);
                 $source  = new Reader\Feed\Atom\Source($element, $this->getXpathPrefix());
             }
@@ -565,7 +571,6 @@ class Entry extends Extension\AbstractEntry
      * Get an author entry
      *
      * @return array<string,null|string>|null
-     *
      * @psalm-return array{email?: null|string, name?: null|string, uri?: null|string}|null
      */
     protected function getAuthorFromElement(DOMElement $element)
@@ -619,12 +624,14 @@ class Entry extends Extension\AbstractEntry
         $dom          = $this->getDomDocument();
         $prefixAtom03 = $dom->lookupPrefix(Reader\Reader::NAMESPACE_ATOM_03);
         $prefixAtom10 = $dom->lookupPrefix(Reader\Reader::NAMESPACE_ATOM_10);
-        if ($dom->isDefaultNamespace(Reader\Reader::NAMESPACE_ATOM_03)
+        if (
+            $dom->isDefaultNamespace(Reader\Reader::NAMESPACE_ATOM_03)
             || ! empty($prefixAtom03)
         ) {
             return Reader\Reader::TYPE_ATOM_03;
         }
-        if ($dom->isDefaultNamespace(Reader\Reader::NAMESPACE_ATOM_10)
+        if (
+            $dom->isDefaultNamespace(Reader\Reader::NAMESPACE_ATOM_10)
             || ! empty($prefixAtom10)
         ) {
             return Reader\Reader::TYPE_ATOM_10;

--- a/src/Reader/Extension/Atom/Entry.php
+++ b/src/Reader/Extension/Atom/Entry.php
@@ -127,7 +127,7 @@ class Entry extends Extension\AbstractEntry
             $content = $this->getDescription();
         }
 
-        $this->data['content'] = trim($content);
+        $this->data['content'] = trim($content ?? '');
 
         return $this->data['content'];
     }

--- a/src/Reader/Extension/Atom/Feed.php
+++ b/src/Reader/Extension/Atom/Feed.php
@@ -81,20 +81,11 @@ class Feed extends Extension\AbstractFeed
             return $this->data['copyright'];
         }
 
-        /** @psalm-suppress UnusedVariable */
-        $copyright = null;
+        $copyright = $this->getType() === Reader\Reader::TYPE_ATOM_03
+            ? $this->xpath->evaluate('string(' . $this->getXpathPrefix() . '/atom:copyright)')
+            : $this->xpath->evaluate('string(' . $this->getXpathPrefix() . '/atom:rights)');
 
-        if ($this->getType() === Reader\Reader::TYPE_ATOM_03) {
-            $copyright = $this->xpath->evaluate('string(' . $this->getXpathPrefix() . '/atom:copyright)');
-        } else {
-            $copyright = $this->xpath->evaluate('string(' . $this->getXpathPrefix() . '/atom:rights)');
-        }
-
-        if (! $copyright) {
-            $copyright = null;
-        }
-
-        $this->data['copyright'] = $copyright;
+        $this->data['copyright'] = is_string($copyright) ? $copyright : null;
 
         return $this->data['copyright'];
     }
@@ -166,20 +157,11 @@ class Feed extends Extension\AbstractFeed
             return $this->data['description'];
         }
 
-        /** @psalm-suppress UnusedVariable */
-        $description = null;
+        $description = $this->getType() === Reader\Reader::TYPE_ATOM_03
+            ? $this->xpath->evaluate('string(' . $this->getXpathPrefix() . '/atom:tagline)')
+            : $this->xpath->evaluate('string(' . $this->getXpathPrefix() . '/atom:subtitle)');
 
-        if ($this->getType() === Reader\Reader::TYPE_ATOM_03) {
-            $description = $this->xpath->evaluate('string(' . $this->getXpathPrefix() . '/atom:tagline)');
-        } else {
-            $description = $this->xpath->evaluate('string(' . $this->getXpathPrefix() . '/atom:subtitle)');
-        }
-
-        if (! $description) {
-            $description = null;
-        }
-
-        $this->data['description'] = $description;
+        $this->data['description'] = is_string($description) ? $description : null;
 
         return $this->data['description'];
     }

--- a/src/Reader/Extension/Content/Entry.php
+++ b/src/Reader/Extension/Content/Entry.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Reader\Extension\Content;
 
 use Laminas\Feed\Reader;
@@ -13,16 +7,17 @@ use Laminas\Feed\Reader\Extension;
 
 class Entry extends Extension\AbstractEntry
 {
+    /** @return string */
     public function getContent()
     {
-        if ($this->getType() !== Reader\Reader::TYPE_RSS_10
+        if (
+            $this->getType() !== Reader\Reader::TYPE_RSS_10
             && $this->getType() !== Reader\Reader::TYPE_RSS_090
         ) {
-            $content = $this->xpath->evaluate('string(' . $this->getXpathPrefix() . '/content:encoded)');
-        } else {
-            $content = $this->xpath->evaluate('string(' . $this->getXpathPrefix() . '/content:encoded)');
+            return $this->xpath->evaluate('string(' . $this->getXpathPrefix() . '/content:encoded)');
         }
-        return $content;
+
+        return $this->xpath->evaluate('string(' . $this->getXpathPrefix() . '/content:encoded)');
     }
 
     /**

--- a/src/Reader/Extension/CreativeCommons/Entry.php
+++ b/src/Reader/Extension/CreativeCommons/Entry.php
@@ -1,14 +1,18 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Reader\Extension\CreativeCommons;
 
+use DOMNodeList;
+use Laminas\Feed\Reader\Exception\RuntimeException;
 use Laminas\Feed\Reader\Extension;
+
+use function array_key_exists;
+use function array_unique;
+use function get_class;
+use function gettype;
+use function is_object;
+use function is_string;
+use function sprintf;
 
 class Entry extends Extension\AbstractEntry
 {
@@ -22,11 +26,18 @@ class Entry extends Extension\AbstractEntry
     {
         $licenses = $this->getLicenses();
 
-        if (isset($licenses[$index])) {
-            return $licenses[$index];
+        if (! isset($licenses[$index])) {
+            return null;
         }
 
-        return;
+        if (! is_string($licenses[$index])) {
+            throw new RuntimeException(sprintf(
+                'Unable to retrieve license; expected string, received "%s"',
+                is_object($licenses[$index]) ? get_class($licenses[$index]) : gettype($licenses[$index])
+            ));
+        }
+
+        return $licenses[$index];
     }
 
     /**
@@ -44,7 +55,7 @@ class Entry extends Extension\AbstractEntry
         $licenses = [];
         $list     = $this->xpath->evaluate($this->getXpathPrefix() . '//cc:license');
 
-        if ($list->length) {
+        if ($list instanceof DOMNodeList && $list->length) {
             foreach ($list as $license) {
                 $licenses[] = $license->nodeValue;
             }

--- a/src/Reader/Extension/CreativeCommons/Feed.php
+++ b/src/Reader/Extension/CreativeCommons/Feed.php
@@ -1,14 +1,17 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Reader\Extension\CreativeCommons;
 
+use Laminas\Feed\Reader\Exception\RuntimeException;
 use Laminas\Feed\Reader\Extension;
+
+use function array_key_exists;
+use function array_unique;
+use function get_class;
+use function gettype;
+use function is_object;
+use function is_string;
+use function sprintf;
 
 class Feed extends Extension\AbstractFeed
 {
@@ -22,11 +25,18 @@ class Feed extends Extension\AbstractFeed
     {
         $licenses = $this->getLicenses();
 
-        if (isset($licenses[$index])) {
-            return $licenses[$index];
+        if (! isset($licenses[$index])) {
+            return null;
         }
 
-        return;
+        if (! is_string($licenses[$index])) {
+            throw new RuntimeException(sprintf(
+                'Unable to retrieve license; expected string, received "%s"',
+                is_object($licenses[$index]) ? get_class($licenses[$index]) : gettype($licenses[$index])
+            ));
+        }
+
+        return $licenses[$index];
     }
 
     /**

--- a/src/Reader/Extension/DublinCore/Entry.php
+++ b/src/Reader/Extension/DublinCore/Entry.php
@@ -1,17 +1,15 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Reader\Extension\DublinCore;
 
 use DateTime;
+use DOMNodeList;
 use Laminas\Feed\Reader;
 use Laminas\Feed\Reader\Collection;
 use Laminas\Feed\Reader\Extension;
+
+use function array_key_exists;
+use function is_array;
 
 class Entry extends Extension\AbstractEntry
 {
@@ -19,17 +17,15 @@ class Entry extends Extension\AbstractEntry
      * Get an author entry
      *
      * @param  int $index
-     * @return string
+     * @return null|array<string, string>
      */
     public function getAuthor($index = 0)
     {
         $authors = $this->getAuthors();
 
-        if (isset($authors[$index])) {
-            return $authors[$index];
-        }
-
-        return;
+        return isset($authors[$index]) && is_array($authors[$index])
+            ? $authors[$index]
+            : null;
     }
 
     /**
@@ -46,18 +42,19 @@ class Entry extends Extension\AbstractEntry
         $authors = [];
         $list    = $this->getXpath()->evaluate($this->getXpathPrefix() . '//dc11:creator');
 
-        if (! $list->length) {
+        if (! $list instanceof DOMNodeList || ! $list->length) {
             $list = $this->getXpath()->evaluate($this->getXpathPrefix() . '//dc10:creator');
         }
-        if (! $list->length) {
+
+        if (! $list instanceof DOMNodeList || ! $list->length) {
             $list = $this->getXpath()->evaluate($this->getXpathPrefix() . '//dc11:publisher');
 
-            if (! $list->length) {
+            if (! $list instanceof DOMNodeList || ! $list->length) {
                 $list = $this->getXpath()->evaluate($this->getXpathPrefix() . '//dc10:publisher');
             }
         }
 
-        if ($list->length) {
+        if ($list instanceof DOMNodeList && $list->length) {
             foreach ($list as $author) {
                 $authors[] = [
                     'name' => $author->nodeValue,
@@ -88,11 +85,11 @@ class Entry extends Extension\AbstractEntry
 
         $list = $this->getXpath()->evaluate($this->getXpathPrefix() . '//dc11:subject');
 
-        if (! $list->length) {
+        if (! $list instanceof DOMNodeList || ! $list->length) {
             $list = $this->getXpath()->evaluate($this->getXpathPrefix() . '//dc10:subject');
         }
 
-        if ($list->length) {
+        if ($list instanceof DOMNodeList && $list->length) {
             $categoryCollection = new Collection\Category();
             foreach ($list as $category) {
                 $categoryCollection[] = [

--- a/src/Reader/Extension/DublinCore/Feed.php
+++ b/src/Reader/Extension/DublinCore/Feed.php
@@ -1,17 +1,15 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Reader\Extension\DublinCore;
 
 use DateTime;
+use DOMNodeList;
 use Laminas\Feed\Reader;
 use Laminas\Feed\Reader\Collection;
 use Laminas\Feed\Reader\Extension;
+
+use function array_key_exists;
+use function is_string;
 
 class Feed extends Extension\AbstractFeed
 {
@@ -25,11 +23,11 @@ class Feed extends Extension\AbstractFeed
     {
         $authors = $this->getAuthors();
 
-        if (isset($authors[$index])) {
+        if (isset($authors[$index]) && is_string($authors[$index])) {
             return $authors[$index];
         }
 
-        return;
+        return null;
     }
 
     /**
@@ -239,11 +237,11 @@ class Feed extends Extension\AbstractFeed
 
         $list = $this->getXpath()->evaluate($this->getXpathPrefix() . '//dc11:subject');
 
-        if (! $list->length) {
+        if (! $list instanceof DOMNodeList || ! $list->length) {
             $list = $this->getXpath()->evaluate($this->getXpathPrefix() . '//dc10:subject');
         }
 
-        if ($list->length) {
+        if ($list instanceof DOMNodeList && $list->length) {
             $categoryCollection = new Collection\Category();
             foreach ($list as $category) {
                 $categoryCollection[] = [

--- a/src/Reader/Extension/GooglePlayPodcast/Entry.php
+++ b/src/Reader/Extension/GooglePlayPodcast/Entry.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Reader\Extension\GooglePlayPodcast;
 
 use Laminas\Feed\Reader\Extension;

--- a/src/Reader/Extension/GooglePlayPodcast/Feed.php
+++ b/src/Reader/Extension/GooglePlayPodcast/Feed.php
@@ -68,13 +68,9 @@ class Feed extends Extension\AbstractFeed
 
         if ($categoryList->length > 0) {
             foreach ($categoryList as $node) {
-                /** @psalm-suppress UnusedVariable */
-                $children = null;
+                $children = [];
 
                 if ($node->childNodes->length > 0) {
-                    /** @psalm-suppress UnusedVariable */
-                    $children = [];
-
                     foreach ($node->childNodes as $childNode) {
                         if (! $childNode instanceof DOMText) {
                             $children[$childNode->getAttribute('text')] = null;
@@ -82,7 +78,7 @@ class Feed extends Extension\AbstractFeed
                     }
                 }
 
-                $categories[$node->getAttribute('text')] = $children;
+                $categories[$node->getAttribute('text')] = $children === [] ? null : $children;
             }
         }
 

--- a/src/Reader/Extension/GooglePlayPodcast/Feed.php
+++ b/src/Reader/Extension/GooglePlayPodcast/Feed.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Reader\Extension\GooglePlayPodcast;
 
 use DOMText;
@@ -74,9 +68,11 @@ class Feed extends Extension\AbstractFeed
 
         if ($categoryList->length > 0) {
             foreach ($categoryList as $node) {
+                /** @psalm-suppress UnusedVariable */
                 $children = null;
 
                 if ($node->childNodes->length > 0) {
+                    /** @psalm-suppress UnusedVariable */
                     $children = [];
 
                     foreach ($node->childNodes as $childNode) {

--- a/src/Reader/Extension/Podcast/Entry.php
+++ b/src/Reader/Extension/Podcast/Entry.php
@@ -1,14 +1,12 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Reader\Extension\Podcast;
 
 use Laminas\Feed\Reader\Extension;
+
+use function trigger_error;
+
+use const E_USER_DEPRECATED;
 
 class Entry extends Extension\AbstractEntry
 {
@@ -105,6 +103,7 @@ class Entry extends Extension\AbstractEntry
      *
      * @deprecated since 2.10.0; itunes:keywords is no longer part of the
      *     iTunes podcast RSS specification.
+     *
      * @return string
      */
     public function getKeywords()
@@ -112,7 +111,7 @@ class Entry extends Extension\AbstractEntry
         trigger_error(
             'itunes:keywords has been deprecated in the iTunes podcast RSS specification,'
             . ' and should not be relied on.',
-            \E_USER_DEPRECATED
+            E_USER_DEPRECATED
         );
 
         if (isset($this->data['keywords'])) {

--- a/src/Reader/Extension/Podcast/Feed.php
+++ b/src/Reader/Extension/Podcast/Feed.php
@@ -1,15 +1,13 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Reader\Extension\Podcast;
 
 use DOMText;
 use Laminas\Feed\Reader\Extension;
+
+use function trigger_error;
+
+use const E_USER_DEPRECATED;
 
 class Feed extends Extension\AbstractFeed
 {
@@ -74,9 +72,11 @@ class Feed extends Extension\AbstractFeed
 
         if ($categoryList->length > 0) {
             foreach ($categoryList as $node) {
+                /** @psalm-suppress UnusedVariable */
                 $children = null;
 
                 if ($node->childNodes->length > 0) {
+                    /** @psalm-suppress UnusedVariable */
                     $children = [];
 
                     foreach ($node->childNodes as $childNode) {
@@ -148,6 +148,7 @@ class Feed extends Extension\AbstractFeed
      *
      * @deprecated since 2.10.0; itunes:keywords is no longer part of the
      *     iTunes podcast RSS specification.
+     *
      * @return string
      */
     public function getKeywords()
@@ -155,7 +156,7 @@ class Feed extends Extension\AbstractFeed
         trigger_error(
             'itunes:keywords has been deprecated in the iTunes podcast RSS specification,'
             . ' and should not be relied on.',
-            \E_USER_DEPRECATED
+            E_USER_DEPRECATED
         );
 
         if (isset($this->data['keywords'])) {

--- a/src/Reader/Extension/Podcast/Feed.php
+++ b/src/Reader/Extension/Podcast/Feed.php
@@ -72,13 +72,9 @@ class Feed extends Extension\AbstractFeed
 
         if ($categoryList->length > 0) {
             foreach ($categoryList as $node) {
-                /** @psalm-suppress UnusedVariable */
-                $children = null;
+                $children = [];
 
                 if ($node->childNodes->length > 0) {
-                    /** @psalm-suppress UnusedVariable */
-                    $children = [];
-
                     foreach ($node->childNodes as $childNode) {
                         if (! $childNode instanceof DOMText) {
                             $children[$childNode->getAttribute('text')] = null;
@@ -86,7 +82,7 @@ class Feed extends Extension\AbstractFeed
                     }
                 }
 
-                $categories[$node->getAttribute('text')] = $children;
+                $categories[$node->getAttribute('text')] = $children === [] ? null : $children;
             }
         }
 

--- a/src/Reader/Extension/PodcastIndex/Entry.php
+++ b/src/Reader/Extension/PodcastIndex/Entry.php
@@ -1,15 +1,13 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Reader\Extension\PodcastIndex;
 
+use DOMElement;
+use DOMNodeList;
 use Laminas\Feed\Reader\Extension;
 use stdClass;
+
+use function array_key_exists;
 
 /**
  * Describes PodcastIndex data of an entry in a RSS Feed
@@ -31,12 +29,14 @@ class Entry extends Extension\AbstractEntry
 
         $nodeList = $this->xpath->query($this->getXpathPrefix() . '/podcast:transcript');
 
-        if ($nodeList->length > 0) {
+        if ($nodeList instanceof DOMNodeList && $nodeList->length > 0) {
+            /** @var DOMElement $node */
+            $node                 = $nodeList->item(0);
             $transcript           = new stdClass();
-            $transcript->url      = $nodeList->item(0)->getAttribute('url');
-            $transcript->type     = $nodeList->item(0)->getAttribute('type');
-            $transcript->language = $nodeList->item(0)->getAttribute('language');
-            $transcript->rel      = $nodeList->item(0)->getAttribute('rel');
+            $transcript->url      = $node->getAttribute('url');
+            $transcript->type     = $node->getAttribute('type');
+            $transcript->language = $node->getAttribute('language');
+            $transcript->rel      = $node->getAttribute('rel');
         }
 
         $this->data['transcript'] = $transcript;
@@ -59,10 +59,12 @@ class Entry extends Extension\AbstractEntry
 
         $nodeList = $this->xpath->query($this->getXpathPrefix() . '/podcast:chapters');
 
-        if ($nodeList->length > 0) {
+        if ($nodeList instanceof DOMNodeList && $nodeList->length > 0) {
+            /** @var DOMElement $node */
+            $node           = $nodeList->item(0);
             $chapters       = new stdClass();
-            $chapters->url  = $nodeList->item(0)->getAttribute('url');
-            $chapters->type = $nodeList->item(0)->getAttribute('type');
+            $chapters->url  = $node->getAttribute('url');
+            $chapters->type = $node->getAttribute('type');
         }
 
         $this->data['chapters'] = $chapters;
@@ -88,7 +90,7 @@ class Entry extends Extension\AbstractEntry
 
         if ($nodeList->length > 0) {
             foreach ($nodeList as $node) {
-                /** @var \DOMElement $node */
+                /** @var DOMElement $node */
                 $soundbite            = new stdClass();
                 $soundbite->title     = $node->nodeValue;
                 $soundbite->startTime = $node->getAttribute('startTime');

--- a/src/Reader/Extension/PodcastIndex/Feed.php
+++ b/src/Reader/Extension/PodcastIndex/Feed.php
@@ -1,15 +1,11 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Reader\Extension\PodcastIndex;
 
 use Laminas\Feed\Reader\Extension;
 use stdClass;
+
+use function array_key_exists;
 
 /**
  * Describes PodcastIndex data of a RSS Feed

--- a/src/Reader/Extension/Slash/Entry.php
+++ b/src/Reader/Extension/Slash/Entry.php
@@ -1,14 +1,11 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Reader\Extension\Slash;
 
 use Laminas\Feed\Reader\Extension;
+
+use function array_key_exists;
+use function explode;
 
 class Entry extends Extension\AbstractEntry
 {

--- a/src/Reader/Extension/Syndication/Feed.php
+++ b/src/Reader/Extension/Syndication/Feed.php
@@ -1,16 +1,12 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Reader\Extension\Syndication;
 
 use DateTime;
 use Laminas\Feed\Reader;
 use Laminas\Feed\Reader\Extension;
+
+use function array_key_exists;
 
 class Feed extends Extension\AbstractFeed
 {

--- a/src/Reader/Extension/Thread/Entry.php
+++ b/src/Reader/Extension/Thread/Entry.php
@@ -1,14 +1,10 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Reader\Extension\Thread;
 
 use Laminas\Feed\Reader\Extension;
+
+use function array_key_exists;
 
 class Entry extends Extension\AbstractEntry
 {

--- a/src/Reader/Extension/WellFormedWeb/Entry.php
+++ b/src/Reader/Extension/WellFormedWeb/Entry.php
@@ -1,14 +1,10 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Reader\Extension\WellFormedWeb;
 
 use Laminas\Feed\Reader\Extension;
+
+use function array_key_exists;
 
 class Entry extends Extension\AbstractEntry
 {

--- a/src/Reader/ExtensionManager.php
+++ b/src/Reader/ExtensionManager.php
@@ -1,12 +1,10 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Reader;
+
+use function call_user_func_array;
+use function method_exists;
+use function sprintf;
 
 /**
  * Default implementation of ExtensionManagerInterface
@@ -15,13 +13,14 @@ namespace Laminas\Feed\Reader;
  */
 class ExtensionManager implements ExtensionManagerInterface
 {
+    /** @var ExtensionPluginManager */
     protected $pluginManager;
 
     /**
      * Seeds the extension manager with a plugin manager; if none provided,
      * creates an instance.
      */
-    public function __construct(ExtensionPluginManager $pluginManager = null)
+    public function __construct(?ExtensionPluginManager $pluginManager = null)
     {
         if (null === $pluginManager) {
             $pluginManager = new ExtensionPluginManager();
@@ -45,7 +44,7 @@ class ExtensionManager implements ExtensionManagerInterface
             throw new Exception\BadMethodCallException(sprintf(
                 'Method by name of %s does not exist in %s',
                 $method,
-                __CLASS__
+                self::class
             ));
         }
         return call_user_func_array([$this->pluginManager, $method], $args);
@@ -54,22 +53,22 @@ class ExtensionManager implements ExtensionManagerInterface
     /**
      * Get the named extension
      *
-     * @param  string $name
+     * @param  string $extension
      * @return Extension\AbstractEntry|Extension\AbstractFeed
      */
-    public function get($name)
+    public function get($extension)
     {
-        return $this->pluginManager->get($name);
+        return $this->pluginManager->get($extension);
     }
 
     /**
      * Do we have the named extension?
      *
-     * @param  string $name
+     * @param  string $extension
      * @return bool
      */
-    public function has($name)
+    public function has($extension)
     {
-        return $this->pluginManager->has($name);
+        return $this->pluginManager->has($extension);
     }
 }

--- a/src/Reader/ExtensionManagerInterface.php
+++ b/src/Reader/ExtensionManagerInterface.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Reader;
 
 interface ExtensionManagerInterface

--- a/src/Reader/ExtensionPluginManager.php
+++ b/src/Reader/ExtensionPluginManager.php
@@ -1,16 +1,17 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Reader;
 
 use Laminas\ServiceManager\AbstractPluginManager;
 use Laminas\ServiceManager\Exception\InvalidServiceException;
 use Laminas\ServiceManager\Factory\InvokableFactory;
+use Zend\Feed\Reader\Extension\Atom\Entry;
+use Zend\Feed\Reader\Extension\Atom\Feed;
+
+use function get_class;
+use function gettype;
+use function is_object;
+use function sprintf;
 
 /**
  * Plugin manager implementation for feed reader extensions based on the
@@ -24,37 +25,37 @@ class ExtensionPluginManager extends AbstractPluginManager implements ExtensionM
     /**
      * Aliases for default set of extension classes
      *
-     * @var array
+     * @var array<array-key, string>
      */
     protected $aliases = [
-        'atomentry'            => Extension\Atom\Entry::class,
-        'atomEntry'            => Extension\Atom\Entry::class,
-        'AtomEntry'            => Extension\Atom\Entry::class,
-        'Atom\Entry'           => Extension\Atom\Entry::class,
-        'atomfeed'             => Extension\Atom\Feed::class,
-        'atomFeed'             => Extension\Atom\Feed::class,
-        'AtomFeed'             => Extension\Atom\Feed::class,
-        'Atom\Feed'            => Extension\Atom\Feed::class,
-        'contententry'         => Extension\Content\Entry::class,
-        'contentEntry'         => Extension\Content\Entry::class,
-        'ContentEntry'         => Extension\Content\Entry::class,
-        'Content\Entry'        => Extension\Content\Entry::class,
-        'creativecommonsentry' => Extension\CreativeCommons\Entry::class,
-        'creativeCommonsEntry' => Extension\CreativeCommons\Entry::class,
-        'CreativeCommonsEntry' => Extension\CreativeCommons\Entry::class,
-        'CreativeCommons\Entry' => Extension\CreativeCommons\Entry::class,
-        'creativecommonsfeed'  => Extension\CreativeCommons\Feed::class,
-        'creativeCommonsFeed'  => Extension\CreativeCommons\Feed::class,
-        'CreativeCommonsFeed'  => Extension\CreativeCommons\Feed::class,
-        'CreativeCommons\Feed' => Extension\CreativeCommons\Feed::class,
-        'dublincoreentry'      => Extension\DublinCore\Entry::class,
-        'dublinCoreEntry'      => Extension\DublinCore\Entry::class,
-        'DublinCoreEntry'      => Extension\DublinCore\Entry::class,
-        'DublinCore\Entry'     => Extension\DublinCore\Entry::class,
-        'dublincorefeed'       => Extension\DublinCore\Feed::class,
-        'dublinCoreFeed'       => Extension\DublinCore\Feed::class,
-        'DublinCoreFeed'       => Extension\DublinCore\Feed::class,
-        'DublinCore\Feed'      => Extension\DublinCore\Feed::class,
+        'atomentry'               => Extension\Atom\Entry::class,
+        'atomEntry'               => Extension\Atom\Entry::class,
+        'AtomEntry'               => Extension\Atom\Entry::class,
+        'Atom\Entry'              => Extension\Atom\Entry::class,
+        'atomfeed'                => Extension\Atom\Feed::class,
+        'atomFeed'                => Extension\Atom\Feed::class,
+        'AtomFeed'                => Extension\Atom\Feed::class,
+        'Atom\Feed'               => Extension\Atom\Feed::class,
+        'contententry'            => Extension\Content\Entry::class,
+        'contentEntry'            => Extension\Content\Entry::class,
+        'ContentEntry'            => Extension\Content\Entry::class,
+        'Content\Entry'           => Extension\Content\Entry::class,
+        'creativecommonsentry'    => Extension\CreativeCommons\Entry::class,
+        'creativeCommonsEntry'    => Extension\CreativeCommons\Entry::class,
+        'CreativeCommonsEntry'    => Extension\CreativeCommons\Entry::class,
+        'CreativeCommons\Entry'   => Extension\CreativeCommons\Entry::class,
+        'creativecommonsfeed'     => Extension\CreativeCommons\Feed::class,
+        'creativeCommonsFeed'     => Extension\CreativeCommons\Feed::class,
+        'CreativeCommonsFeed'     => Extension\CreativeCommons\Feed::class,
+        'CreativeCommons\Feed'    => Extension\CreativeCommons\Feed::class,
+        'dublincoreentry'         => Extension\DublinCore\Entry::class,
+        'dublinCoreEntry'         => Extension\DublinCore\Entry::class,
+        'DublinCoreEntry'         => Extension\DublinCore\Entry::class,
+        'DublinCore\Entry'        => Extension\DublinCore\Entry::class,
+        'dublincorefeed'          => Extension\DublinCore\Feed::class,
+        'dublinCoreFeed'          => Extension\DublinCore\Feed::class,
+        'DublinCoreFeed'          => Extension\DublinCore\Feed::class,
+        'DublinCore\Feed'         => Extension\DublinCore\Feed::class,
         'googleplaypodcastentry'  => Extension\GooglePlayPodcast\Entry::class,
         'googlePlayPodcastEntry'  => Extension\GooglePlayPodcast\Entry::class,
         'GooglePlayPodcastEntry'  => Extension\GooglePlayPodcast\Entry::class,
@@ -63,117 +64,117 @@ class ExtensionPluginManager extends AbstractPluginManager implements ExtensionM
         'googlePlayPodcastFeed'   => Extension\GooglePlayPodcast\Feed::class,
         'GooglePlayPodcastFeed'   => Extension\GooglePlayPodcast\Feed::class,
         'GooglePlayPodcast\Feed'  => Extension\GooglePlayPodcast\Feed::class,
-        'podcastentry'         => Extension\Podcast\Entry::class,
-        'podcastEntry'         => Extension\Podcast\Entry::class,
-        'PodcastEntry'         => Extension\Podcast\Entry::class,
-        'Podcast\Entry'        => Extension\Podcast\Entry::class,
-        'podcastfeed'          => Extension\Podcast\Feed::class,
-        'podcastFeed'          => Extension\Podcast\Feed::class,
-        'PodcastFeed'          => Extension\Podcast\Feed::class,
-        'Podcast\Feed'         => Extension\Podcast\Feed::class,
-        'podcastindexentry'    => Extension\PodcastIndex\Entry::class,
-        'podcastIndexEntry'    => Extension\PodcastIndex\Entry::class,
-        'PodcastIndexEntry'    => Extension\PodcastIndex\Entry::class,
-        'PodcastIndex\Entry'   => Extension\PodcastIndex\Entry::class,
-        'podcastindexfeed'     => Extension\PodcastIndex\Feed::class,
-        'podcastIndexFeed'     => Extension\PodcastIndex\Feed::class,
-        'PodcastIndexFeed'     => Extension\PodcastIndex\Feed::class,
-        'PodcastIndex\Feed'    => Extension\PodcastIndex\Feed::class,
-        'slashentry'           => Extension\Slash\Entry::class,
-        'slashEntry'           => Extension\Slash\Entry::class,
-        'SlashEntry'           => Extension\Slash\Entry::class,
-        'Slash\Entry'          => Extension\Slash\Entry::class,
-        'syndicationfeed'      => Extension\Syndication\Feed::class,
-        'syndicationFeed'      => Extension\Syndication\Feed::class,
-        'SyndicationFeed'      => Extension\Syndication\Feed::class,
-        'Syndication\Feed'     => Extension\Syndication\Feed::class,
-        'threadentry'          => Extension\Thread\Entry::class,
-        'threadEntry'          => Extension\Thread\Entry::class,
-        'ThreadEntry'          => Extension\Thread\Entry::class,
-        'Thread\Entry'         => Extension\Thread\Entry::class,
-        'wellformedwebentry'   => Extension\WellFormedWeb\Entry::class,
-        'wellFormedWebEntry'   => Extension\WellFormedWeb\Entry::class,
-        'WellFormedWebEntry'   => Extension\WellFormedWeb\Entry::class,
-        'WellFormedWeb\Entry'  => Extension\WellFormedWeb\Entry::class,
+        'podcastentry'            => Extension\Podcast\Entry::class,
+        'podcastEntry'            => Extension\Podcast\Entry::class,
+        'PodcastEntry'            => Extension\Podcast\Entry::class,
+        'Podcast\Entry'           => Extension\Podcast\Entry::class,
+        'podcastfeed'             => Extension\Podcast\Feed::class,
+        'podcastFeed'             => Extension\Podcast\Feed::class,
+        'PodcastFeed'             => Extension\Podcast\Feed::class,
+        'Podcast\Feed'            => Extension\Podcast\Feed::class,
+        'podcastindexentry'       => Extension\PodcastIndex\Entry::class,
+        'podcastIndexEntry'       => Extension\PodcastIndex\Entry::class,
+        'PodcastIndexEntry'       => Extension\PodcastIndex\Entry::class,
+        'PodcastIndex\Entry'      => Extension\PodcastIndex\Entry::class,
+        'podcastindexfeed'        => Extension\PodcastIndex\Feed::class,
+        'podcastIndexFeed'        => Extension\PodcastIndex\Feed::class,
+        'PodcastIndexFeed'        => Extension\PodcastIndex\Feed::class,
+        'PodcastIndex\Feed'       => Extension\PodcastIndex\Feed::class,
+        'slashentry'              => Extension\Slash\Entry::class,
+        'slashEntry'              => Extension\Slash\Entry::class,
+        'SlashEntry'              => Extension\Slash\Entry::class,
+        'Slash\Entry'             => Extension\Slash\Entry::class,
+        'syndicationfeed'         => Extension\Syndication\Feed::class,
+        'syndicationFeed'         => Extension\Syndication\Feed::class,
+        'SyndicationFeed'         => Extension\Syndication\Feed::class,
+        'Syndication\Feed'        => Extension\Syndication\Feed::class,
+        'threadentry'             => Extension\Thread\Entry::class,
+        'threadEntry'             => Extension\Thread\Entry::class,
+        'ThreadEntry'             => Extension\Thread\Entry::class,
+        'Thread\Entry'            => Extension\Thread\Entry::class,
+        'wellformedwebentry'      => Extension\WellFormedWeb\Entry::class,
+        'wellFormedWebEntry'      => Extension\WellFormedWeb\Entry::class,
+        'WellFormedWebEntry'      => Extension\WellFormedWeb\Entry::class,
+        'WellFormedWeb\Entry'     => Extension\WellFormedWeb\Entry::class,
 
         // Legacy Zend Framework aliases
-        \Zend\Feed\Reader\Extension\Atom\Entry::class => Extension\Atom\Entry::class,
-        \Zend\Feed\Reader\Extension\Atom\Feed::class => Extension\Atom\Feed::class,
-        \Zend\Feed\Reader\Extension\Content\Entry::class => Extension\Content\Entry::class,
-        \Zend\Feed\Reader\Extension\CreativeCommons\Entry::class => Extension\CreativeCommons\Entry::class,
-        \Zend\Feed\Reader\Extension\CreativeCommons\Feed::class => Extension\CreativeCommons\Feed::class,
-        \Zend\Feed\Reader\Extension\DublinCore\Entry::class => Extension\DublinCore\Entry::class,
-        \Zend\Feed\Reader\Extension\DublinCore\Feed::class => Extension\DublinCore\Feed::class,
+        Entry::class                                               => Extension\Atom\Entry::class,
+        Feed::class                                                => Extension\Atom\Feed::class,
+        \Zend\Feed\Reader\Extension\Content\Entry::class           => Extension\Content\Entry::class,
+        \Zend\Feed\Reader\Extension\CreativeCommons\Entry::class   => Extension\CreativeCommons\Entry::class,
+        \Zend\Feed\Reader\Extension\CreativeCommons\Feed::class    => Extension\CreativeCommons\Feed::class,
+        \Zend\Feed\Reader\Extension\DublinCore\Entry::class        => Extension\DublinCore\Entry::class,
+        \Zend\Feed\Reader\Extension\DublinCore\Feed::class         => Extension\DublinCore\Feed::class,
         \Zend\Feed\Reader\Extension\GooglePlayPodcast\Entry::class => Extension\GooglePlayPodcast\Entry::class,
-        \Zend\Feed\Reader\Extension\GooglePlayPodcast\Feed::class => Extension\GooglePlayPodcast\Feed::class,
-        \Zend\Feed\Reader\Extension\Podcast\Entry::class => Extension\Podcast\Entry::class,
-        \Zend\Feed\Reader\Extension\Podcast\Feed::class => Extension\Podcast\Feed::class,
-        \Zend\Feed\Reader\Extension\Slash\Entry::class => Extension\Slash\Entry::class,
-        \Zend\Feed\Reader\Extension\Syndication\Feed::class => Extension\Syndication\Feed::class,
-        \Zend\Feed\Reader\Extension\Thread\Entry::class => Extension\Thread\Entry::class,
-        \Zend\Feed\Reader\Extension\WellFormedWeb\Entry::class => Extension\WellFormedWeb\Entry::class,
+        \Zend\Feed\Reader\Extension\GooglePlayPodcast\Feed::class  => Extension\GooglePlayPodcast\Feed::class,
+        \Zend\Feed\Reader\Extension\Podcast\Entry::class           => Extension\Podcast\Entry::class,
+        \Zend\Feed\Reader\Extension\Podcast\Feed::class            => Extension\Podcast\Feed::class,
+        \Zend\Feed\Reader\Extension\Slash\Entry::class             => Extension\Slash\Entry::class,
+        \Zend\Feed\Reader\Extension\Syndication\Feed::class        => Extension\Syndication\Feed::class,
+        \Zend\Feed\Reader\Extension\Thread\Entry::class            => Extension\Thread\Entry::class,
+        \Zend\Feed\Reader\Extension\WellFormedWeb\Entry::class     => Extension\WellFormedWeb\Entry::class,
 
         // v2 normalized FQCNs
-        'zendfeedreaderextensionatomentry' => Extension\Atom\Entry::class,
-        'zendfeedreaderextensionatomfeed' => Extension\Atom\Feed::class,
-        'zendfeedreaderextensioncontententry' => Extension\Content\Entry::class,
-        'zendfeedreaderextensioncreativecommonsentry' => Extension\CreativeCommons\Entry::class,
-        'zendfeedreaderextensioncreativecommonsfeed' => Extension\CreativeCommons\Feed::class,
-        'zendfeedreaderextensiondublincoreentry' => Extension\DublinCore\Entry::class,
-        'zendfeedreaderextensiondublincorefeed' => Extension\DublinCore\Feed::class,
+        'zendfeedreaderextensionatomentry'              => Extension\Atom\Entry::class,
+        'zendfeedreaderextensionatomfeed'               => Extension\Atom\Feed::class,
+        'zendfeedreaderextensioncontententry'           => Extension\Content\Entry::class,
+        'zendfeedreaderextensioncreativecommonsentry'   => Extension\CreativeCommons\Entry::class,
+        'zendfeedreaderextensioncreativecommonsfeed'    => Extension\CreativeCommons\Feed::class,
+        'zendfeedreaderextensiondublincoreentry'        => Extension\DublinCore\Entry::class,
+        'zendfeedreaderextensiondublincorefeed'         => Extension\DublinCore\Feed::class,
         'zendfeedreaderextensiongoogleplaypodcastentry' => Extension\GooglePlayPodcast\Entry::class,
-        'zendfeedreaderextensiongoogleplaypodcastfeed' => Extension\GooglePlayPodcast\Feed::class,
-        'zendfeedreaderextensionpodcastentry' => Extension\Podcast\Entry::class,
-        'zendfeedreaderextensionpodcastfeed' => Extension\Podcast\Feed::class,
-        'zendfeedreaderextensionslashentry' => Extension\Slash\Entry::class,
-        'zendfeedreaderextensionsyndicationfeed' => Extension\Syndication\Feed::class,
-        'zendfeedreaderextensionthreadentry' => Extension\Thread\Entry::class,
-        'zendfeedreaderextensionwellformedwebentry' => Extension\WellFormedWeb\Entry::class,
+        'zendfeedreaderextensiongoogleplaypodcastfeed'  => Extension\GooglePlayPodcast\Feed::class,
+        'zendfeedreaderextensionpodcastentry'           => Extension\Podcast\Entry::class,
+        'zendfeedreaderextensionpodcastfeed'            => Extension\Podcast\Feed::class,
+        'zendfeedreaderextensionslashentry'             => Extension\Slash\Entry::class,
+        'zendfeedreaderextensionsyndicationfeed'        => Extension\Syndication\Feed::class,
+        'zendfeedreaderextensionthreadentry'            => Extension\Thread\Entry::class,
+        'zendfeedreaderextensionwellformedwebentry'     => Extension\WellFormedWeb\Entry::class,
     ];
 
     /**
      * Factories for default set of extension classes
      *
-     * @var array
+     * @var array<array-key, callable|string>
      */
     protected $factories = [
-        Extension\Atom\Entry::class            => InvokableFactory::class,
-        Extension\Atom\Feed::class             => InvokableFactory::class,
-        Extension\Content\Entry::class         => InvokableFactory::class,
-        Extension\CreativeCommons\Entry::class => InvokableFactory::class,
-        Extension\CreativeCommons\Feed::class  => InvokableFactory::class,
-        Extension\DublinCore\Entry::class      => InvokableFactory::class,
-        Extension\DublinCore\Feed::class       => InvokableFactory::class,
+        Extension\Atom\Entry::class              => InvokableFactory::class,
+        Extension\Atom\Feed::class               => InvokableFactory::class,
+        Extension\Content\Entry::class           => InvokableFactory::class,
+        Extension\CreativeCommons\Entry::class   => InvokableFactory::class,
+        Extension\CreativeCommons\Feed::class    => InvokableFactory::class,
+        Extension\DublinCore\Entry::class        => InvokableFactory::class,
+        Extension\DublinCore\Feed::class         => InvokableFactory::class,
         Extension\GooglePlayPodcast\Entry::class => InvokableFactory::class,
         Extension\GooglePlayPodcast\Feed::class  => InvokableFactory::class,
-        Extension\Podcast\Entry::class         => InvokableFactory::class,
-        Extension\Podcast\Feed::class          => InvokableFactory::class,
-        Extension\PodcastIndex\Entry::class    => InvokableFactory::class,
-        Extension\PodcastIndex\Feed::class     => InvokableFactory::class,
-        Extension\Slash\Entry::class           => InvokableFactory::class,
-        Extension\Syndication\Feed::class      => InvokableFactory::class,
-        Extension\Thread\Entry::class          => InvokableFactory::class,
-        Extension\WellFormedWeb\Entry::class   => InvokableFactory::class,
+        Extension\Podcast\Entry::class           => InvokableFactory::class,
+        Extension\Podcast\Feed::class            => InvokableFactory::class,
+        Extension\PodcastIndex\Entry::class      => InvokableFactory::class,
+        Extension\PodcastIndex\Feed::class       => InvokableFactory::class,
+        Extension\Slash\Entry::class             => InvokableFactory::class,
+        Extension\Syndication\Feed::class        => InvokableFactory::class,
+        Extension\Thread\Entry::class            => InvokableFactory::class,
+        Extension\WellFormedWeb\Entry::class     => InvokableFactory::class,
         // Legacy (v2) due to alias resolution; canonical form of resolved
         // alias is used to look up the factory, while the non-normalized
         // resolved alias is used as the requested name passed to the factory.
-        'laminasfeedreaderextensionatomentry'            => InvokableFactory::class,
-        'laminasfeedreaderextensionatomfeed'             => InvokableFactory::class,
-        'laminasfeedreaderextensioncontententry'         => InvokableFactory::class,
-        'laminasfeedreaderextensioncreativecommonsentry' => InvokableFactory::class,
-        'laminasfeedreaderextensioncreativecommonsfeed'  => InvokableFactory::class,
-        'laminasfeedreaderextensiondublincoreentry'      => InvokableFactory::class,
-        'laminasfeedreaderextensiondublincorefeed'       => InvokableFactory::class,
+        'laminasfeedreaderextensionatomentry'              => InvokableFactory::class,
+        'laminasfeedreaderextensionatomfeed'               => InvokableFactory::class,
+        'laminasfeedreaderextensioncontententry'           => InvokableFactory::class,
+        'laminasfeedreaderextensioncreativecommonsentry'   => InvokableFactory::class,
+        'laminasfeedreaderextensioncreativecommonsfeed'    => InvokableFactory::class,
+        'laminasfeedreaderextensiondublincoreentry'        => InvokableFactory::class,
+        'laminasfeedreaderextensiondublincorefeed'         => InvokableFactory::class,
         'laminasfeedreaderextensiongoogleplaypodcastentry' => InvokableFactory::class,
         'laminasfeedreaderextensiongoogleplaypodcastfeed'  => InvokableFactory::class,
-        'laminasfeedreaderextensionpodcastentry'         => InvokableFactory::class,
-        'laminasfeedreaderextensionpodcastfeed'          => InvokableFactory::class,
-        'laminasfeedreaderextensionpodcastindexentry'    => InvokableFactory::class,
-        'laminasfeedreaderextensionpodcastindexfeed'     => InvokableFactory::class,
-        'laminasfeedreaderextensionslashentry'           => InvokableFactory::class,
-        'laminasfeedreaderextensionsyndicationfeed'      => InvokableFactory::class,
-        'laminasfeedreaderextensionthreadentry'          => InvokableFactory::class,
-        'laminasfeedreaderextensionwellformedwebentry'   => InvokableFactory::class,
+        'laminasfeedreaderextensionpodcastentry'           => InvokableFactory::class,
+        'laminasfeedreaderextensionpodcastfeed'            => InvokableFactory::class,
+        'laminasfeedreaderextensionpodcastindexentry'      => InvokableFactory::class,
+        'laminasfeedreaderextensionpodcastindexfeed'       => InvokableFactory::class,
+        'laminasfeedreaderextensionslashentry'             => InvokableFactory::class,
+        'laminasfeedreaderextensionsyndicationfeed'        => InvokableFactory::class,
+        'laminasfeedreaderextensionthreadentry'            => InvokableFactory::class,
+        'laminasfeedreaderextensionwellformedwebentry'     => InvokableFactory::class,
     ];
 
     /**
@@ -195,14 +196,15 @@ class ExtensionPluginManager extends AbstractPluginManager implements ExtensionM
      *
      * Checks that the extension loaded is of a valid type.
      *
-     * @param  mixed $plugin
+     * @param  mixed $instance
      * @return void
-     * @throws Exception\InvalidArgumentException if invalid
+     * @throws Exception\InvalidArgumentException If invalid.
      */
-    public function validate($plugin)
+    public function validate($instance)
     {
-        if ($plugin instanceof Extension\AbstractEntry
-            || $plugin instanceof Extension\AbstractFeed
+        if (
+            $instance instanceof Extension\AbstractEntry
+            || $instance instanceof Extension\AbstractFeed
         ) {
             // we're okay
             return;
@@ -211,7 +213,7 @@ class ExtensionPluginManager extends AbstractPluginManager implements ExtensionM
         throw new InvalidServiceException(sprintf(
             'Plugin of type %s is invalid; must implement %s\Extension\AbstractFeed '
             . 'or %s\Extension\AbstractEntry',
-            is_object($plugin) ? get_class($plugin) : gettype($plugin),
+            is_object($instance) ? get_class($instance) : gettype($instance),
             __NAMESPACE__,
             __NAMESPACE__
         ));
@@ -222,7 +224,7 @@ class ExtensionPluginManager extends AbstractPluginManager implements ExtensionM
      *
      * @param  mixed $plugin
      * @return void
-     * @throws Exception\InvalidArgumentException if invalid
+     * @throws Exception\InvalidArgumentException If invalid.
      */
     public function validatePlugin($plugin)
     {

--- a/src/Reader/Feed/AbstractFeed.php
+++ b/src/Reader/Feed/AbstractFeed.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Reader\Feed;
 
 use DOMDocument;
@@ -13,6 +7,14 @@ use DOMElement;
 use DOMXPath;
 use Laminas\Feed\Reader;
 use Laminas\Feed\Reader\Exception;
+
+use function array_key_exists;
+use function call_user_func_array;
+use function count;
+use function in_array;
+use function method_exists;
+use function sprintf;
+use function strpos;
 
 abstract class AbstractFeed implements FeedInterface
 {
@@ -237,11 +239,17 @@ abstract class AbstractFeed implements FeedInterface
         return 0 <= $this->entriesKey && $this->entriesKey < $this->count();
     }
 
+    /** @return array */
     public function getExtensions()
     {
         return $this->extensions;
     }
 
+    /**
+     * @param string $method
+     * @param mixed[] $args
+     * @return mixed
+     */
     public function __call($method, $args)
     {
         foreach ($this->extensions as $extension) {

--- a/src/Reader/Feed/AbstractFeed.php
+++ b/src/Reader/Feed/AbstractFeed.php
@@ -7,6 +7,8 @@ use DOMElement;
 use DOMXPath;
 use Laminas\Feed\Reader;
 use Laminas\Feed\Reader\Exception;
+// phpcs:ignore SlevomatCodingStandard.Namespaces.UnusedUses.UnusedUse
+use ReturnTypeWillChange;
 
 use function array_key_exists;
 use function call_user_func_array;
@@ -116,6 +118,7 @@ abstract class AbstractFeed implements FeedInterface
      *
      * @return int
      */
+    #[ReturnTypeWillChange]
     public function count()
     {
         return count($this->entries);
@@ -126,6 +129,7 @@ abstract class AbstractFeed implements FeedInterface
      *
      * @return Reader\Entry\EntryInterface
      */
+    #[ReturnTypeWillChange]
     public function current()
     {
         if (0 === strpos($this->getType(), 'rss')) {
@@ -208,6 +212,7 @@ abstract class AbstractFeed implements FeedInterface
      *
      * @return int
      */
+    #[ReturnTypeWillChange]
     public function key()
     {
         return $this->entriesKey;
@@ -216,6 +221,7 @@ abstract class AbstractFeed implements FeedInterface
     /**
      * Move the feed pointer forward
      */
+    #[ReturnTypeWillChange]
     public function next()
     {
         ++$this->entriesKey;
@@ -224,6 +230,7 @@ abstract class AbstractFeed implements FeedInterface
     /**
      * Reset the pointer in the feed object
      */
+    #[ReturnTypeWillChange]
     public function rewind()
     {
         $this->entriesKey = 0;
@@ -234,6 +241,7 @@ abstract class AbstractFeed implements FeedInterface
      *
      * @return bool
      */
+    #[ReturnTypeWillChange]
     public function valid()
     {
         return 0 <= $this->entriesKey && $this->entriesKey < $this->count();

--- a/src/Reader/Feed/Atom.php
+++ b/src/Reader/Feed/Atom.php
@@ -1,16 +1,14 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Reader\Feed;
 
 use DateTime;
 use DOMDocument;
 use Laminas\Feed\Reader;
+
+use function array_key_exists;
+use function count;
+use function is_array;
 
 class Atom extends AbstractFeed
 {
@@ -43,17 +41,15 @@ class Atom extends AbstractFeed
      * Get a single author
      *
      * @param  int $index
-     * @return null|string
+     * @return null|array<string, string>
      */
     public function getAuthor($index = 0)
     {
         $authors = $this->getAuthors();
 
-        if (isset($authors[$index])) {
-            return $authors[$index];
-        }
-
-        return;
+        return isset($authors[$index]) && is_array($authors[$index])
+            ? $authors[$index]
+            : null;
     }
 
     /**
@@ -147,7 +143,6 @@ class Atom extends AbstractFeed
      */
     public function getLastBuildDate()
     {
-        return;
     }
 
     /**
@@ -375,7 +370,8 @@ class Atom extends AbstractFeed
      */
     protected function indexEntries()
     {
-        if ($this->getType() === Reader\Reader::TYPE_ATOM_10
+        if (
+            $this->getType() === Reader\Reader::TYPE_ATOM_10
             || $this->getType() === Reader\Reader::TYPE_ATOM_03
         ) {
             $entries = $this->xpath->evaluate('//atom:entry');

--- a/src/Reader/Feed/Atom/Source.php
+++ b/src/Reader/Feed/Atom/Source.php
@@ -1,17 +1,13 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Reader\Feed\Atom;
 
 use DOMElement;
 use DOMXPath;
 use Laminas\Feed\Reader;
 use Laminas\Feed\Reader\Feed;
+
+use function rtrim;
 
 class Source extends Feed\Atom
 {

--- a/src/Reader/Feed/FeedInterface.php
+++ b/src/Reader/Feed/FeedInterface.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Reader\Feed;
 
 use Countable;

--- a/src/Reader/Feed/Rss.php
+++ b/src/Reader/Feed/Rss.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Reader\Feed;
 
 use DateTime;
@@ -13,6 +7,14 @@ use DOMDocument;
 use Laminas\Feed\Reader;
 use Laminas\Feed\Reader\Collection;
 use Laminas\Feed\Reader\Exception;
+
+use function array_key_exists;
+use function array_unique;
+use function count;
+use function is_array;
+use function preg_match;
+use function strtotime;
+use function trim;
 
 class Rss extends AbstractFeed
 {
@@ -37,7 +39,8 @@ class Rss extends AbstractFeed
         $feed->setXpath($this->xpath);
         $this->extensions['Atom\Feed'] = $feed;
 
-        if ($this->getType() !== Reader\Reader::TYPE_RSS_10
+        if (
+            $this->getType() !== Reader\Reader::TYPE_RSS_10
             && $this->getType() !== Reader\Reader::TYPE_RSS_090
         ) {
             $xpathPrefix = '/rss/channel';
@@ -53,17 +56,15 @@ class Rss extends AbstractFeed
      * Get a single author
      *
      * @param  int $index
-     * @return null|string
+     * @return null|array<string, string>
      */
     public function getAuthor($index = 0)
     {
         $authors = $this->getAuthors();
 
-        if (isset($authors[$index])) {
-            return $authors[$index];
-        }
-
-        return;
+        return isset($authors[$index]) && is_array($authors[$index])
+            ? $authors[$index]
+            : null;
     }
 
     /**
@@ -91,7 +92,8 @@ class Rss extends AbstractFeed
          * Technically RSS doesn't specific author element use at the feed level
          * but it's supported on a "just in case" basis.
          */
-        if ($this->getType() !== Reader\Reader::TYPE_RSS_10
+        if (
+            $this->getType() !== Reader\Reader::TYPE_RSS_10
             && $this->getType() !== Reader\Reader::TYPE_RSS_090
         ) {
             $list = $this->xpath->query('//author');
@@ -143,7 +145,8 @@ class Rss extends AbstractFeed
 
         $copyright = null;
 
-        if ($this->getType() !== Reader\Reader::TYPE_RSS_10
+        if (
+            $this->getType() !== Reader\Reader::TYPE_RSS_10
             && $this->getType() !== Reader\Reader::TYPE_RSS_090
         ) {
             $copyright = $this->xpath->evaluate('string(/rss/channel/copyright)');
@@ -190,7 +193,8 @@ class Rss extends AbstractFeed
 
         $date = null;
 
-        if ($this->getType() !== Reader\Reader::TYPE_RSS_10
+        if (
+            $this->getType() !== Reader\Reader::TYPE_RSS_10
             && $this->getType() !== Reader\Reader::TYPE_RSS_090
         ) {
             $dateModified = $this->xpath->evaluate('string(/rss/channel/pubDate)');
@@ -257,7 +261,8 @@ class Rss extends AbstractFeed
 
         $date = null;
 
-        if ($this->getType() !== Reader\Reader::TYPE_RSS_10
+        if (
+            $this->getType() !== Reader\Reader::TYPE_RSS_10
             && $this->getType() !== Reader\Reader::TYPE_RSS_090
         ) {
             $lastBuildDate = $this->xpath->evaluate('string(/rss/channel/lastBuildDate)');
@@ -311,7 +316,8 @@ class Rss extends AbstractFeed
             return $this->data['description'];
         }
 
-        if ($this->getType() !== Reader\Reader::TYPE_RSS_10
+        if (
+            $this->getType() !== Reader\Reader::TYPE_RSS_10
             && $this->getType() !== Reader\Reader::TYPE_RSS_090
         ) {
             $description = $this->xpath->evaluate('string(/rss/channel/description)');
@@ -349,7 +355,8 @@ class Rss extends AbstractFeed
 
         $id = null;
 
-        if ($this->getType() !== Reader\Reader::TYPE_RSS_10
+        if (
+            $this->getType() !== Reader\Reader::TYPE_RSS_10
             && $this->getType() !== Reader\Reader::TYPE_RSS_090
         ) {
             $id = $this->xpath->evaluate('string(/rss/channel/guid)');
@@ -389,7 +396,8 @@ class Rss extends AbstractFeed
             return $this->data['image'];
         }
 
-        if ($this->getType() !== Reader\Reader::TYPE_RSS_10
+        if (
+            $this->getType() !== Reader\Reader::TYPE_RSS_10
             && $this->getType() !== Reader\Reader::TYPE_RSS_090
         ) {
             $list   = $this->xpath->query('/rss/channel/image');
@@ -446,7 +454,8 @@ class Rss extends AbstractFeed
 
         $language = null;
 
-        if ($this->getType() !== Reader\Reader::TYPE_RSS_10
+        if (
+            $this->getType() !== Reader\Reader::TYPE_RSS_10
             && $this->getType() !== Reader\Reader::TYPE_RSS_090
         ) {
             $language = $this->xpath->evaluate('string(/rss/channel/language)');
@@ -484,7 +493,8 @@ class Rss extends AbstractFeed
             return $this->data['link'];
         }
 
-        if ($this->getType() !== Reader\Reader::TYPE_RSS_10
+        if (
+            $this->getType() !== Reader\Reader::TYPE_RSS_10
             && $this->getType() !== Reader\Reader::TYPE_RSS_090
         ) {
             $link = $this->xpath->evaluate('string(/rss/channel/link)');
@@ -540,14 +550,16 @@ class Rss extends AbstractFeed
 
         $generator = null;
 
-        if ($this->getType() !== Reader\Reader::TYPE_RSS_10
+        if (
+            $this->getType() !== Reader\Reader::TYPE_RSS_10
             && $this->getType() !== Reader\Reader::TYPE_RSS_090
         ) {
             $generator = $this->xpath->evaluate('string(/rss/channel/generator)');
         }
 
         if (! $generator) {
-            if ($this->getType() !== Reader\Reader::TYPE_RSS_10
+            if (
+                $this->getType() !== Reader\Reader::TYPE_RSS_10
                 && $this->getType() !== Reader\Reader::TYPE_RSS_090
             ) {
                 $generator = $this->xpath->evaluate('string(/rss/channel/atom:generator)');
@@ -580,7 +592,8 @@ class Rss extends AbstractFeed
             return $this->data['title'];
         }
 
-        if ($this->getType() !== Reader\Reader::TYPE_RSS_10
+        if (
+            $this->getType() !== Reader\Reader::TYPE_RSS_10
             && $this->getType() !== Reader\Reader::TYPE_RSS_090
         ) {
             $title = $this->xpath->evaluate('string(/rss/channel/title)');
@@ -640,7 +653,8 @@ class Rss extends AbstractFeed
             return $this->data['categories'];
         }
 
-        if ($this->getType() !== Reader\Reader::TYPE_RSS_10
+        if (
+            $this->getType() !== Reader\Reader::TYPE_RSS_10
             && $this->getType() !== Reader\Reader::TYPE_RSS_090
         ) {
             $list = $this->xpath->query('/rss/channel//category');

--- a/src/Reader/FeedSet.php
+++ b/src/Reader/FeedSet.php
@@ -1,23 +1,30 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Reader;
 
 use ArrayObject;
+use DOMElement;
 use DOMNodeList;
 use Laminas\Feed\Uri;
 
+use function array_filter;
+use function array_pop;
+use function explode;
+use function implode;
+use function ltrim;
+use function sprintf;
+use function strtolower;
+use function trim;
+
 class FeedSet extends ArrayObject
 {
+    /** @var null|string */
     public $rss;
 
+    /** @var null|string */
     public $rdf;
 
+    /** @var null|string */
     public $atom;
 
     /**
@@ -38,16 +45,18 @@ class FeedSet extends ArrayObject
     public function addLinks(DOMNodeList $links, $uri)
     {
         foreach ($links as $link) {
-            if (strtolower($link->getAttribute('rel')) !== 'alternate'
+            /** @var DOMElement $link */
+            if (
+                strtolower($link->getAttribute('rel')) !== 'alternate'
                 || ! $link->getAttribute('type') || ! $link->getAttribute('href')
             ) {
                 continue;
             }
-            if (! isset($this->rss) && $link->getAttribute('type') === 'application/rss+xml') {
+            if (null === $this->rss && $link->getAttribute('type') === 'application/rss+xml') {
                 $this->rss = $this->absolutiseUri(trim($link->getAttribute('href')), $uri);
-            } elseif (! isset($this->atom) && $link->getAttribute('type') === 'application/atom+xml') {
+            } elseif (null === $this->atom && $link->getAttribute('type') === 'application/atom+xml') {
                 $this->atom = $this->absolutiseUri(trim($link->getAttribute('href')), $uri);
-            } elseif (! isset($this->rdf) && $link->getAttribute('type') === 'application/rdf+xml') {
+            } elseif (null === $this->rdf && $link->getAttribute('type') === 'application/rdf+xml') {
                 $this->rdf = $this->absolutiseUri(trim($link->getAttribute('href')), $uri);
             }
             $this[] = new static([

--- a/src/Reader/FeedSet.php
+++ b/src/Reader/FeedSet.php
@@ -6,6 +6,8 @@ use ArrayObject;
 use DOMElement;
 use DOMNodeList;
 use Laminas\Feed\Uri;
+// phpcs:ignore SlevomatCodingStandard.Namespaces.UnusedUses.UnusedUse
+use ReturnTypeWillChange;
 
 use function array_filter;
 use function array_pop;
@@ -167,6 +169,7 @@ class FeedSet extends ArrayObject
      * @param  string $offset
      * @return mixed
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         if ($offset === 'feed' && ! $this->offsetExists('feed')) {

--- a/src/Reader/Http/ClientInterface.php
+++ b/src/Reader/Http/ClientInterface.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Reader\Http;
 
 interface ClientInterface

--- a/src/Reader/Http/HeaderAwareClientInterface.php
+++ b/src/Reader/Http/HeaderAwareClientInterface.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Reader\Http;
 
 interface HeaderAwareClientInterface extends ClientInterface

--- a/src/Reader/Http/HeaderAwareResponseInterface.php
+++ b/src/Reader/Http/HeaderAwareResponseInterface.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Reader\Http;
 
 interface HeaderAwareResponseInterface extends ResponseInterface

--- a/src/Reader/Http/LaminasHttpClientDecorator.php
+++ b/src/Reader/Http/LaminasHttpClientDecorator.php
@@ -1,22 +1,23 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Reader\Http;
 
 use Laminas\Feed\Reader\Exception;
 use Laminas\Http\Client as LaminasHttpClient;
 use Laminas\Http\Headers;
 
+use function get_class;
+use function gettype;
+use function implode;
+use function is_array;
+use function is_numeric;
+use function is_object;
+use function is_string;
+use function sprintf;
+
 class LaminasHttpClientDecorator implements HeaderAwareClientInterface
 {
-    /**
-     * @var LaminasHttpClient
-     */
+    /** @var LaminasHttpClient */
     private $client;
 
     public function __construct(LaminasHttpClient $client)
@@ -65,7 +66,7 @@ class LaminasHttpClientDecorator implements HeaderAwareClientInterface
             if (! is_string($name) || is_numeric($name) || empty($name)) {
                 throw new Exception\InvalidArgumentException(sprintf(
                     'Header names provided to %s::get must be non-empty, non-numeric strings; received %s',
-                    __CLASS__,
+                    self::class,
                     $name
                 ));
             }
@@ -73,7 +74,7 @@ class LaminasHttpClientDecorator implements HeaderAwareClientInterface
             if (! is_array($values)) {
                 throw new Exception\InvalidArgumentException(sprintf(
                     'Header values provided to %s::get must be arrays of values; received %s',
-                    __CLASS__,
+                    self::class,
                     is_object($values) ? get_class($values) : gettype($values)
                 ));
             }
@@ -83,7 +84,7 @@ class LaminasHttpClientDecorator implements HeaderAwareClientInterface
                     throw new Exception\InvalidArgumentException(sprintf(
                         'Individual header values provided to %s::get must be strings or numbers; '
                         . 'received %s for header %s',
-                        __CLASS__,
+                        self::class,
                         is_object($value) ? get_class($value) : gettype($value),
                         $name
                     ));

--- a/src/Reader/Http/Psr7ResponseDecorator.php
+++ b/src/Reader/Http/Psr7ResponseDecorator.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Reader\Http;
 
 use Psr\Http\Message\ResponseInterface as Psr7ResponseInterface;
@@ -15,9 +9,7 @@ use Psr\Http\Message\ResponseInterface as Psr7ResponseInterface;
  */
 class Psr7ResponseDecorator implements HeaderAwareResponseInterface
 {
-    /**
-     * @var Psr7ResponseInterface
-     */
+    /** @var Psr7ResponseInterface */
     private $decoratedResponse;
 
     public function __construct(Psr7ResponseInterface $response)

--- a/src/Reader/Http/Response.php
+++ b/src/Reader/Http/Response.php
@@ -1,31 +1,29 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Reader\Http;
 
 use Laminas\Feed\Reader\Exception;
+
+use function get_class;
+use function gettype;
+use function intval;
+use function is_numeric;
+use function is_object;
 use function is_string;
+use function method_exists;
+use function sprintf;
+use function strtolower;
+use function trim;
 
 class Response implements HeaderAwareResponseInterface
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     private $body;
 
-    /**
-     * @var array
-     */
+    /** @var array */
     private $headers;
 
-    /**
-     * @var int
-     */
+    /** @var int */
     private $statusCode;
 
     /**
@@ -66,18 +64,15 @@ class Response implements HeaderAwareResponseInterface
     public function getHeaderLine($name, $default = null)
     {
         $normalizedName = strtolower($name);
-        return isset($this->headers[$normalizedName])
-            ? $this->headers[$normalizedName]
-            : $default;
+        return $this->headers[$normalizedName] ?? $default;
     }
 
     /**
      * Validate that we have a status code argument that will work for our context.
      *
      * @param int $statusCode
-     * @throws Exception\InvalidArgumentException for arguments not castable
+     * @throws Exception\InvalidArgumentException For arguments not castable
      *     to integer HTTP status codes.
-     *
      * @return void
      */
     private function validateStatusCode($statusCode)
@@ -85,7 +80,7 @@ class Response implements HeaderAwareResponseInterface
         if (! is_numeric($statusCode) || (is_string($statusCode) && trim($statusCode) !== $statusCode)) {
             throw new Exception\InvalidArgumentException(sprintf(
                 '%s expects a numeric status code; received %s',
-                __CLASS__,
+                self::class,
                 is_object($statusCode) ? get_class($statusCode) : gettype($statusCode)
             ));
         }
@@ -93,15 +88,15 @@ class Response implements HeaderAwareResponseInterface
         if (100 > $statusCode || 599 < $statusCode) {
             throw new Exception\InvalidArgumentException(sprintf(
                 '%s expects an integer status code between 100 and 599 inclusive; received %s',
-                __CLASS__,
+                self::class,
                 $statusCode
             ));
         }
 
-        if (intval($statusCode) != $statusCode) {
+        if (intval($statusCode) !== $statusCode) {
             throw new Exception\InvalidArgumentException(sprintf(
                 '%s expects an integer status code; received %s',
-                __CLASS__,
+                self::class,
                 $statusCode
             ));
         }
@@ -111,9 +106,8 @@ class Response implements HeaderAwareResponseInterface
      * Validate that we have a body argument that will work for our context.
      *
      * @param mixed $body
-     * @throws Exception\InvalidArgumentException for arguments not castable
+     * @throws Exception\InvalidArgumentException For arguments not castable
      *     to strings.
-     *
      * @return void
      */
     private function validateBody($body)
@@ -128,7 +122,7 @@ class Response implements HeaderAwareResponseInterface
 
         throw new Exception\InvalidArgumentException(sprintf(
             '%s expects a string body, or an object that can cast to string; received %s',
-            __CLASS__,
+            self::class,
             is_object($body) ? get_class($body) : gettype($body)
         ));
     }
@@ -137,7 +131,6 @@ class Response implements HeaderAwareResponseInterface
      * Validate header values.
      *
      * @throws Exception\InvalidArgumentException
-     *
      * @return void
      */
     private function validateHeaders(array $headers)
@@ -146,7 +139,7 @@ class Response implements HeaderAwareResponseInterface
             if (! is_string($name) || is_numeric($name) || empty($name)) {
                 throw new Exception\InvalidArgumentException(sprintf(
                     'Header names provided to %s must be non-empty, non-numeric strings; received %s',
-                    __CLASS__,
+                    self::class,
                     $name
                 ));
             }
@@ -154,7 +147,7 @@ class Response implements HeaderAwareResponseInterface
             if (! is_string($value) && ! is_numeric($value)) {
                 throw new Exception\InvalidArgumentException(sprintf(
                     'Individual header values provided to %s must be a string or numeric; received %s for header %s',
-                    __CLASS__,
+                    self::class,
                     is_object($value) ? get_class($value) : gettype($value),
                     $name
                 ));

--- a/src/Reader/Http/ResponseInterface.php
+++ b/src/Reader/Http/ResponseInterface.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Reader\Http;
 
 interface ResponseInterface

--- a/src/Reader/ReaderImportInterface.php
+++ b/src/Reader/ReaderImportInterface.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Reader;
 
 interface ReaderImportInterface
@@ -32,7 +26,7 @@ interface ReaderImportInterface
      *
      * @param  string $uri
      * @return self
-     * @throws Exception\RuntimeException if response is not an Http\ResponseInterface
+     * @throws Exception\RuntimeException If response is not an Http\ResponseInterface.
      */
     public static function importRemoteFeed($uri, Http\ClientInterface $client);
 

--- a/src/Reader/StandaloneExtensionManager.php
+++ b/src/Reader/StandaloneExtensionManager.php
@@ -1,17 +1,17 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Reader;
 
 use Laminas\Feed\Reader\Exception\InvalidArgumentException;
 
+use function array_key_exists;
+use function is_a;
+use function is_string;
+use function sprintf;
+
 class StandaloneExtensionManager implements ExtensionManagerInterface
 {
+    /** @var array<string, class-string> */
     private $extensions = [
         'Atom\Entry'              => Extension\Atom\Entry::class,
         'Atom\Feed'               => Extension\Atom\Feed::class,
@@ -64,7 +64,8 @@ class StandaloneExtensionManager implements ExtensionManagerInterface
      */
     public function add($name, $class)
     {
-        if (is_string($class)
+        if (
+            is_string($class)
             && (is_a($class, Extension\AbstractEntry::class, true)
                 || is_a($class, Extension\AbstractFeed::class, true))
         ) {

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -1,62 +1,44 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed;
+
+use function in_array;
+use function parse_url;
+use function strpos;
 
 class Uri
 {
-    /**
-     * @var string
-     */
+    /** @var null|string */
     protected $fragment;
 
-    /**
-     * @var string
-     */
+    /** @var null|string */
     protected $host;
 
-    /**
-     * @var string
-     */
+    /** @var null|string */
     protected $pass;
 
-    /**
-     * @var string
-     */
+    /** @var null|string */
     protected $path;
 
-    /**
-     * @var int
-     */
+    /** @var null|int */
     protected $port;
 
-    /**
-     * @var string
-     */
+    /** @var null|string */
     protected $query;
 
-    /**
-     * @var string
-     */
+    /** @var null|string */
     protected $scheme;
 
-    /**
-     * @var string
-     */
+    /** @var null|string */
     protected $user;
 
-    /**
-     * @var bool
-     */
+    /** @var null|bool */
     protected $valid;
 
     /**
      * Valid schemes
+     *
+     * @var string[]
      */
     protected $validSchemes = [
         'http',
@@ -75,14 +57,14 @@ class Uri
             return;
         }
 
-        $this->scheme   = isset($parsed['scheme']) ? $parsed['scheme'] : null;
-        $this->host     = isset($parsed['host']) ? $parsed['host'] : null;
-        $this->port     = isset($parsed['port']) ? $parsed['port'] : null;
-        $this->user     = isset($parsed['user']) ? $parsed['user'] : null;
-        $this->pass     = isset($parsed['pass']) ? $parsed['pass'] : null;
-        $this->path     = isset($parsed['path']) ? $parsed['path'] : null;
-        $this->query    = isset($parsed['query']) ? $parsed['query'] : null;
-        $this->fragment = isset($parsed['fragment']) ? $parsed['fragment'] : null;
+        $this->scheme   = $parsed['scheme'] ?? '';
+        $this->host     = $parsed['host'] ?? '';
+        $this->port     = $parsed['port'] ?? null;
+        $this->user     = $parsed['user'] ?? null;
+        $this->pass     = $parsed['pass'] ?? null;
+        $this->path     = $parsed['path'] ?? '';
+        $this->query    = $parsed['query'] ?? null;
+        $this->fragment = $parsed['fragment'] ?? null;
     }
 
     /**
@@ -139,7 +121,7 @@ class Uri
             return false;
         }
 
-        if ($this->scheme && ! in_array($this->scheme, $this->validSchemes)) {
+        if ($this->scheme && ! in_array($this->scheme, $this->validSchemes, true)) {
             return false;
         }
 
@@ -178,6 +160,6 @@ class Uri
      */
     public function isAbsolute()
     {
-        return $this->scheme !== null;
+        return ! empty($this->scheme);
     }
 }

--- a/src/Writer/AbstractFeed.php
+++ b/src/Writer/AbstractFeed.php
@@ -1,17 +1,25 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Writer;
 
 use DateTime;
+use DateTimeImmutable;
 use DateTimeInterface;
 use Laminas\Feed\Uri;
 use Laminas\Validator;
+
+use function array_key_exists;
+use function date;
+use function in_array;
+use function is_array;
+use function is_int;
+use function is_numeric;
+use function is_string;
+use function preg_match;
+use function sprintf;
+use function strlen;
+use function strtolower;
+use function strtotime;
 
 class AbstractFeed
 {
@@ -30,9 +38,7 @@ class AbstractFeed
      */
     protected $type;
 
-    /**
-     * @var Extension\RendererInterface[]
-     */
+    /** @var Extension\RendererInterface[] */
     protected $extensions;
 
     /**
@@ -59,7 +65,8 @@ class AbstractFeed
     public function addAuthor(array $author)
     {
         // Check array values
-        if (! array_key_exists('name', $author)
+        if (
+            ! array_key_exists('name', $author)
             || empty($author['name'])
             || ! is_string($author['name'])
         ) {
@@ -76,7 +83,8 @@ class AbstractFeed
             }
         }
         if (isset($author['uri'])) {
-            if (empty($author['uri'])
+            if (
+                empty($author['uri'])
                 || ! is_string($author['uri'])
                 || ! Uri::factory($author['uri'])->isValid()
             ) {
@@ -95,6 +103,7 @@ class AbstractFeed
      * Set an array with feed authors
      *
      * @see addAuthor
+     *
      * @return $this
      */
     public function addAuthors(array $authors)
@@ -126,11 +135,8 @@ class AbstractFeed
     /**
      * Set the feed creation date
      *
-     * @param null|int|DateTimeInterface
-     * @param DateTime|\DateTimeImmutable|int|null|string $date
-     *
+     * @param DateTime|DateTimeImmutable|int|null|string $date
      * @return self
-     *
      * @throws Exception\InvalidArgumentException
      */
     public function setDateCreated($date = null)
@@ -154,11 +160,8 @@ class AbstractFeed
     /**
      * Set the feed modification date
      *
-     * @param null|int|DateTimeInterface
-     * @param DateTime|\DateTimeImmutable|int|null|string $date
-     *
+     * @param DateTime|DateTimeImmutable|int|null|string $date
      * @return self
-     *
      * @throws Exception\InvalidArgumentException
      */
     public function setDateModified($date = null)
@@ -182,11 +185,8 @@ class AbstractFeed
     /**
      * Set the feed last-build date. Ignored for Atom 1.0.
      *
-     * @param null|int|DateTimeInterface
-     * @param DateTime|\DateTimeImmutable|int|null|string $date
-     *
+     * @param DateTime|DateTimeImmutable|int|null|string $date
      * @return self
-     *
      * @throws Exception\InvalidArgumentException
      */
     public function setLastBuildDate($date = null)
@@ -293,55 +293,21 @@ class AbstractFeed
      */
     public function setId($id)
     {
-        // @codingStandardsIgnoreStart
-        if ((empty($id) || ! is_string($id) || ! Uri::factory($id)->isValid())
+        // phpcs:disable Generic.Files.LineLength.TooLong
+        if (
+            (empty($id) || ! is_string($id) || ! Uri::factory($id)->isValid())
             && ! preg_match("#^urn:[a-zA-Z0-9][a-zA-Z0-9\-]{1,31}:([a-zA-Z0-9\(\)\+\,\.\:\=\@\;\$\_\!\*\-]|%[0-9a-fA-F]{2})*#", $id)
             && ! $this->_validateTagUri($id)
         ) {
-            // @codingStandardsIgnoreEnd
             throw new Exception\InvalidArgumentException(
                 'Invalid parameter: parameter must be a non-empty string and valid URI/IRI'
             );
         }
+        // phpcs:enable Generic.Files.LineLength.TooLong
+
         $this->data['id'] = $id;
 
         return $this;
-    }
-
-    /**
-     * Validate a URI using the tag scheme (RFC 4151)
-     *
-     * @param  string $id
-     * @return bool
-     */
-    // @codingStandardsIgnoreStart
-    protected function _validateTagUri($id)
-    {
-        // @codingStandardsIgnoreEnd
-        if (preg_match(
-            '/^tag:(?P<name>.*),(?P<date>\d{4}-?\d{0,2}-?\d{0,2}):(?P<specific>.*)(.*:)*$/',
-            $id,
-            $matches
-        )) {
-            $dvalid = false;
-            $date   = $matches['date'];
-            $d6     = strtotime($date);
-            if ((strlen($date) === 4) && $date <= date('Y')) {
-                $dvalid = true;
-            } elseif ((strlen($date) === 7) && ($d6 < strtotime('now'))) {
-                $dvalid = true;
-            } elseif ((strlen($date) === 10) && ($d6 < strtotime('now'))) {
-                $dvalid = true;
-            }
-            $validator = new Validator\EmailAddress();
-            if ($validator->isValid($matches['name'])) {
-                $nvalid = true;
-            } else {
-                $nvalid = $validator->isValid('info@' . $matches['name']);
-            }
-            return $dvalid && $nvalid;
-        }
-        return false;
     }
 
     /**
@@ -355,7 +321,8 @@ class AbstractFeed
      */
     public function setImage(array $data)
     {
-        if (empty($data['uri']) || ! is_string($data['uri'])
+        if (
+            empty($data['uri']) || ! is_string($data['uri'])
             || ! Uri::factory($data['uri'])->isValid()
         ) {
             throw new Exception\InvalidArgumentException(
@@ -532,7 +499,8 @@ class AbstractFeed
             );
         }
         if (isset($category['scheme'])) {
-            if (empty($category['scheme'])
+            if (
+                empty($category['scheme'])
                 || ! is_string($category['scheme'])
                 || ! Uri::factory($category['scheme'])->isValid()
             ) {
@@ -869,7 +837,7 @@ class AbstractFeed
      * @param  string $method
      * @param  array $args
      * @return mixed
-     * @throws Exception\BadMethodCallException if no extensions implements the method
+     * @throws Exception\BadMethodCallException If no extensions implements the method.
      */
     public function __call($method, $args)
     {
@@ -885,16 +853,52 @@ class AbstractFeed
         );
     }
 
+    // phpcs:disable PSR2.Methods.MethodDeclaration.Underscore
+
+    /**
+     * Validate a URI using the tag scheme (RFC 4151)
+     *
+     * @param  string $id
+     * @return bool
+     */
+    protected function _validateTagUri($id)
+    {
+        if (
+            preg_match(
+                '/^tag:(?P<name>.*),(?P<date>\d{4}-?\d{0,2}-?\d{0,2}):(?P<specific>.*)(.*:)*$/',
+                $id,
+                $matches
+            )
+        ) {
+            $dvalid = false;
+            $date   = $matches['date'];
+            $d6     = strtotime($date);
+            if ((strlen($date) === 4) && $date <= date('Y')) {
+                $dvalid = true;
+            } elseif ((strlen($date) === 7) && ($d6 < strtotime('now'))) {
+                $dvalid = true;
+            } elseif ((strlen($date) === 10) && ($d6 < strtotime('now'))) {
+                $dvalid = true;
+            }
+            $validator = new Validator\EmailAddress();
+            if ($validator->isValid($matches['name'])) {
+                $nvalid = true;
+            } else {
+                $nvalid = $validator->isValid('info@' . $matches['name']);
+            }
+            return $dvalid && $nvalid;
+        }
+        return false;
+    }
+
     /**
      * Load extensions from Laminas\Feed\Writer\Writer
      *
      * @throws Exception\RuntimeException
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _loadExtensions()
     {
-        // @codingStandardsIgnoreEnd
         $all     = Writer::getExtensions();
         $manager = Writer::getExtensionManager();
         $exts    = $all['feed'];
@@ -908,4 +912,6 @@ class AbstractFeed
             $this->extensions[$ext]->setEncoding($this->getEncoding());
         }
     }
+
+    // phpcs:enable PSR2.Methods.MethodDeclaration.Underscore
 }

--- a/src/Writer/Deleted.php
+++ b/src/Writer/Deleted.php
@@ -1,16 +1,14 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Writer;
 
 use DateTime;
 use DateTimeInterface;
 use Laminas\Feed\Uri;
+
+use function array_key_exists;
+use function is_int;
+use function is_string;
 
 class Deleted
 {
@@ -32,14 +30,13 @@ class Deleted
     /**
      * Set the feed character encoding
      *
-     * @param  string $encoding
-     * @return null|string
-     * @return Deleted
+     * @param  null|string $encoding
+     * @return static
      * @throws Exception\InvalidArgumentException
      */
     public function setEncoding($encoding)
     {
-        if (empty($encoding) || ! is_string($encoding)) {
+        if (empty($encoding)) {
             throw new Exception\InvalidArgumentException('Invalid parameter: parameter must be a non-empty string');
         }
         $this->data['encoding'] = $encoding;
@@ -172,7 +169,8 @@ class Deleted
     public function setBy(array $by)
     {
         $author = [];
-        if (! array_key_exists('name', $by)
+        if (
+            ! array_key_exists('name', $by)
             || empty($by['name'])
             || ! is_string($by['name'])
         ) {
@@ -190,7 +188,8 @@ class Deleted
             $author['email'] = $by['email'];
         }
         if (isset($by['uri'])) {
-            if (empty($by['uri'])
+            if (
+                empty($by['uri'])
                 || ! is_string($by['uri'])
                 || ! Uri::factory($by['uri'])->isValid()
             ) {

--- a/src/Writer/Entry.php
+++ b/src/Writer/Entry.php
@@ -1,16 +1,21 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Writer;
 
+use BadMethodCallException;
 use DateTime;
 use DateTimeInterface;
 use Laminas\Feed\Uri;
+
+use function array_key_exists;
+use function get_class;
+use function gettype;
+use function in_array;
+use function is_int;
+use function is_numeric;
+use function is_object;
+use function is_string;
+use function sprintf;
 
 class Entry
 {
@@ -60,7 +65,8 @@ class Entry
     public function addAuthor(array $author)
     {
         // Check array values
-        if (! array_key_exists('name', $author)
+        if (
+            ! array_key_exists('name', $author)
             || empty($author['name'])
             || ! is_string($author['name'])
         ) {
@@ -77,7 +83,8 @@ class Entry
             }
         }
         if (isset($author['uri'])) {
-            if (empty($author['uri']) || ! is_string($author['uri'])
+            if (
+                empty($author['uri']) || ! is_string($author['uri'])
                 || ! Uri::factory($author['uri'])->isValid()
             ) {
                 throw new Exception\InvalidArgumentException(
@@ -95,6 +102,7 @@ class Entry
      * Set an array with feed authors
      *
      * @see addAuthor
+     *
      * @return $this
      */
     public function addAuthors(array $authors)
@@ -276,12 +284,13 @@ class Entry
     /**
      * Set the number of comments associated with this entry
      *
-     * @param  int $count
+     * @param  int|float|string $count
      * @return $this
      * @throws Exception\InvalidArgumentException
      */
     public function setCommentCount($count)
     {
+        // phpcs:ignore SlevomatCodingStandard.Operators.DisallowEqualOperators.DisallowedNotEqualOperator
         if (! is_numeric($count) || (int) $count != $count || (int) $count < 0) {
             throw new Exception\InvalidArgumentException(
                 'Invalid parameter: "count" must be a positive integer number or zero'
@@ -474,7 +483,6 @@ class Entry
         return $this->data['link'];
     }
 
-
     /**
      * Get all links
      *
@@ -556,7 +564,8 @@ class Entry
             );
         }
         if (isset($category['scheme'])) {
-            if (empty($category['scheme'])
+            if (
+                empty($category['scheme'])
                 || ! is_string($category['scheme'])
                 || ! Uri::factory($category['scheme'])->isValid()
             ) {
@@ -664,14 +673,23 @@ class Entry
      * Return an Extension object with the matching name (postfixed with _Entry)
      *
      * @param  string $name
-     * @return object
+     * @return null|object
      */
     public function getExtension($name)
     {
-        if (array_key_exists($name . '\\Entry', $this->extensions)) {
-            return $this->extensions[$name . '\\Entry'];
+        $extensionClassName = $name . '\\Entry';
+        if (! isset($this->extensions[$extensionClassName])) {
+            return null;
         }
-        return;
+
+        if (! is_object($this->extensions[$extensionClassName])) {
+            throw new Exception\RuntimeException(sprintf(
+                'Extension is of invalid type; expected object, received "%s"',
+                gettype($this->extensions[$extensionClassName])
+            ));
+        }
+
+        return $this->extensions[$extensionClassName];
     }
 
     /**
@@ -704,7 +722,7 @@ class Entry
      * @param  string $method
      * @param  array $args
      * @return mixed
-     * @throws Exception\BadMethodCallException if no extensions implements the method
+     * @throws Exception\BadMethodCallException If no extensions implements the method.
      */
     public function __call($method, $args)
     {
@@ -712,7 +730,7 @@ class Entry
             try {
                 $callback = [$extension, $method];
                 return $callback(...$args);
-            } catch (\BadMethodCallException $e) {
+            } catch (BadMethodCallException $e) {
             }
         }
         throw new Exception\BadMethodCallException(
@@ -750,14 +768,22 @@ class Entry
     }
 
     /**
-     * @return Source
+     * @return null|Source
      */
     public function getSource()
     {
-        if (isset($this->data['source'])) {
-            return $this->data['source'];
+        if (! isset($this->data['source'])) {
+            return null;
         }
-        return;
+
+        if (! $this->data['source'] instanceof Source) {
+            throw new Exception\RuntimeException(sprintf(
+                'Entry source is of invalid type ("%s")',
+                is_object($this->data['source']) ? get_class($this->data['source']) : gettype($this->data['source'])
+            ));
+        }
+
+        return $this->data['source'];
     }
 
     /**
@@ -765,10 +791,9 @@ class Entry
      *
      * @return void
      */
-    // @codingStandardsIgnoreStart
+    // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     protected function _loadExtensions()
     {
-        // @codingStandardsIgnoreEnd
         $all     = Writer::getExtensions();
         $manager = Writer::getExtensionManager();
         $exts    = $all['entry'];

--- a/src/Writer/Exception/BadMethodCallException.php
+++ b/src/Writer/Exception/BadMethodCallException.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Writer\Exception;
 
 use Laminas\Feed\Exception;

--- a/src/Writer/Exception/ExceptionInterface.php
+++ b/src/Writer/Exception/ExceptionInterface.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Writer\Exception;
 
 /**

--- a/src/Writer/Exception/InvalidArgumentException.php
+++ b/src/Writer/Exception/InvalidArgumentException.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Writer\Exception;
 
 use Laminas\Feed\Exception;

--- a/src/Writer/Exception/RuntimeException.php
+++ b/src/Writer/Exception/RuntimeException.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Writer\Exception;
 
 use Laminas\Feed\Exception;

--- a/src/Writer/Extension/AbstractRenderer.php
+++ b/src/Writer/Extension/AbstractRenderer.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Writer\Extension;
 
 use DOMDocument;
@@ -13,34 +7,22 @@ use DOMElement;
 
 abstract class AbstractRenderer implements RendererInterface
 {
-    /**
-     * @var DOMDocument
-     */
+    /** @var DOMDocument */
     protected $dom;
 
-    /**
-     * @var mixed
-     */
+    /** @var mixed */
     protected $entry;
 
-    /**
-     * @var DOMElement
-     */
+    /** @var DOMElement */
     protected $base;
 
-    /**
-     * @var mixed
-     */
+    /** @var mixed */
     protected $container;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $type;
 
-    /**
-     * @var DOMElement
-     */
+    /** @var DOMElement */
     protected $rootElement;
 
     /**
@@ -154,7 +136,6 @@ abstract class AbstractRenderer implements RendererInterface
      *
      * @return void
      */
-    // @codingStandardsIgnoreStart
+    // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     abstract protected function _appendNamespaces();
-    // @codingStandardsIgnoreEnd
 }

--- a/src/Writer/Extension/Atom/Renderer/Feed.php
+++ b/src/Writer/Extension/Atom/Renderer/Feed.php
@@ -1,16 +1,12 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Writer\Extension\Atom\Renderer;
 
 use DOMDocument;
 use DOMElement;
 use Laminas\Feed\Writer\Extension;
+
+use function strtolower;
 
 class Feed extends Extension\AbstractRenderer
 {
@@ -44,15 +40,15 @@ class Feed extends Extension\AbstractRenderer
         }
     }
 
+    // phpcs:disable PSR2.Methods.MethodDeclaration.Underscore
+
     /**
      * Append namespaces to root element of feed
      *
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _appendNamespaces()
     {
-        // @codingStandardsIgnoreEnd
         $this->getRootElement()->setAttribute(
             'xmlns:atom',
             'http://www.w3.org/2005/Atom'
@@ -62,20 +58,16 @@ class Feed extends Extension\AbstractRenderer
     /**
      * Set feed link elements
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _setFeedLinks(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         $flinks = $this->getDataContainer()->getFeedLinks();
         if (! $flinks || empty($flinks)) {
             return;
         }
         foreach ($flinks as $type => $href) {
-            if (strtolower($type) == $this->getType()) { // issue 2605
+            if (strtolower($type) === $this->getType()) { // issue 2605
                 $mime  = 'application/' . strtolower($type) . '+xml';
                 $flink = $dom->createElement('atom:link');
                 $root->appendChild($flink);
@@ -90,14 +82,10 @@ class Feed extends Extension\AbstractRenderer
     /**
      * Set PuSH hubs
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _setHubs(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         $hubs = $this->getDataContainer()->getHubs();
         if (! $hubs || empty($hubs)) {
             return;
@@ -110,4 +98,6 @@ class Feed extends Extension\AbstractRenderer
         }
         $this->called = true;
     }
+
+    // phpcs:enable PSR2.Methods.MethodDeclaration.Underscore
 }

--- a/src/Writer/Extension/Content/Renderer/Entry.php
+++ b/src/Writer/Extension/Content/Renderer/Entry.php
@@ -1,16 +1,12 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Writer\Extension\Content\Renderer;
 
 use DOMDocument;
 use DOMElement;
 use Laminas\Feed\Writer\Extension;
+
+use function strtolower;
 
 class Entry extends Extension\AbstractRenderer
 {
@@ -39,15 +35,15 @@ class Entry extends Extension\AbstractRenderer
         }
     }
 
+    // phpcs:disable PSR2.Methods.MethodDeclaration.Underscore
+
     /**
      * Append namespaces to root element
      *
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _appendNamespaces()
     {
-        // @codingStandardsIgnoreEnd
         $this->getRootElement()->setAttribute(
             'xmlns:content',
             'http://purl.org/rss/1.0/modules/content/'
@@ -57,14 +53,10 @@ class Entry extends Extension\AbstractRenderer
     /**
      * Set entry content
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _setContent(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         $content = $this->getDataContainer()->getContent();
         if (! $content) {
             return;
@@ -75,4 +67,6 @@ class Entry extends Extension\AbstractRenderer
         $element->appendChild($cdata);
         $this->called = true;
     }
+
+    // phpcs:enable PSR2.Methods.MethodDeclaration.Underscore
 }

--- a/src/Writer/Extension/DublinCore/Renderer/Entry.php
+++ b/src/Writer/Extension/DublinCore/Renderer/Entry.php
@@ -1,16 +1,13 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Writer\Extension\DublinCore\Renderer;
 
 use DOMDocument;
 use DOMElement;
 use Laminas\Feed\Writer\Extension;
+
+use function array_key_exists;
+use function strtolower;
 
 class Entry extends Extension\AbstractRenderer
 {
@@ -39,15 +36,15 @@ class Entry extends Extension\AbstractRenderer
         }
     }
 
+    // phpcs:disable PSR2.Methods.MethodDeclaration.Underscore
+
     /**
      * Append namespaces to entry
      *
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _appendNamespaces()
     {
-        // @codingStandardsIgnoreEnd
         $this->getRootElement()->setAttribute(
             'xmlns:dc',
             'http://purl.org/dc/elements/1.1/'
@@ -57,14 +54,10 @@ class Entry extends Extension\AbstractRenderer
     /**
      * Set entry author elements
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _setAuthors(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         $authors = $this->getDataContainer()->getAuthors();
         if (! $authors || empty($authors)) {
             return;
@@ -79,4 +72,6 @@ class Entry extends Extension\AbstractRenderer
         }
         $this->called = true;
     }
+
+    // phpcs:enable PSR2.Methods.MethodDeclaration.Underscore
 }

--- a/src/Writer/Extension/DublinCore/Renderer/Feed.php
+++ b/src/Writer/Extension/DublinCore/Renderer/Feed.php
@@ -1,16 +1,13 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Writer\Extension\DublinCore\Renderer;
 
 use DOMDocument;
 use DOMElement;
 use Laminas\Feed\Writer\Extension;
+
+use function array_key_exists;
+use function strtolower;
 
 class Feed extends Extension\AbstractRenderer
 {
@@ -39,15 +36,15 @@ class Feed extends Extension\AbstractRenderer
         }
     }
 
+    // phpcs:disable PSR2.Methods.MethodDeclaration.Underscore
+
     /**
      * Append namespaces to feed element
      *
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _appendNamespaces()
     {
-        // @codingStandardsIgnoreEnd
         $this->getRootElement()->setAttribute(
             'xmlns:dc',
             'http://purl.org/dc/elements/1.1/'
@@ -57,14 +54,10 @@ class Feed extends Extension\AbstractRenderer
     /**
      * Set feed authors
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _setAuthors(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         $authors = $this->getDataContainer()->getAuthors();
         if (! $authors || empty($authors)) {
             return;
@@ -79,4 +72,6 @@ class Feed extends Extension\AbstractRenderer
         }
         $this->called = true;
     }
+
+    // phpcs:enable PSR2.Methods.MethodDeclaration.Underscore
 }

--- a/src/Writer/Extension/GooglePlayPodcast/Entry.php
+++ b/src/Writer/Extension/GooglePlayPodcast/Entry.php
@@ -1,16 +1,19 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Writer\Extension\GooglePlayPodcast;
 
 use Laminas\Feed\Writer;
 use Laminas\Stdlib\StringUtils;
 use Laminas\Stdlib\StringWrapper\StringWrapperInterface;
+
+use function array_key_exists;
+use function ctype_alpha;
+use function in_array;
+use function lcfirst;
+use function method_exists;
+use function strlen;
+use function substr;
+use function ucfirst;
 
 class Entry
 {
@@ -66,10 +69,8 @@ class Entry
     /**
      * Set a block value of "yes" or "no". You may also set an empty string.
      *
-     * @param string
-     *
+     * @param string $value
      * @throws Writer\Exception\InvalidArgumentException
-     *
      * @return void
      */
     public function setPlayPodcastBlock($value)
@@ -134,14 +135,16 @@ class Entry
     public function __call($method, array $params)
     {
         $point = lcfirst(substr($method, 14));
-        if (! method_exists($this, 'setPlayPodcast' . ucfirst($point))
+        if (
+            ! method_exists($this, 'setPlayPodcast' . ucfirst($point))
             && ! method_exists($this, 'addPlayPodcast' . ucfirst($point))
         ) {
             throw new Writer\Exception\BadMethodCallException(
                 'invalid method: ' . $method
             );
         }
-        if (! array_key_exists($point, $this->data)
+        if (
+            ! array_key_exists($point, $this->data)
             || empty($this->data[$point])
         ) {
             return;

--- a/src/Writer/Extension/GooglePlayPodcast/Feed.php
+++ b/src/Writer/Extension/GooglePlayPodcast/Feed.php
@@ -1,17 +1,22 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Writer\Extension\GooglePlayPodcast;
 
 use Laminas\Feed\Uri;
 use Laminas\Feed\Writer;
 use Laminas\Stdlib\StringUtils;
 use Laminas\Stdlib\StringWrapper\StringWrapperInterface;
+
+use function array_key_exists;
+use function ctype_alpha;
+use function in_array;
+use function is_array;
+use function is_string;
+use function lcfirst;
+use function method_exists;
+use function strlen;
+use function substr;
+use function ucfirst;
 
 class Feed
 {
@@ -67,10 +72,8 @@ class Feed
     /**
      * Set a block value of "yes" or "no". You may also set an empty string.
      *
-     * @param string
-     *
+     * @param string $value
      * @return self
-     *
      * @throws Writer\Exception\InvalidArgumentException
      */
     public function setPlayPodcastBlock($value)
@@ -226,7 +229,8 @@ class Feed
     public function __call($method, array $params)
     {
         $point = lcfirst(substr($method, 14));
-        if (! method_exists($this, 'setPlayPodcast' . ucfirst($point))
+        if (
+            ! method_exists($this, 'setPlayPodcast' . ucfirst($point))
             && ! method_exists($this, 'addPlayPodcast' . ucfirst($point))
         ) {
             throw new Writer\Exception\BadMethodCallException(

--- a/src/Writer/Extension/GooglePlayPodcast/Renderer/Entry.php
+++ b/src/Writer/Extension/GooglePlayPodcast/Renderer/Entry.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Writer\Extension\GooglePlayPodcast\Renderer;
 
 use DOMDocument;
@@ -38,15 +32,15 @@ class Entry extends Extension\AbstractRenderer
         }
     }
 
+    // phpcs:disable PSR2.Methods.MethodDeclaration.Underscore
+
     /**
      * Append namespaces to entry root
      *
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _appendNamespaces()
     {
-        // @codingStandardsIgnoreEnd
         $this->getRootElement()->setAttribute(
             'xmlns:googleplay',
             'http://www.google.com/schemas/play-podcasts/1.0'
@@ -56,14 +50,10 @@ class Entry extends Extension\AbstractRenderer
     /**
      * Set itunes block
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _setBlock(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         $block = $this->getDataContainer()->getPlayPodcastBlock();
         if ($block === null) {
             return;
@@ -78,14 +68,10 @@ class Entry extends Extension\AbstractRenderer
     /**
      * Set explicit flag
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _setExplicit(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         $explicit = $this->getDataContainer()->getPlayPodcastExplicit();
         if ($explicit === null) {
             return;
@@ -100,14 +86,10 @@ class Entry extends Extension\AbstractRenderer
     /**
      * Set episode description
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _setDescription(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         $description = $this->getDataContainer()->getPlayPodcastDescription();
         if (! $description) {
             return;
@@ -118,4 +100,6 @@ class Entry extends Extension\AbstractRenderer
         $root->appendChild($el);
         $this->called = true;
     }
+
+    // phpcs:enable PSR2.Methods.MethodDeclaration.Underscore
 }

--- a/src/Writer/Extension/GooglePlayPodcast/Renderer/Feed.php
+++ b/src/Writer/Extension/GooglePlayPodcast/Renderer/Feed.php
@@ -1,16 +1,12 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Writer\Extension\GooglePlayPodcast\Renderer;
 
 use DOMDocument;
 use DOMElement;
 use Laminas\Feed\Writer\Extension;
+
+use function is_array;
 
 class Feed extends Extension\AbstractRenderer
 {
@@ -41,15 +37,15 @@ class Feed extends Extension\AbstractRenderer
         }
     }
 
+    // phpcs:disable PSR2.Methods.MethodDeclaration.Underscore
+
     /**
      * Append feed namespaces
      *
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _appendNamespaces()
     {
-        // @codingStandardsIgnoreEnd
         $this->getRootElement()->setAttribute(
             'xmlns:googleplay',
             'http://www.google.com/schemas/play-podcasts/1.0'
@@ -59,14 +55,10 @@ class Feed extends Extension\AbstractRenderer
     /**
      * Set feed authors
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _setAuthors(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         $authors = $this->getDataContainer()->getPlayPodcastAuthors();
         if (! $authors || empty($authors)) {
             return;
@@ -83,14 +75,10 @@ class Feed extends Extension\AbstractRenderer
     /**
      * Set feed itunes block
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _setBlock(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         $block = $this->getDataContainer()->getPlayPodcastBlock();
         if ($block === null) {
             return;
@@ -105,14 +93,10 @@ class Feed extends Extension\AbstractRenderer
     /**
      * Set feed categories
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _setCategories(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         $cats = $this->getDataContainer()->getPlayPodcastCategories();
         if (! $cats || empty($cats)) {
             return;
@@ -139,14 +123,10 @@ class Feed extends Extension\AbstractRenderer
     /**
      * Set feed image (icon)
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _setImage(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         $image = $this->getDataContainer()->getPlayPodcastImage();
         if (! $image) {
             return;
@@ -160,14 +140,10 @@ class Feed extends Extension\AbstractRenderer
     /**
      * Set explicit flag
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _setExplicit(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         $explicit = $this->getDataContainer()->getPlayPodcastExplicit();
         if ($explicit === null) {
             return;
@@ -182,14 +158,10 @@ class Feed extends Extension\AbstractRenderer
     /**
      * Set podcast description
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _setDescription(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         $description = $this->getDataContainer()->getPlayPodcastDescription();
         if (! $description) {
             return;
@@ -200,4 +172,6 @@ class Feed extends Extension\AbstractRenderer
         $root->appendChild($el);
         $this->called = true;
     }
+
+    // phpcs:enable PSR2.Methods.MethodDeclaration.Underscore
 }

--- a/src/Writer/Extension/ITunes/Entry.php
+++ b/src/Writer/Extension/ITunes/Entry.php
@@ -1,17 +1,36 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Writer\Extension\ITunes;
 
 use Laminas\Feed\Uri;
 use Laminas\Feed\Writer;
 use Laminas\Stdlib\StringUtils;
 use Laminas\Stdlib\StringWrapper\StringWrapperInterface;
+
+use function array_key_exists;
+use function count;
+use function ctype_alpha;
+use function ctype_digit;
+use function get_class;
+use function gettype;
+use function implode;
+use function in_array;
+use function is_bool;
+use function is_float;
+use function is_numeric;
+use function is_object;
+use function is_string;
+use function lcfirst;
+use function method_exists;
+use function preg_match;
+use function sprintf;
+use function strlen;
+use function substr;
+use function trigger_error;
+use function ucfirst;
+use function var_export;
+
+use const E_USER_DEPRECATED;
 
 class Entry
 {
@@ -67,10 +86,8 @@ class Entry
     /**
      * Set a block value of "yes" or "no". You may also set an empty string.
      *
-     * @param string
-     *
+     * @param string $value
      * @throws Writer\Exception\InvalidArgumentException
-     *
      * @return void
      */
     public function setItunesBlock($value)
@@ -133,7 +150,8 @@ class Entry
     public function setItunesDuration($value)
     {
         $value = (string) $value;
-        if (! ctype_digit($value)
+        if (
+            ! ctype_digit($value)
             && ! preg_match('/^\d+:[0-5]{1}[0-9]{1}$/', $value)
             && ! preg_match('/^\d+:[0-5]{1}[0-9]{1}:[0-5]{1}[0-9]{1}$/', $value)
         ) {
@@ -183,6 +201,8 @@ class Entry
      *
      * @deprecated since 2.10.0; itunes:keywords is no longer part of the
      *     iTunes podcast RSS specification.
+     *
+     * @param string[] $value
      * @return $this
      * @throws Writer\Exception\InvalidArgumentException
      */
@@ -191,7 +211,7 @@ class Entry
         trigger_error(
             'itunes:keywords has been deprecated in the iTunes podcast RSS specification,'
             . ' and should not be relied on.',
-            \E_USER_DEPRECATED
+            E_USER_DEPRECATED
         );
 
         if (count($value) > 12) {
@@ -392,14 +412,16 @@ class Entry
     public function __call($method, array $params)
     {
         $point = lcfirst(substr($method, 9));
-        if (! method_exists($this, 'setItunes' . ucfirst($point))
+        if (
+            ! method_exists($this, 'setItunes' . ucfirst($point))
             && ! method_exists($this, 'addItunes' . ucfirst($point))
         ) {
             throw new Writer\Exception\BadMethodCallException(
                 'invalid method: ' . $method
             );
         }
-        if (! array_key_exists($point, $this->data)
+        if (
+            ! array_key_exists($point, $this->data)
             || empty($this->data[$point])
         ) {
             return;

--- a/src/Writer/Extension/ITunes/Feed.php
+++ b/src/Writer/Extension/ITunes/Feed.php
@@ -1,17 +1,34 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Writer\Extension\ITunes;
 
 use Laminas\Feed\Uri;
 use Laminas\Feed\Writer;
 use Laminas\Stdlib\StringUtils;
 use Laminas\Stdlib\StringWrapper\StringWrapperInterface;
+
+use function array_key_exists;
+use function count;
+use function ctype_alpha;
+use function ctype_digit;
+use function get_class;
+use function implode;
+use function in_array;
+use function is_array;
+use function is_bool;
+use function is_object;
+use function is_string;
+use function lcfirst;
+use function method_exists;
+use function preg_match;
+use function sprintf;
+use function strlen;
+use function substr;
+use function trigger_error;
+use function ucfirst;
+use function var_export;
+
+use const E_USER_DEPRECATED;
 
 class Feed
 {
@@ -67,10 +84,8 @@ class Feed
     /**
      * Set a block value of "yes" or "no". You may also set an empty string.
      *
-     * @param string
-     *
+     * @param string $value
      * @return self
-     *
      * @throws Writer\Exception\InvalidArgumentException
      */
     public function setItunesBlock($value)
@@ -197,7 +212,8 @@ class Feed
     public function setItunesDuration($value)
     {
         $value = (string) $value;
-        if (! ctype_digit($value)
+        if (
+            ! ctype_digit($value)
             && ! preg_match('/^\d+:[0-5]{1}[0-9]{1}$/', $value)
             && ! preg_match('/^\d+:[0-5]{1}[0-9]{1}:[0-5]{1}[0-9]{1}$/', $value)
         ) {
@@ -247,6 +263,8 @@ class Feed
      *
      * @deprecated since 2.10.0; itunes:keywords is no longer part of the
      *     iTunes podcast RSS specification.
+     *
+     * @param string[] $value
      * @return $this
      * @throws Writer\Exception\InvalidArgumentException
      */
@@ -255,7 +273,7 @@ class Feed
         trigger_error(
             'itunes:keywords has been deprecated in the iTunes podcast RSS specification,'
             . ' and should not be relied on.',
-            \E_USER_DEPRECATED
+            E_USER_DEPRECATED
         );
 
         if (count($value) > 12) {
@@ -319,7 +337,8 @@ class Feed
                 'invalid parameter: any "owner" must be an array containing keys "name" and "email"'
             );
         }
-        if ($this->stringWrapper->strlen($value['name']) > 255
+        if (
+            $this->stringWrapper->strlen($value['name']) > 255
             || $this->stringWrapper->strlen($value['email']) > 255
         ) {
             throw new Writer\Exception\InvalidArgumentException(
@@ -425,7 +444,8 @@ class Feed
     public function __call($method, array $params)
     {
         $point = lcfirst(substr($method, 9));
-        if (! method_exists($this, 'setItunes' . ucfirst($point))
+        if (
+            ! method_exists($this, 'setItunes' . ucfirst($point))
             && ! method_exists($this, 'addItunes' . ucfirst($point))
         ) {
             throw new Writer\Exception\BadMethodCallException(

--- a/src/Writer/Extension/ITunes/Renderer/Entry.php
+++ b/src/Writer/Extension/ITunes/Renderer/Entry.php
@@ -1,16 +1,12 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Writer\Extension\ITunes\Renderer;
 
 use DOMDocument;
 use DOMElement;
 use Laminas\Feed\Writer\Extension;
+
+use function implode;
 
 class Entry extends Extension\AbstractRenderer
 {
@@ -48,15 +44,15 @@ class Entry extends Extension\AbstractRenderer
         }
     }
 
+    // phpcs:disable PSR2.Methods.MethodDeclaration.Underscore
+
     /**
      * Append namespaces to entry root
      *
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _appendNamespaces()
     {
-        // @codingStandardsIgnoreEnd
         $this->getRootElement()->setAttribute(
             'xmlns:itunes',
             'http://www.itunes.com/dtds/podcast-1.0.dtd'
@@ -66,14 +62,10 @@ class Entry extends Extension\AbstractRenderer
     /**
      * Set entry authors
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _setAuthors(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         $authors = $this->getDataContainer()->getItunesAuthors();
         if (! $authors || empty($authors)) {
             return;
@@ -90,14 +82,10 @@ class Entry extends Extension\AbstractRenderer
     /**
      * Set itunes block
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _setBlock(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         $block = $this->getDataContainer()->getItunesBlock();
         if ($block === null) {
             return;
@@ -112,14 +100,10 @@ class Entry extends Extension\AbstractRenderer
     /**
      * Set entry duration
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _setDuration(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         $duration = $this->getDataContainer()->getItunesDuration();
         if (! $duration) {
             return;
@@ -134,14 +118,10 @@ class Entry extends Extension\AbstractRenderer
     /**
      * Set feed image (icon)
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _setImage(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         $image = $this->getDataContainer()->getItunesImage();
         if (! $image) {
             return;
@@ -155,14 +135,10 @@ class Entry extends Extension\AbstractRenderer
     /**
      * Set explicit flag
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _setExplicit(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         $explicit = $this->getDataContainer()->getItunesExplicit();
         if ($explicit === null) {
             return;
@@ -177,14 +153,10 @@ class Entry extends Extension\AbstractRenderer
     /**
      * Set entry keywords
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _setKeywords(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         $keywords = $this->getDataContainer()->getItunesKeywords();
         if (! $keywords || empty($keywords)) {
             return;
@@ -199,14 +171,10 @@ class Entry extends Extension\AbstractRenderer
     /**
      * Set entry title
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _setTitle(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         $title = $this->getDataContainer()->getItunesTitle();
         if (! $title) {
             return;
@@ -221,14 +189,10 @@ class Entry extends Extension\AbstractRenderer
     /**
      * Set entry subtitle
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _setSubtitle(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         $subtitle = $this->getDataContainer()->getItunesSubtitle();
         if (! $subtitle) {
             return;
@@ -243,14 +207,10 @@ class Entry extends Extension\AbstractRenderer
     /**
      * Set entry summary
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _setSummary(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         $summary = $this->getDataContainer()->getItunesSummary();
         if (! $summary) {
             return;
@@ -265,14 +225,10 @@ class Entry extends Extension\AbstractRenderer
     /**
      * Set entry episode number
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _setEpisode(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         $episode = $this->getDataContainer()->getItunesEpisode();
         if (! $episode) {
             return;
@@ -287,14 +243,10 @@ class Entry extends Extension\AbstractRenderer
     /**
      * Set entry episode type
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _setEpisodeType(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         $type = $this->getDataContainer()->getItunesEpisodeType();
         if (! $type) {
             return;
@@ -309,14 +261,10 @@ class Entry extends Extension\AbstractRenderer
     /**
      * Set closed captioning status for episode
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _setClosedCaptioned(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         $status = $this->getDataContainer()->getItunesIsClosedCaptioned();
         if (! $status) {
             return;
@@ -331,14 +279,10 @@ class Entry extends Extension\AbstractRenderer
     /**
      * Set entry season number
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _setSeason(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         $season = $this->getDataContainer()->getItunesSeason();
         if (! $season) {
             return;
@@ -349,4 +293,6 @@ class Entry extends Extension\AbstractRenderer
         $root->appendChild($el);
         $this->called = true;
     }
+
+    // phpcs:enable PSR2.Methods.MethodDeclaration.Underscore
 }

--- a/src/Writer/Extension/ITunes/Renderer/Feed.php
+++ b/src/Writer/Extension/ITunes/Renderer/Feed.php
@@ -1,16 +1,13 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Writer\Extension\ITunes\Renderer;
 
 use DOMDocument;
 use DOMElement;
 use Laminas\Feed\Writer\Extension;
+
+use function implode;
+use function is_array;
 
 class Feed extends Extension\AbstractRenderer
 {
@@ -48,15 +45,15 @@ class Feed extends Extension\AbstractRenderer
         }
     }
 
+    // phpcs:disable PSR2.Methods.MethodDeclaration.Underscore
+
     /**
      * Append feed namespaces
      *
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _appendNamespaces()
     {
-        // @codingStandardsIgnoreEnd
         $this->getRootElement()->setAttribute(
             'xmlns:itunes',
             'http://www.itunes.com/dtds/podcast-1.0.dtd'
@@ -66,14 +63,10 @@ class Feed extends Extension\AbstractRenderer
     /**
      * Set feed authors
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _setAuthors(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         $authors = $this->getDataContainer()->getItunesAuthors();
         if (! $authors || empty($authors)) {
             return;
@@ -90,14 +83,10 @@ class Feed extends Extension\AbstractRenderer
     /**
      * Set feed itunes block
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _setBlock(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         $block = $this->getDataContainer()->getItunesBlock();
         if ($block === null) {
             return;
@@ -112,14 +101,10 @@ class Feed extends Extension\AbstractRenderer
     /**
      * Set feed categories
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _setCategories(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         $cats = $this->getDataContainer()->getItunesCategories();
         if (! $cats || empty($cats)) {
             return;
@@ -146,14 +131,10 @@ class Feed extends Extension\AbstractRenderer
     /**
      * Set feed image (icon)
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _setImage(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         $image = $this->getDataContainer()->getItunesImage();
         if (! $image) {
             return;
@@ -167,14 +148,10 @@ class Feed extends Extension\AbstractRenderer
     /**
      * Set feed cumulative duration
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _setDuration(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         $duration = $this->getDataContainer()->getItunesDuration();
         if (! $duration) {
             return;
@@ -189,14 +166,10 @@ class Feed extends Extension\AbstractRenderer
     /**
      * Set explicit flag
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _setExplicit(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         $explicit = $this->getDataContainer()->getItunesExplicit();
         if ($explicit === null) {
             return;
@@ -211,14 +184,10 @@ class Feed extends Extension\AbstractRenderer
     /**
      * Set feed keywords
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _setKeywords(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         $keywords = $this->getDataContainer()->getItunesKeywords();
         if (! $keywords || empty($keywords)) {
             return;
@@ -233,14 +202,10 @@ class Feed extends Extension\AbstractRenderer
     /**
      * Set feed's new URL
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _setNewFeedUrl(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         $url = $this->getDataContainer()->getItunesNewFeedUrl();
         if (! $url) {
             return;
@@ -255,14 +220,10 @@ class Feed extends Extension\AbstractRenderer
     /**
      * Set feed owners
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _setOwners(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         $owners = $this->getDataContainer()->getItunesOwners();
         if (! $owners || empty($owners)) {
             return;
@@ -285,14 +246,10 @@ class Feed extends Extension\AbstractRenderer
     /**
      * Set feed subtitle
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _setSubtitle(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         $subtitle = $this->getDataContainer()->getItunesSubtitle();
         if (! $subtitle) {
             return;
@@ -307,14 +264,10 @@ class Feed extends Extension\AbstractRenderer
     /**
      * Set feed summary
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _setSummary(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         $summary = $this->getDataContainer()->getItunesSummary();
         if (! $summary) {
             return;
@@ -329,14 +282,10 @@ class Feed extends Extension\AbstractRenderer
     /**
      * Set podcast type
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _setType(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         $type = $this->getDataContainer()->getItunesType();
         if (! $type) {
             return;
@@ -351,14 +300,10 @@ class Feed extends Extension\AbstractRenderer
     /**
      * Set complete status
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _setComplete(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         $status = $this->getDataContainer()->getItunesComplete();
         if (! $status) {
             return;
@@ -369,4 +314,6 @@ class Feed extends Extension\AbstractRenderer
         $root->appendChild($el);
         $this->called = true;
     }
+
+    // phpcs:enable PSR2.Methods.MethodDeclaration.Underscore
 }

--- a/src/Writer/Extension/PodcastIndex/Entry.php
+++ b/src/Writer/Extension/PodcastIndex/Entry.php
@@ -1,16 +1,19 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Writer\Extension\PodcastIndex;
 
 use Laminas\Feed\Writer;
 use Laminas\Stdlib\StringUtils;
 use Laminas\Stdlib\StringWrapper\StringWrapperInterface;
+
+use function array_key_exists;
+use function is_numeric;
+use function is_string;
+use function lcfirst;
+use function method_exists;
+use function strlen;
+use function substr;
+use function ucfirst;
 
 /**
  * Describes PodcastIndex data of an entry in a RSS Feed
@@ -121,14 +124,16 @@ class Entry
                 . ' keys "startTime" and "duration" and optionally "title"'
             );
         }
-        if (! is_string($value['startTime'])
+        if (
+            ! is_string($value['startTime'])
             || (! is_numeric($value['startTime']) && strlen($value['startTime']) > 0)
         ) {
             throw new Writer\Exception\InvalidArgumentException(
                 'invalid parameter: "startTime" of "soundbite" may only contain numeric characters and dots'
             );
         }
-        if (! is_string($value['duration'])
+        if (
+            ! is_string($value['duration'])
             || (! is_numeric($value['duration']) && strlen($value['duration']) > 0)
         ) {
             throw new Writer\Exception\InvalidArgumentException(
@@ -151,14 +156,16 @@ class Entry
     public function __call(string $method, array $params)
     {
         $point = lcfirst(substr($method, 15));
-        if (! method_exists($this, 'setPodcastIndex' . ucfirst($point))
+        if (
+            ! method_exists($this, 'setPodcastIndex' . ucfirst($point))
             && ! method_exists($this, 'addPodcastIndex' . ucfirst($point))
         ) {
             throw new Writer\Exception\BadMethodCallException(
                 'invalid method: ' . $method
             );
         }
-        if (! array_key_exists($point, $this->data)
+        if (
+            ! array_key_exists($point, $this->data)
             || empty($this->data[$point])
         ) {
             return;

--- a/src/Writer/Extension/PodcastIndex/Feed.php
+++ b/src/Writer/Extension/PodcastIndex/Feed.php
@@ -1,16 +1,19 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Writer\Extension\PodcastIndex;
 
 use Laminas\Feed\Writer;
 use Laminas\Stdlib\StringUtils;
 use Laminas\Stdlib\StringWrapper\StringWrapperInterface;
+
+use function array_key_exists;
+use function ctype_alpha;
+use function is_string;
+use function lcfirst;
+use function method_exists;
+use function strlen;
+use function substr;
+use function ucfirst;
 
 /**
  * Describes PodcastIndex data of a RSS Feed
@@ -73,7 +76,8 @@ class Feed
                 'invalid parameter: "locked" must be an array containing keys "value" and "owner"'
             );
         }
-        if (! is_string($value['value'])
+        if (
+            ! is_string($value['value'])
             || ! ctype_alpha($value['value']) && strlen($value['value']) > 0
         ) {
             throw new Writer\Exception\InvalidArgumentException(
@@ -109,7 +113,8 @@ class Feed
     public function __call(string $method, array $params)
     {
         $point = lcfirst(substr($method, 15));
-        if (! method_exists($this, 'setPodcastIndex' . ucfirst($point))
+        if (
+            ! method_exists($this, 'setPodcastIndex' . ucfirst($point))
             && ! method_exists($this, 'addPodcastIndex' . ucfirst($point))
         ) {
             throw new Writer\Exception\BadMethodCallException(

--- a/src/Writer/Extension/PodcastIndex/Renderer/Entry.php
+++ b/src/Writer/Extension/PodcastIndex/Renderer/Entry.php
@@ -1,16 +1,12 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Writer\Extension\PodcastIndex\Renderer;
 
 use DOMDocument;
 use DOMElement;
 use Laminas\Feed\Writer\Extension;
+
+use function array_key_exists;
 
 /**
  * Renders PodcastIndex data of an entry in a RSS Feed
@@ -42,10 +38,9 @@ class Entry extends Extension\AbstractRenderer
     /**
      * Append namespaces to entry root
      */
-    // @codingStandardsIgnoreStart
+    // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     protected function _appendNamespaces(): void
     {
-        // @codingStandardsIgnoreEnd
         $this->getRootElement()->setAttribute(
             'xmlns:podcast',
             'https://github.com/Podcastindex-org/podcast-namespace/blob/main/docs/1.0.md'

--- a/src/Writer/Extension/PodcastIndex/Renderer/Feed.php
+++ b/src/Writer/Extension/PodcastIndex/Renderer/Feed.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Writer\Extension\PodcastIndex\Renderer;
 
 use DOMDocument;
@@ -41,10 +35,9 @@ class Feed extends Extension\AbstractRenderer
     /**
      * Append feed namespaces
      */
-    // @codingStandardsIgnoreStart
+    // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     protected function _appendNamespaces(): void
     {
-        // @codingStandardsIgnoreEnd
         $this->getRootElement()->setAttribute(
             'xmlns:podcast',
             'https://github.com/Podcastindex-org/podcast-namespace/blob/main/docs/1.0.md'

--- a/src/Writer/Extension/RendererInterface.php
+++ b/src/Writer/Extension/RendererInterface.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Writer\Extension;
 
 use DOMDocument;

--- a/src/Writer/Extension/Slash/Renderer/Entry.php
+++ b/src/Writer/Extension/Slash/Renderer/Entry.php
@@ -1,16 +1,12 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Writer\Extension\Slash\Renderer;
 
 use DOMDocument;
 use DOMElement;
 use Laminas\Feed\Writer\Extension;
+
+use function strtolower;
 
 class Entry extends Extension\AbstractRenderer
 {
@@ -39,15 +35,15 @@ class Entry extends Extension\AbstractRenderer
         }
     }
 
+    // phpcs:disable PSR2.Methods.MethodDeclaration.Underscore
+
     /**
      * Append entry namespaces
      *
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _appendNamespaces()
     {
-        // @codingStandardsIgnoreEnd
         $this->getRootElement()->setAttribute(
             'xmlns:slash',
             'http://purl.org/rss/1.0/modules/slash/'
@@ -57,14 +53,10 @@ class Entry extends Extension\AbstractRenderer
     /**
      * Set entry comment count
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _setCommentCount(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         $count = $this->getDataContainer()->getCommentCount();
         if (! $count) {
             $count = 0;
@@ -74,4 +66,6 @@ class Entry extends Extension\AbstractRenderer
         $root->appendChild($tcount);
         $this->called = true;
     }
+
+    // phpcs:enable PSR2.Methods.MethodDeclaration.Underscore
 }

--- a/src/Writer/Extension/Threading/Renderer/Entry.php
+++ b/src/Writer/Extension/Threading/Renderer/Entry.php
@@ -1,16 +1,12 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Writer\Extension\Threading\Renderer;
 
 use DOMDocument;
 use DOMElement;
 use Laminas\Feed\Writer\Extension;
+
+use function strtolower;
 
 class Entry extends Extension\AbstractRenderer
 {
@@ -41,15 +37,15 @@ class Entry extends Extension\AbstractRenderer
         }
     }
 
+    // phpcs:disable PSR2.Methods.MethodDeclaration.Underscore
+
     /**
      * Append entry namespaces
      *
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _appendNamespaces()
     {
-        // @codingStandardsIgnoreEnd
         $this->getRootElement()->setAttribute(
             'xmlns:thr',
             'http://purl.org/syndication/thread/1.0'
@@ -59,14 +55,10 @@ class Entry extends Extension\AbstractRenderer
     /**
      * Set comment link
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _setCommentLink(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         $link = $this->getDataContainer()->getCommentLink();
         if (! $link) {
             return;
@@ -86,14 +78,10 @@ class Entry extends Extension\AbstractRenderer
     /**
      * Set comment feed links
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _setCommentFeedLinks(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         $links = $this->getDataContainer()->getCommentFeedLinks();
         if (! $links || empty($links)) {
             return;
@@ -115,14 +103,10 @@ class Entry extends Extension\AbstractRenderer
     /**
      * Set entry comment count
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _setCommentCount(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         $count = $this->getDataContainer()->getCommentCount();
         if ($count === null) {
             return;
@@ -132,4 +116,6 @@ class Entry extends Extension\AbstractRenderer
         $root->appendChild($tcount);
         $this->called = true;
     }
+
+    // phpcs:enable PSR2.Methods.MethodDeclaration.Underscore
 }

--- a/src/Writer/Extension/WellFormedWeb/Renderer/Entry.php
+++ b/src/Writer/Extension/WellFormedWeb/Renderer/Entry.php
@@ -1,16 +1,12 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Writer\Extension\WellFormedWeb\Renderer;
 
 use DOMDocument;
 use DOMElement;
 use Laminas\Feed\Writer\Extension;
+
+use function strtolower;
 
 class Entry extends Extension\AbstractRenderer
 {
@@ -39,15 +35,15 @@ class Entry extends Extension\AbstractRenderer
         }
     }
 
+    // phpcs:disable PSR2.Methods.MethodDeclaration.Underscore
+
     /**
      * Append entry namespaces
      *
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _appendNamespaces()
     {
-        // @codingStandardsIgnoreEnd
         $this->getRootElement()->setAttribute(
             'xmlns:wfw',
             'http://wellformedweb.org/CommentAPI/'
@@ -57,14 +53,10 @@ class Entry extends Extension\AbstractRenderer
     /**
      * Set entry comment feed links
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _setCommentFeedLinks(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         $links = $this->getDataContainer()->getCommentFeedLinks();
         if (! $links || empty($links)) {
             return;
@@ -79,4 +71,6 @@ class Entry extends Extension\AbstractRenderer
         }
         $this->called = true;
     }
+
+    // phpcs:enable PSR2.Methods.MethodDeclaration.Underscore
 }

--- a/src/Writer/ExtensionManager.php
+++ b/src/Writer/ExtensionManager.php
@@ -1,12 +1,10 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Writer;
+
+use function call_user_func_array;
+use function method_exists;
+use function sprintf;
 
 /**
  * Default implementation of ExtensionManagerInterface
@@ -15,13 +13,14 @@ namespace Laminas\Feed\Writer;
  */
 class ExtensionManager implements ExtensionManagerInterface
 {
+    /** @var ExtensionManagerInterface */
     protected $pluginManager;
 
     /**
      * Seeds the extension manager with a plugin manager; if none provided,
      * creates and decorates an instance of StandaloneExtensionManager.
      */
-    public function __construct(ExtensionManagerInterface $pluginManager = null)
+    public function __construct(?ExtensionManagerInterface $pluginManager = null)
     {
         if (null === $pluginManager) {
             $pluginManager = new StandaloneExtensionManager();
@@ -45,7 +44,7 @@ class ExtensionManager implements ExtensionManagerInterface
             throw new Exception\BadMethodCallException(sprintf(
                 'Method by name of %s does not exist in %s',
                 $method,
-                __CLASS__
+                self::class
             ));
         }
         return call_user_func_array([$this->pluginManager, $method], $args);
@@ -54,22 +53,22 @@ class ExtensionManager implements ExtensionManagerInterface
     /**
      * Get the named extension
      *
-     * @param  string $name
+     * @param  string $extension
      * @return Extension\AbstractRenderer
      */
-    public function get($name)
+    public function get($extension)
     {
-        return $this->pluginManager->get($name);
+        return $this->pluginManager->get($extension);
     }
 
     /**
      * Do we have the named extension?
      *
-     * @param  string $name
+     * @param  string $extension
      * @return bool
      */
-    public function has($name)
+    public function has($extension)
     {
-        return $this->pluginManager->has($name);
+        return $this->pluginManager->has($extension);
     }
 }

--- a/src/Writer/ExtensionManagerInterface.php
+++ b/src/Writer/ExtensionManagerInterface.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Writer;
 
 interface ExtensionManagerInterface

--- a/src/Writer/ExtensionPluginManager.php
+++ b/src/Writer/ExtensionPluginManager.php
@@ -1,16 +1,16 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Writer;
 
 use Laminas\ServiceManager\AbstractPluginManager;
 use Laminas\ServiceManager\Exception\InvalidServiceException;
 use Laminas\ServiceManager\Factory\InvokableFactory;
+
+use function get_class;
+use function gettype;
+use function is_object;
+use function sprintf;
+use function substr;
 
 /**
  * Plugin manager implementation for feed writer extensions
@@ -22,29 +22,30 @@ class ExtensionPluginManager extends AbstractPluginManager implements ExtensionM
     /**
      * Aliases for default set of extension classes
      *
-     * @var array
+     * @var array<array-key, string>
      */
     protected $aliases = [
-        'atomrendererfeed'           => Extension\Atom\Renderer\Feed::class,
-        'atomRendererFeed'           => Extension\Atom\Renderer\Feed::class,
-        'AtomRendererFeed'           => Extension\Atom\Renderer\Feed::class,
-        'AtomRenderer\Feed'          => Extension\Atom\Renderer\Feed::class,
-        'Atom\Renderer\Feed'         => Extension\Atom\Renderer\Feed::class,
-        'contentrendererentry'       => Extension\Content\Renderer\Entry::class,
-        'contentRendererEntry'       => Extension\Content\Renderer\Entry::class,
-        'ContentRendererEntry'       => Extension\Content\Renderer\Entry::class,
-        'ContentRenderer\Entry'      => Extension\Content\Renderer\Entry::class,
-        'Content\Renderer\Entry'     => Extension\Content\Renderer\Entry::class,
-        'dublincorerendererentry'    => Extension\DublinCore\Renderer\Entry::class,
-        'dublinCoreRendererEntry'    => Extension\DublinCore\Renderer\Entry::class,
-        'DublinCoreRendererEntry'    => Extension\DublinCore\Renderer\Entry::class,
-        'DublinCoreRenderer\Entry'   => Extension\DublinCore\Renderer\Entry::class,
-        'DublinCore\Renderer\Entry'  => Extension\DublinCore\Renderer\Entry::class,
-        'dublincorerendererfeed'     => Extension\DublinCore\Renderer\Feed::class,
-        'dublinCoreRendererFeed'     => Extension\DublinCore\Renderer\Feed::class,
-        'DublinCoreRendererFeed'     => Extension\DublinCore\Renderer\Feed::class,
-        'DublinCoreRenderer\Feed'    => Extension\DublinCore\Renderer\Feed::class,
-        'DublinCore\Renderer\Feed'   => Extension\DublinCore\Renderer\Feed::class,
+        // phpcs:disable Generic.Files.LineLength.TooLong
+        'atomrendererfeed'                 => Extension\Atom\Renderer\Feed::class,
+        'atomRendererFeed'                 => Extension\Atom\Renderer\Feed::class,
+        'AtomRendererFeed'                 => Extension\Atom\Renderer\Feed::class,
+        'AtomRenderer\Feed'                => Extension\Atom\Renderer\Feed::class,
+        'Atom\Renderer\Feed'               => Extension\Atom\Renderer\Feed::class,
+        'contentrendererentry'             => Extension\Content\Renderer\Entry::class,
+        'contentRendererEntry'             => Extension\Content\Renderer\Entry::class,
+        'ContentRendererEntry'             => Extension\Content\Renderer\Entry::class,
+        'ContentRenderer\Entry'            => Extension\Content\Renderer\Entry::class,
+        'Content\Renderer\Entry'           => Extension\Content\Renderer\Entry::class,
+        'dublincorerendererentry'          => Extension\DublinCore\Renderer\Entry::class,
+        'dublinCoreRendererEntry'          => Extension\DublinCore\Renderer\Entry::class,
+        'DublinCoreRendererEntry'          => Extension\DublinCore\Renderer\Entry::class,
+        'DublinCoreRenderer\Entry'         => Extension\DublinCore\Renderer\Entry::class,
+        'DublinCore\Renderer\Entry'        => Extension\DublinCore\Renderer\Entry::class,
+        'dublincorerendererfeed'           => Extension\DublinCore\Renderer\Feed::class,
+        'dublinCoreRendererFeed'           => Extension\DublinCore\Renderer\Feed::class,
+        'DublinCoreRendererFeed'           => Extension\DublinCore\Renderer\Feed::class,
+        'DublinCoreRenderer\Feed'          => Extension\DublinCore\Renderer\Feed::class,
+        'DublinCore\Renderer\Feed'         => Extension\DublinCore\Renderer\Feed::class,
         'googleplaypodcastentry'           => Extension\GooglePlayPodcast\Entry::class,
         'googleplaypodcastEntry'           => Extension\GooglePlayPodcast\Entry::class,
         'googlePlayPodcastEntry'           => Extension\GooglePlayPodcast\Entry::class,
@@ -69,66 +70,66 @@ class ExtensionPluginManager extends AbstractPluginManager implements ExtensionM
         'GooglePlayPodcastRendererFeed'    => Extension\GooglePlayPodcast\Renderer\Feed::class,
         'GoogleplaypodcastRenderer\Feed'   => Extension\GooglePlayPodcast\Renderer\Feed::class,
         'GooglePlayPodcast\Renderer\Feed'  => Extension\GooglePlayPodcast\Renderer\Feed::class,
-        'itunesentry'                => Extension\ITunes\Entry::class,
-        'itunesEntry'                => Extension\ITunes\Entry::class,
-        'iTunesEntry'                => Extension\ITunes\Entry::class,
-        'ItunesEntry'                => Extension\ITunes\Entry::class,
-        'Itunes\Entry'               => Extension\ITunes\Entry::class,
-        'ITunes\Entry'               => Extension\ITunes\Entry::class,
-        'itunesfeed'                 => Extension\ITunes\Feed::class,
-        'itunesFeed'                 => Extension\ITunes\Feed::class,
-        'iTunesFeed'                 => Extension\ITunes\Feed::class,
-        'ItunesFeed'                 => Extension\ITunes\Feed::class,
-        'Itunes\Feed'                => Extension\ITunes\Feed::class,
-        'ITunes\Feed'                => Extension\ITunes\Feed::class,
-        'itunesrendererentry'        => Extension\ITunes\Renderer\Entry::class,
-        'itunesRendererEntry'        => Extension\ITunes\Renderer\Entry::class,
-        'iTunesRendererEntry'        => Extension\ITunes\Renderer\Entry::class,
-        'ItunesRendererEntry'        => Extension\ITunes\Renderer\Entry::class,
-        'ItunesRenderer\Entry'       => Extension\ITunes\Renderer\Entry::class,
-        'ITunes\Renderer\Entry'      => Extension\ITunes\Renderer\Entry::class,
-        'itunesrendererfeed'         => Extension\ITunes\Renderer\Feed::class,
-        'itunesRendererFeed'         => Extension\ITunes\Renderer\Feed::class,
-        'iTunesRendererFeed'         => Extension\ITunes\Renderer\Feed::class,
-        'ItunesRendererFeed'         => Extension\ITunes\Renderer\Feed::class,
-        'ItunesRenderer\Feed'        => Extension\ITunes\Renderer\Feed::class,
-        'ITunes\Renderer\Feed'       => Extension\ITunes\Renderer\Feed::class,
-        'podcastindexentry'          => Extension\PodcastIndex\Entry::class,
-        'podcastindexEntry'          => Extension\PodcastIndex\Entry::class,
-        'PodcastIndexEntry'          => Extension\PodcastIndex\Entry::class,
-        'PodcastIndex\Entry'         => Extension\PodcastIndex\Entry::class,
-        'podcastindexfeed'           => Extension\PodcastIndex\Feed::class,
-        'podcastindexFeed'           => Extension\PodcastIndex\Feed::class,
-        'PodcastIndexFeed'           => Extension\PodcastIndex\Feed::class,
-        'PodcastIndex\Feed'          => Extension\PodcastIndex\Feed::class,
-        'podcastindexrendererentry'  => Extension\PodcastIndex\Renderer\Entry::class,
-        'podcastindexRendererEntry'  => Extension\PodcastIndex\Renderer\Entry::class,
-        'PodcastIndexRendererEntry'  => Extension\PodcastIndex\Renderer\Entry::class,
-        'PodcastIndexRenderer\Entry' => Extension\PodcastIndex\Renderer\Entry::class,
-        'PodcastIndex\Renderer\Entry' => Extension\PodcastIndex\Renderer\Entry::class,
-        'podcastindexrendererfeed'   => Extension\PodcastIndex\Renderer\Feed::class,
-        'podcastindexRendererFeed'   => Extension\PodcastIndex\Renderer\Feed::class,
-        'PodcastIndexRendererFeed'   => Extension\PodcastIndex\Renderer\Feed::class,
-        'PodcastIndexRenderer\Feed'  => Extension\PodcastIndex\Renderer\Feed::class,
-        'PodcastIndex\Renderer\Feed' => Extension\PodcastIndex\Renderer\Feed::class,
-        'slashrendererentry'         => Extension\Slash\Renderer\Entry::class,
-        'slashRendererEntry'         => Extension\Slash\Renderer\Entry::class,
-        'SlashRendererEntry'         => Extension\Slash\Renderer\Entry::class,
-        'SlashRenderer\Entry'        => Extension\Slash\Renderer\Entry::class,
-        'Slash\Renderer\Entry'       => Extension\Slash\Renderer\Entry::class,
-        'threadingrendererentry'     => Extension\Threading\Renderer\Entry::class,
-        'threadingRendererEntry'     => Extension\Threading\Renderer\Entry::class,
-        'ThreadingRendererEntry'     => Extension\Threading\Renderer\Entry::class,
-        'ThreadingRenderer\Entry'    => Extension\Threading\Renderer\Entry::class,
-        'Threading\Renderer\Entry'   => Extension\Threading\Renderer\Entry::class,
-        'wellformedwebrendererentry' => Extension\WellFormedWeb\Renderer\Entry::class,
-        'wellFormedWebRendererEntry' => Extension\WellFormedWeb\Renderer\Entry::class,
-        'WellFormedWebRendererEntry' => Extension\WellFormedWeb\Renderer\Entry::class,
-        'WellFormedWebRenderer\Entry' => Extension\WellFormedWeb\Renderer\Entry::class,
-        'WellFormedWeb\Renderer\Entry' => Extension\WellFormedWeb\Renderer\Entry::class,
+        'itunesentry'                      => Extension\ITunes\Entry::class,
+        'itunesEntry'                      => Extension\ITunes\Entry::class,
+        'iTunesEntry'                      => Extension\ITunes\Entry::class,
+        'ItunesEntry'                      => Extension\ITunes\Entry::class,
+        'Itunes\Entry'                     => Extension\ITunes\Entry::class,
+        'ITunes\Entry'                     => Extension\ITunes\Entry::class,
+        'itunesfeed'                       => Extension\ITunes\Feed::class,
+        'itunesFeed'                       => Extension\ITunes\Feed::class,
+        'iTunesFeed'                       => Extension\ITunes\Feed::class,
+        'ItunesFeed'                       => Extension\ITunes\Feed::class,
+        'Itunes\Feed'                      => Extension\ITunes\Feed::class,
+        'ITunes\Feed'                      => Extension\ITunes\Feed::class,
+        'itunesrendererentry'              => Extension\ITunes\Renderer\Entry::class,
+        'itunesRendererEntry'              => Extension\ITunes\Renderer\Entry::class,
+        'iTunesRendererEntry'              => Extension\ITunes\Renderer\Entry::class,
+        'ItunesRendererEntry'              => Extension\ITunes\Renderer\Entry::class,
+        'ItunesRenderer\Entry'             => Extension\ITunes\Renderer\Entry::class,
+        'ITunes\Renderer\Entry'            => Extension\ITunes\Renderer\Entry::class,
+        'itunesrendererfeed'               => Extension\ITunes\Renderer\Feed::class,
+        'itunesRendererFeed'               => Extension\ITunes\Renderer\Feed::class,
+        'iTunesRendererFeed'               => Extension\ITunes\Renderer\Feed::class,
+        'ItunesRendererFeed'               => Extension\ITunes\Renderer\Feed::class,
+        'ItunesRenderer\Feed'              => Extension\ITunes\Renderer\Feed::class,
+        'ITunes\Renderer\Feed'             => Extension\ITunes\Renderer\Feed::class,
+        'podcastindexentry'                => Extension\PodcastIndex\Entry::class,
+        'podcastindexEntry'                => Extension\PodcastIndex\Entry::class,
+        'PodcastIndexEntry'                => Extension\PodcastIndex\Entry::class,
+        'PodcastIndex\Entry'               => Extension\PodcastIndex\Entry::class,
+        'podcastindexfeed'                 => Extension\PodcastIndex\Feed::class,
+        'podcastindexFeed'                 => Extension\PodcastIndex\Feed::class,
+        'PodcastIndexFeed'                 => Extension\PodcastIndex\Feed::class,
+        'PodcastIndex\Feed'                => Extension\PodcastIndex\Feed::class,
+        'podcastindexrendererentry'        => Extension\PodcastIndex\Renderer\Entry::class,
+        'podcastindexRendererEntry'        => Extension\PodcastIndex\Renderer\Entry::class,
+        'PodcastIndexRendererEntry'        => Extension\PodcastIndex\Renderer\Entry::class,
+        'PodcastIndexRenderer\Entry'       => Extension\PodcastIndex\Renderer\Entry::class,
+        'PodcastIndex\Renderer\Entry'      => Extension\PodcastIndex\Renderer\Entry::class,
+        'podcastindexrendererfeed'         => Extension\PodcastIndex\Renderer\Feed::class,
+        'podcastindexRendererFeed'         => Extension\PodcastIndex\Renderer\Feed::class,
+        'PodcastIndexRendererFeed'         => Extension\PodcastIndex\Renderer\Feed::class,
+        'PodcastIndexRenderer\Feed'        => Extension\PodcastIndex\Renderer\Feed::class,
+        'PodcastIndex\Renderer\Feed'       => Extension\PodcastIndex\Renderer\Feed::class,
+        'slashrendererentry'               => Extension\Slash\Renderer\Entry::class,
+        'slashRendererEntry'               => Extension\Slash\Renderer\Entry::class,
+        'SlashRendererEntry'               => Extension\Slash\Renderer\Entry::class,
+        'SlashRenderer\Entry'              => Extension\Slash\Renderer\Entry::class,
+        'Slash\Renderer\Entry'             => Extension\Slash\Renderer\Entry::class,
+        'threadingrendererentry'           => Extension\Threading\Renderer\Entry::class,
+        'threadingRendererEntry'           => Extension\Threading\Renderer\Entry::class,
+        'ThreadingRendererEntry'           => Extension\Threading\Renderer\Entry::class,
+        'ThreadingRenderer\Entry'          => Extension\Threading\Renderer\Entry::class,
+        'Threading\Renderer\Entry'         => Extension\Threading\Renderer\Entry::class,
+        'wellformedwebrendererentry'       => Extension\WellFormedWeb\Renderer\Entry::class,
+        'wellFormedWebRendererEntry'       => Extension\WellFormedWeb\Renderer\Entry::class,
+        'WellFormedWebRendererEntry'       => Extension\WellFormedWeb\Renderer\Entry::class,
+        'WellFormedWebRenderer\Entry'      => Extension\WellFormedWeb\Renderer\Entry::class,
+        'WellFormedWeb\Renderer\Entry'     => Extension\WellFormedWeb\Renderer\Entry::class,
 
         // Legacy Zend Framework aliases
-        // @codingStandardsIgnoreStart
+        // phpcs:disable SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly.ReferenceViaFullyQualifiedName
         \Zend\Feed\Writer\Extension\Atom\Renderer\Feed::class               => Extension\Atom\Renderer\Feed::class,
         \Zend\Feed\Writer\Extension\Content\Renderer\Entry::class           => Extension\Content\Renderer\Entry::class,
         \Zend\Feed\Writer\Extension\DublinCore\Renderer\Entry::class        => Extension\DublinCore\Renderer\Entry::class,
@@ -144,74 +145,74 @@ class ExtensionPluginManager extends AbstractPluginManager implements ExtensionM
         \Zend\Feed\Writer\Extension\Slash\Renderer\Entry::class             => Extension\Slash\Renderer\Entry::class,
         \Zend\Feed\Writer\Extension\Threading\Renderer\Entry::class         => Extension\Threading\Renderer\Entry::class,
         \Zend\Feed\Writer\Extension\WellFormedWeb\Renderer\Entry::class     => Extension\WellFormedWeb\Renderer\Entry::class,
-        // @codingStandardsIgnoreEnd
+        // phpcs:enable SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly.ReferenceViaFullyQualifiedName
 
         // v2 normalized FQCNs
-        'zendfeedwriterextensionatomrendererfeed' => Extension\Atom\Renderer\Feed::class,
-        'zendfeedwriterextensioncontentrendererentry' => Extension\Content\Renderer\Entry::class,
-        'zendfeedwriterextensiondublincorerendererentry' => Extension\DublinCore\Renderer\Entry::class,
-        'zendfeedwriterextensiondublincorerendererfeed' => Extension\DublinCore\Renderer\Feed::class,
-        'zendfeedwriterextensiongoogleplaypodcastentry' => Extension\GooglePlayPodcast\Entry::class,
-        'zendfeedwriterextensiongoogleplaypodcastfeed' => Extension\GooglePlayPodcast\Feed::class,
+        'zendfeedwriterextensionatomrendererfeed'               => Extension\Atom\Renderer\Feed::class,
+        'zendfeedwriterextensioncontentrendererentry'           => Extension\Content\Renderer\Entry::class,
+        'zendfeedwriterextensiondublincorerendererentry'        => Extension\DublinCore\Renderer\Entry::class,
+        'zendfeedwriterextensiondublincorerendererfeed'         => Extension\DublinCore\Renderer\Feed::class,
+        'zendfeedwriterextensiongoogleplaypodcastentry'         => Extension\GooglePlayPodcast\Entry::class,
+        'zendfeedwriterextensiongoogleplaypodcastfeed'          => Extension\GooglePlayPodcast\Feed::class,
         'zendfeedwriterextensiongoogleplaypodcastrendererentry' => Extension\GooglePlayPodcast\Renderer\Entry::class,
-        'zendfeedwriterextensiongoogleplaypodcastrendererfeed' => Extension\GooglePlayPodcast\Renderer\Feed::class,
-        'zendfeedwriterextensionitunesentry' => Extension\ITunes\Entry::class,
-        'zendfeedwriterextensionitunesfeed' => Extension\ITunes\Feed::class,
-        'zendfeedwriterextensionitunesrendererentry' => Extension\ITunes\Renderer\Entry::class,
-        'zendfeedwriterextensionitunesrendererfeed' => Extension\ITunes\Renderer\Feed::class,
-        'zendfeedwriterextensionslashrendererentry' => Extension\Slash\Renderer\Entry::class,
-        'zendfeedwriterextensionthreadingrendererentry' => Extension\Threading\Renderer\Entry::class,
-        'zendfeedwriterextensionwellformedwebrendererentry' => Extension\WellFormedWeb\Renderer\Entry::class,
+        'zendfeedwriterextensiongoogleplaypodcastrendererfeed'  => Extension\GooglePlayPodcast\Renderer\Feed::class,
+        'zendfeedwriterextensionitunesentry'                    => Extension\ITunes\Entry::class,
+        'zendfeedwriterextensionitunesfeed'                     => Extension\ITunes\Feed::class,
+        'zendfeedwriterextensionitunesrendererentry'            => Extension\ITunes\Renderer\Entry::class,
+        'zendfeedwriterextensionitunesrendererfeed'             => Extension\ITunes\Renderer\Feed::class,
+        'zendfeedwriterextensionslashrendererentry'             => Extension\Slash\Renderer\Entry::class,
+        'zendfeedwriterextensionthreadingrendererentry'         => Extension\Threading\Renderer\Entry::class,
+        'zendfeedwriterextensionwellformedwebrendererentry'     => Extension\WellFormedWeb\Renderer\Entry::class,
+        // phpcs:enable Generic.Files.LineLength.TooLong
     ];
 
     /**
      * Factories for default set of extension classes
      *
-     * @var array
+     * @var array<array-key, callable|string>
      */
     protected $factories = [
-        Extension\Atom\Renderer\Feed::class           => InvokableFactory::class,
-        Extension\Content\Renderer\Entry::class       => InvokableFactory::class,
-        Extension\DublinCore\Renderer\Entry::class    => InvokableFactory::class,
-        Extension\DublinCore\Renderer\Feed::class     => InvokableFactory::class,
+        Extension\Atom\Renderer\Feed::class               => InvokableFactory::class,
+        Extension\Content\Renderer\Entry::class           => InvokableFactory::class,
+        Extension\DublinCore\Renderer\Entry::class        => InvokableFactory::class,
+        Extension\DublinCore\Renderer\Feed::class         => InvokableFactory::class,
         Extension\GooglePlayPodcast\Entry::class          => InvokableFactory::class,
         Extension\GooglePlayPodcast\Feed::class           => InvokableFactory::class,
         Extension\GooglePlayPodcast\Renderer\Entry::class => InvokableFactory::class,
         Extension\GooglePlayPodcast\Renderer\Feed::class  => InvokableFactory::class,
-        Extension\ITunes\Entry::class                 => InvokableFactory::class,
-        Extension\ITunes\Feed::class                  => InvokableFactory::class,
-        Extension\ITunes\Renderer\Entry::class        => InvokableFactory::class,
-        Extension\ITunes\Renderer\Feed::class         => InvokableFactory::class,
-        Extension\PodcastIndex\Entry::class                 => InvokableFactory::class,
-        Extension\PodcastIndex\Feed::class                  => InvokableFactory::class,
-        Extension\PodcastIndex\Renderer\Entry::class        => InvokableFactory::class,
-        Extension\PodcastIndex\Renderer\Feed::class         => InvokableFactory::class,
-        Extension\Slash\Renderer\Entry::class         => InvokableFactory::class,
-        Extension\Threading\Renderer\Entry::class     => InvokableFactory::class,
-        Extension\WellFormedWeb\Renderer\Entry::class => InvokableFactory::class,
+        Extension\ITunes\Entry::class                     => InvokableFactory::class,
+        Extension\ITunes\Feed::class                      => InvokableFactory::class,
+        Extension\ITunes\Renderer\Entry::class            => InvokableFactory::class,
+        Extension\ITunes\Renderer\Feed::class             => InvokableFactory::class,
+        Extension\PodcastIndex\Entry::class               => InvokableFactory::class,
+        Extension\PodcastIndex\Feed::class                => InvokableFactory::class,
+        Extension\PodcastIndex\Renderer\Entry::class      => InvokableFactory::class,
+        Extension\PodcastIndex\Renderer\Feed::class       => InvokableFactory::class,
+        Extension\Slash\Renderer\Entry::class             => InvokableFactory::class,
+        Extension\Threading\Renderer\Entry::class         => InvokableFactory::class,
+        Extension\WellFormedWeb\Renderer\Entry::class     => InvokableFactory::class,
         // Legacy (v2) due to alias resolution; canonical form of resolved
         // alias is used to look up the factory, while the non-normalized
         // resolved alias is used as the requested name passed to the factory.
-        'laminasfeedwriterextensionatomrendererfeed'           => InvokableFactory::class,
-        'laminasfeedwriterextensioncontentrendererentry'       => InvokableFactory::class,
-        'laminasfeedwriterextensiondublincorerendererentry'    => InvokableFactory::class,
-        'laminasfeedwriterextensiondublincorerendererfeed'     => InvokableFactory::class,
+        'laminasfeedwriterextensionatomrendererfeed'               => InvokableFactory::class,
+        'laminasfeedwriterextensioncontentrendererentry'           => InvokableFactory::class,
+        'laminasfeedwriterextensiondublincorerendererentry'        => InvokableFactory::class,
+        'laminasfeedwriterextensiondublincorerendererfeed'         => InvokableFactory::class,
         'laminasfeedwriterextensiongoogleplaypodcastentry'         => InvokableFactory::class,
         'laminasfeedwriterextensiongoogleplaypodcastfeed'          => InvokableFactory::class,
         'laminasfeedwriterextensiongoogleplaypodcastrendererentry' => InvokableFactory::class,
         'laminasfeedwriterextensiongoogleplaypodcastrendererfeed'  => InvokableFactory::class,
-
-        'laminasfeedwriterextensionitunesentry'                => InvokableFactory::class,
-        'laminasfeedwriterextensionitunesfeed'                 => InvokableFactory::class,
-        'laminasfeedwriterextensionitunesrendererentry'        => InvokableFactory::class,
-        'laminasfeedwriterextensionitunesrendererfeed'         => InvokableFactory::class,
-        'laminasfeedwriterextensionpodcastindexentry'          => InvokableFactory::class,
-        'laminasfeedwriterextensionpodcastindexfeed'           => InvokableFactory::class,
-        'laminasfeedwriterextensionpodcastindexrendererentry'  => InvokableFactory::class,
-        'laminasfeedwriterextensionpodcastindexrendererfeed'   => InvokableFactory::class,
-        'laminasfeedwriterextensionslashrendererentry'         => InvokableFactory::class,
-        'laminasfeedwriterextensionthreadingrendererentry'     => InvokableFactory::class,
-        'laminasfeedwriterextensionwellformedwebrendererentry' => InvokableFactory::class,
+        'laminasfeedwriterextensionitunesentry'                    => InvokableFactory::class,
+        'laminasfeedwriterextensionitunesfeed'                     => InvokableFactory::class,
+        'laminasfeedwriterextensionitunesrendererentry'            => InvokableFactory::class,
+        'laminasfeedwriterextensionitunesrendererfeed'             => InvokableFactory::class,
+        'laminasfeedwriterextensionpodcastindexentry'              => InvokableFactory::class,
+        'laminasfeedwriterextensionpodcastindexfeed'               => InvokableFactory::class,
+        'laminasfeedwriterextensionpodcastindexrendererentry'      => InvokableFactory::class,
+        'laminasfeedwriterextensionpodcastindexrendererfeed'       => InvokableFactory::class,
+        'laminasfeedwriterextensionslashrendererentry'             => InvokableFactory::class,
+        'laminasfeedwriterextensionthreadingrendererentry'         => InvokableFactory::class,
+        'laminasfeedwriterextensionwellformedwebrendererentry'     => InvokableFactory::class,
     ];
 
     /**
@@ -233,23 +234,23 @@ class ExtensionPluginManager extends AbstractPluginManager implements ExtensionM
      *
      * Checks that the extension loaded is of a valid type.
      *
-     * @param  mixed $plugin
+     * @param  object $instance
      * @return void
-     * @throws InvalidServiceException if invalid
+     * @throws InvalidServiceException If invalid.
      */
-    public function validate($plugin)
+    public function validate($instance)
     {
-        if ($plugin instanceof Extension\AbstractRenderer) {
+        if ($instance instanceof Extension\AbstractRenderer) {
             // we're okay
             return;
         }
 
-        if ('Feed' === substr(get_class($plugin), -4)) {
+        if ('Feed' === substr(get_class($instance), -4)) {
             // we're okay
             return;
         }
 
-        if ('Entry' === substr(get_class($plugin), -5)) {
+        if ('Entry' === substr(get_class($instance), -5)) {
             // we're okay
             return;
         }
@@ -257,7 +258,7 @@ class ExtensionPluginManager extends AbstractPluginManager implements ExtensionM
         throw new InvalidServiceException(sprintf(
             'Plugin of type %s is invalid; must implement %s\Extension\RendererInterface '
             . 'or the classname must end in "Feed" or "Entry"',
-            is_object($plugin) ? get_class($plugin) : gettype($plugin),
+            is_object($instance) ? get_class($instance) : gettype($instance),
             __NAMESPACE__
         ));
     }
@@ -267,7 +268,7 @@ class ExtensionPluginManager extends AbstractPluginManager implements ExtensionM
      *
      * @param  mixed $plugin
      * @return void
-     * @throws Exception\InvalidArgumentException when invalid
+     * @throws Exception\InvalidArgumentException When invalid.
      */
     public function validatePlugin($plugin)
     {

--- a/src/Writer/Feed.php
+++ b/src/Writer/Feed.php
@@ -4,6 +4,8 @@ namespace Laminas\Feed\Writer;
 
 use Countable;
 use Iterator;
+// phpcs:ignore SlevomatCodingStandard.Namespaces.UnusedUses.UnusedUse
+use ReturnTypeWillChange;
 
 use function array_values;
 use function count;
@@ -158,6 +160,7 @@ class Feed extends AbstractFeed implements Iterator, Countable
      *
      * @return int
      */
+    #[ReturnTypeWillChange]
     public function count()
     {
         return count($this->entries);
@@ -168,6 +171,7 @@ class Feed extends AbstractFeed implements Iterator, Countable
      *
      * @return Entry
      */
+    #[ReturnTypeWillChange]
     public function current()
     {
         return $this->entries[$this->key()];
@@ -178,6 +182,7 @@ class Feed extends AbstractFeed implements Iterator, Countable
      *
      * @return mixed
      */
+    #[ReturnTypeWillChange]
     public function key()
     {
         return $this->entriesKey;
@@ -188,6 +193,7 @@ class Feed extends AbstractFeed implements Iterator, Countable
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function next()
     {
         ++$this->entriesKey;
@@ -198,6 +204,7 @@ class Feed extends AbstractFeed implements Iterator, Countable
      *
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function rewind()
     {
         $this->entriesKey = 0;
@@ -208,6 +215,7 @@ class Feed extends AbstractFeed implements Iterator, Countable
      *
      * @return bool
      */
+    #[ReturnTypeWillChange]
     public function valid()
     {
         return 0 <= $this->entriesKey && $this->entriesKey < $this->count();

--- a/src/Writer/Feed.php
+++ b/src/Writer/Feed.php
@@ -1,15 +1,18 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Writer;
 
 use Countable;
 use Iterator;
+
+use function array_values;
+use function count;
+use function krsort;
+use function strtolower;
+use function time;
+use function ucfirst;
+
+use const SORT_NUMERIC;
 
 class Feed extends AbstractFeed implements Iterator, Countable
 {
@@ -64,9 +67,10 @@ class Feed extends AbstractFeed implements Iterator, Countable
      */
     public function createTombstone()
     {
-        $deleted = new Deleted();
-        if ($this->getEncoding()) {
-            $deleted->setEncoding($this->getEncoding());
+        $deleted  = new Deleted();
+        $encoding = $this->getEncoding();
+        if (null !== $encoding) {
+            $deleted->setEncoding($encoding);
         }
         $deleted->setType($this->getType());
         return $deleted;

--- a/src/Writer/FeedFactory.php
+++ b/src/Writer/FeedFactory.php
@@ -1,15 +1,20 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Writer;
 
 use Traversable;
 
+use function array_key_exists;
+use function get_class;
+use function gettype;
+use function is_array;
+use function is_object;
+use function method_exists;
+use function sprintf;
+use function str_replace;
+use function strtolower;
+
+// phpcs:ignore WebimpressCodingStandard.NamingConventions.AbstractClass.Prefix
 abstract class FeedFactory
 {
     /**
@@ -89,7 +94,7 @@ abstract class FeedFactory
         if (! is_array($entries) && ! $entries instanceof Traversable) {
             throw new Exception\InvalidArgumentException(sprintf(
                 '%s::factory expects the "entries" value to be an array or Traversable; received "%s"',
-                get_called_class(),
+                static::class,
                 is_object($entries) ? get_class($entries) : gettype($entries)
             ));
         }

--- a/src/Writer/Renderer/AbstractRenderer.php
+++ b/src/Writer/Renderer/AbstractRenderer.php
@@ -1,16 +1,13 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Writer\Renderer;
 
 use DOMDocument;
 use DOMElement;
 use Laminas\Feed\Writer;
+
+use function is_bool;
+use function stripos;
 
 class AbstractRenderer
 {
@@ -21,24 +18,16 @@ class AbstractRenderer
      */
     protected $extensions = [];
 
-    /**
-     * @var Writer\AbstractFeed
-     */
+    /** @var Writer\AbstractFeed */
     protected $container;
 
-    /**
-     * @var DOMDocument
-     */
+    /** @var DOMDocument */
     protected $dom;
 
-    /**
-     * @var bool
-     */
+    /** @var bool */
     protected $ignoreExceptions = false;
 
-    /**
-     * @var array
-     */
+    /** @var array */
     protected $exceptions = [];
 
     /**
@@ -56,9 +45,7 @@ class AbstractRenderer
      */
     protected $type;
 
-    /**
-     * @var DOMElement
-     */
+    /** @var DOMElement */
     protected $rootElement;
 
     /**
@@ -212,14 +199,13 @@ class AbstractRenderer
      *
      * @return void
      */
-    // @codingStandardsIgnoreStart
+    // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     protected function _loadExtensions()
     {
-        // @codingStandardsIgnoreEnd
         Writer\Writer::registerCoreExtensions();
         $manager = Writer\Writer::getExtensionManager();
         $all     = Writer\Writer::getExtensions();
-        $exts    = stripos(get_class($this), 'entry')
+        $exts    = stripos(static::class, 'entry')
             ? $all['entryRenderer']
             : $all['feedRenderer'];
         foreach ($exts as $extension) {

--- a/src/Writer/Renderer/Entry/Atom.php
+++ b/src/Writer/Renderer/Entry/Atom.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Writer\Renderer\Entry;
 
 use DateTime;
@@ -16,6 +10,18 @@ use Laminas\Feed\Writer;
 use Laminas\Feed\Writer\Renderer;
 use Laminas\Validator;
 use tidy;
+
+use function array_key_exists;
+use function class_exists;
+use function date;
+use function preg_match;
+use function preg_replace;
+use function str_replace;
+use function strlen;
+use function strtotime;
+use function version_compare;
+
+use const PHP_VERSION;
 
 class Atom extends Renderer\AbstractRenderer implements Renderer\RendererInterface
 {
@@ -58,18 +64,16 @@ class Atom extends Renderer\AbstractRenderer implements Renderer\RendererInterfa
         return $this;
     }
 
+    // phpcs:disable PSR2.Methods.MethodDeclaration.Underscore
+
     /**
      * Set entry title
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      * @throws Writer\Exception\InvalidArgumentException
      */
-    // @codingStandardsIgnoreStart
     protected function _setTitle(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         if (! $this->getDataContainer()->getTitle()) {
             $message   = 'Atom 1.0 entry elements MUST contain exactly one'
                 . ' atom:title element but a title has not been set';
@@ -91,14 +95,10 @@ class Atom extends Renderer\AbstractRenderer implements Renderer\RendererInterfa
     /**
      * Set entry description
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _setDescription(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         if (! $this->getDataContainer()->getDescription()) {
             return; // unless src content or base64
         }
@@ -114,15 +114,11 @@ class Atom extends Renderer\AbstractRenderer implements Renderer\RendererInterfa
     /**
      * Set date entry was modified
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      * @throws Writer\Exception\InvalidArgumentException
      */
-    // @codingStandardsIgnoreStart
     protected function _setDateModified(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         if (! $this->getDataContainer()->getDateModified()) {
             $message   = 'Atom 1.0 entry elements MUST contain exactly one'
                 . ' atom:updated element but a modification date has not been set';
@@ -146,14 +142,10 @@ class Atom extends Renderer\AbstractRenderer implements Renderer\RendererInterfa
     /**
      * Set date entry was created
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _setDateCreated(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         if (! $this->getDataContainer()->getDateCreated()) {
             return;
         }
@@ -168,14 +160,10 @@ class Atom extends Renderer\AbstractRenderer implements Renderer\RendererInterfa
     /**
      * Set entry authors
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _setAuthors(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         $authors = $this->container->getAuthors();
         if (! $authors || empty($authors)) {
             /**
@@ -209,14 +197,10 @@ class Atom extends Renderer\AbstractRenderer implements Renderer\RendererInterfa
     /**
      * Set entry enclosure
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _setEnclosure(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         $data = $this->container->getEnclosure();
         if (! $data || empty($data)) {
             return;
@@ -233,13 +217,11 @@ class Atom extends Renderer\AbstractRenderer implements Renderer\RendererInterfa
         $root->appendChild($enclosure);
     }
 
-    // @codingStandardsIgnoreStart
     /**
      * @return void
      */
     protected function _setLink(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         if (! $this->getDataContainer()->getLink()) {
             return;
         }
@@ -253,16 +235,13 @@ class Atom extends Renderer\AbstractRenderer implements Renderer\RendererInterfa
     /**
      * Set entry identifier
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      * @throws Writer\Exception\InvalidArgumentException
      */
-    // @codingStandardsIgnoreStart
     protected function _setId(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
-        if (! $this->getDataContainer()->getId()
+        if (
+            ! $this->getDataContainer()->getId()
             && ! $this->getDataContainer()->getLink()
         ) {
             $message   = 'Atom 1.0 entry elements MUST contain exactly one '
@@ -283,7 +262,8 @@ class Atom extends Renderer\AbstractRenderer implements Renderer\RendererInterfa
                 $this->getDataContainer()->getLink()
             );
         }
-        if (! Uri::factory($this->getDataContainer()->getId())->isValid()
+        if (
+            ! Uri::factory($this->getDataContainer()->getId())->isValid()
             && ! preg_match(
                 "#^urn:[a-zA-Z0-9][a-zA-Z0-9\-]{1,31}:([a-zA-Z0-9\(\)\+\,\.\:\=\@\;\$\_\!\*\-]|%[0-9a-fA-F]{2})*#",
                 $this->getDataContainer()->getId()
@@ -304,15 +284,15 @@ class Atom extends Renderer\AbstractRenderer implements Renderer\RendererInterfa
      * @param  string $id
      * @return bool
      */
-    // @codingStandardsIgnoreStart
     protected function _validateTagUri($id)
     {
-        // @codingStandardsIgnoreEnd
-        if (preg_match(
-            '/^tag:(?P<name>.*),(?P<date>\d{4}-?\d{0,2}-?\d{0,2}):(?P<specific>.*)(.*:)*$/',
-            $id,
-            $matches
-        )) {
+        if (
+            preg_match(
+                '/^tag:(?P<name>.*),(?P<date>\d{4}-?\d{0,2}-?\d{0,2}):(?P<specific>.*)(.*:)*$/',
+                $id,
+                $matches
+            )
+        ) {
             $dvalid = false;
             $date   = $matches['date'];
             $d6     = strtotime($date);
@@ -337,15 +317,11 @@ class Atom extends Renderer\AbstractRenderer implements Renderer\RendererInterfa
     /**
      * Set entry content
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      * @throws Writer\Exception\InvalidArgumentException
      */
-    // @codingStandardsIgnoreStart
     protected function _setContent(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         $content = $this->getDataContainer()->getContent();
         if (! $content && ! $this->getDataContainer()->getLink()) {
             $message   = 'Atom 1.0 entry elements MUST contain exactly one '
@@ -376,14 +352,12 @@ class Atom extends Renderer\AbstractRenderer implements Renderer\RendererInterfa
      * Load a HTML string and attempt to normalise to XML
      *
      * @param string $content
-     * @return \DOMElement
+     * @return DOMElement
      */
-    // @codingStandardsIgnoreStart
     protected function _loadXhtml($content)
     {
-        // @codingStandardsIgnoreEnd
         if (class_exists(tidy::class, false)) {
-            $tidy = new tidy();
+            $tidy     = new tidy();
             $config   = [
                 'output-xhtml'   => true,
                 'show-body-only' => true,
@@ -411,14 +385,10 @@ class Atom extends Renderer\AbstractRenderer implements Renderer\RendererInterfa
     /**
      * Set entry categories
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _setCategories(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         $categories = $this->getDataContainer()->getCategories();
         if (! $categories) {
             return;
@@ -441,14 +411,10 @@ class Atom extends Renderer\AbstractRenderer implements Renderer\RendererInterfa
     /**
      * Append Source element (Atom 1.0 Feed Metadata)
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _setSource(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         $source = $this->getDataContainer()->getSource();
         if (! $source) {
             return;
@@ -459,4 +425,6 @@ class Atom extends Renderer\AbstractRenderer implements Renderer\RendererInterfa
         $imported = $dom->importNode($element, true);
         $root->appendChild($imported);
     }
+
+    // phpcs:enable PSR2.Methods.MethodDeclaration.Underscore
 }

--- a/src/Writer/Renderer/Entry/Atom/Deleted.php
+++ b/src/Writer/Renderer/Entry/Atom/Deleted.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Writer\Renderer\Entry\Atom;
 
 use DateTime;
@@ -13,6 +7,8 @@ use DOMDocument;
 use DOMElement;
 use Laminas\Feed\Writer;
 use Laminas\Feed\Writer\Renderer;
+
+use function array_key_exists;
 
 class Deleted extends Renderer\AbstractRenderer implements Renderer\RendererInterface
 {
@@ -42,17 +38,15 @@ class Deleted extends Renderer\AbstractRenderer implements Renderer\RendererInte
         return $this;
     }
 
+    // phpcs:disable PSR2.Methods.MethodDeclaration.Underscore
+
     /**
      * Set tombstone comment
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _setComment(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         if (! $this->getDataContainer()->getComment()) {
             return;
         }
@@ -66,14 +60,10 @@ class Deleted extends Renderer\AbstractRenderer implements Renderer\RendererInte
     /**
      * Set entry authors
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _setBy(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         $data = $this->container->getBy();
         if (! $data || empty($data)) {
             return;
@@ -97,4 +87,6 @@ class Deleted extends Renderer\AbstractRenderer implements Renderer\RendererInte
             $uri->appendChild($text);
         }
     }
+
+    // phpcs:enable PSR2.Methods.MethodDeclaration.Underscore
 }

--- a/src/Writer/Renderer/Entry/AtomDeleted.php
+++ b/src/Writer/Renderer/Entry/AtomDeleted.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Writer\Renderer\Entry;
 
 use DateTime;
@@ -13,6 +7,8 @@ use DOMDocument;
 use DOMElement;
 use Laminas\Feed\Writer;
 use Laminas\Feed\Writer\Renderer;
+
+use function array_key_exists;
 
 class AtomDeleted extends Renderer\AbstractRenderer implements Renderer\RendererInterface
 {
@@ -42,17 +38,15 @@ class AtomDeleted extends Renderer\AbstractRenderer implements Renderer\Renderer
         return $this;
     }
 
+    // phpcs:disable PSR2.Methods.MethodDeclaration.Underscore
+
     /**
      * Set tombstone comment
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _setComment(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         if (! $this->getDataContainer()->getComment()) {
             return;
         }
@@ -66,14 +60,10 @@ class AtomDeleted extends Renderer\AbstractRenderer implements Renderer\Renderer
     /**
      * Set entry authors
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _setBy(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         $data = $this->container->getBy();
         if (! $data || empty($data)) {
             return;
@@ -97,4 +87,6 @@ class AtomDeleted extends Renderer\AbstractRenderer implements Renderer\Renderer
             $uri->appendChild($text);
         }
     }
+
+    // phpcs:enable PSR2.Methods.MethodDeclaration.Underscore
 }

--- a/src/Writer/Renderer/Entry/Rss.php
+++ b/src/Writer/Renderer/Entry/Rss.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Writer\Renderer\Entry;
 
 use DateTime;
@@ -14,6 +8,9 @@ use DOMElement;
 use Laminas\Feed\Uri;
 use Laminas\Feed\Writer;
 use Laminas\Feed\Writer\Renderer;
+
+use function array_key_exists;
+use function ctype_digit;
 
 class Rss extends Renderer\AbstractRenderer implements Renderer\RendererInterface
 {
@@ -55,19 +52,18 @@ class Rss extends Renderer\AbstractRenderer implements Renderer\RendererInterfac
         return $this;
     }
 
+    // phpcs:disable PSR2.Methods.MethodDeclaration.Underscore
+
     /**
      * Set entry title
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      * @throws Writer\Exception\InvalidArgumentException
      */
-    // @codingStandardsIgnoreStart
     protected function _setTitle(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
-        if (! $this->getDataContainer()->getDescription()
+        if (
+            ! $this->getDataContainer()->getDescription()
             && ! $this->getDataContainer()->getTitle()
         ) {
             $message   = 'RSS 2.0 entry elements SHOULD contain exactly one'
@@ -90,16 +86,13 @@ class Rss extends Renderer\AbstractRenderer implements Renderer\RendererInterfac
     /**
      * Set entry description
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      * @throws Writer\Exception\InvalidArgumentException
      */
-    // @codingStandardsIgnoreStart
     protected function _setDescription(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
-        if (! $this->getDataContainer()->getDescription()
+        if (
+            ! $this->getDataContainer()->getDescription()
             && ! $this->getDataContainer()->getTitle()
         ) {
             $message   = 'RSS 2.0 entry elements SHOULD contain exactly one'
@@ -126,14 +119,10 @@ class Rss extends Renderer\AbstractRenderer implements Renderer\RendererInterfac
     /**
      * Set date entry was last modified
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _setDateModified(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         if (! $this->getDataContainer()->getDateModified()) {
             return;
         }
@@ -149,14 +138,10 @@ class Rss extends Renderer\AbstractRenderer implements Renderer\RendererInterfac
     /**
      * Set date entry was created
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _setDateCreated(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         if (! $this->getDataContainer()->getDateCreated()) {
             return;
         }
@@ -170,14 +155,10 @@ class Rss extends Renderer\AbstractRenderer implements Renderer\RendererInterfac
     /**
      * Set entry authors
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _setAuthors(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         $authors = $this->container->getAuthors();
         if (! $authors || empty($authors)) {
             return;
@@ -197,15 +178,11 @@ class Rss extends Renderer\AbstractRenderer implements Renderer\RendererInterfac
     /**
      * Set entry enclosure
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      * @throws Writer\Exception\InvalidArgumentException
      */
-    // @codingStandardsIgnoreStart
     protected function _setEnclosure(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         $data = $this->container->getEnclosure();
         if (! $data || empty($data)) {
             return;
@@ -249,14 +226,10 @@ class Rss extends Renderer\AbstractRenderer implements Renderer\RendererInterfac
     /**
      * Set link to entry
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _setLink(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         if (! $this->getDataContainer()->getLink()) {
             return;
         }
@@ -269,15 +242,12 @@ class Rss extends Renderer\AbstractRenderer implements Renderer\RendererInterfac
     /**
      * Set entry identifier
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _setId(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
-        if (! $this->getDataContainer()->getId()
+        if (
+            ! $this->getDataContainer()->getId()
             && ! $this->getDataContainer()->getLink()
         ) {
             return;
@@ -303,14 +273,10 @@ class Rss extends Renderer\AbstractRenderer implements Renderer\RendererInterfac
     /**
      * Set link to entry comments
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _setCommentLink(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         $link = $this->getDataContainer()->getCommentLink();
         if (! $link) {
             return;
@@ -324,14 +290,10 @@ class Rss extends Renderer\AbstractRenderer implements Renderer\RendererInterfac
     /**
      * Set entry categories
      *
-     * @param DOMDocument $dom
-     * @param DOMElement $root
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _setCategories(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         $categories = $this->getDataContainer()->getCategories();
         if (! $categories) {
             return;
@@ -346,4 +308,6 @@ class Rss extends Renderer\AbstractRenderer implements Renderer\RendererInterfac
             $root->appendChild($category);
         }
     }
+
+    // phpcs:enable PSR2.Methods.MethodDeclaration.Underscore
 }

--- a/src/Writer/Renderer/Feed/AbstractAtom.php
+++ b/src/Writer/Renderer/Feed/AbstractAtom.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Writer\Renderer\Feed;
 
 use DateTime;
@@ -14,6 +8,9 @@ use DOMElement;
 use Laminas\Feed\Writer;
 use Laminas\Feed\Writer\Renderer;
 use Laminas\Feed\Writer\Version;
+
+use function array_key_exists;
+use function strtolower;
 
 class AbstractAtom extends Renderer\AbstractRenderer
 {
@@ -25,17 +22,15 @@ class AbstractAtom extends Renderer\AbstractRenderer
         parent::__construct($container);
     }
 
+    // phpcs:disable PSR2.Methods.MethodDeclaration.Underscore
+
     /**
      * Set feed language
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _setLanguage(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         if ($this->getDataContainer()->getLanguage()) {
             $root->setAttribute('xml:lang', $this->getDataContainer()->getLanguage());
         }
@@ -44,15 +39,11 @@ class AbstractAtom extends Renderer\AbstractRenderer
     /**
      * Set feed title
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      * @throws Writer\Exception\InvalidArgumentException
      */
-    // @codingStandardsIgnoreStart
     protected function _setTitle(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         if (! $this->getDataContainer()->getTitle()) {
             $message   = 'Atom 1.0 feed elements MUST contain exactly one'
                 . ' atom:title element but a title has not been set';
@@ -75,14 +66,10 @@ class AbstractAtom extends Renderer\AbstractRenderer
     /**
      * Set feed description
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _setDescription(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         if (! $this->getDataContainer()->getDescription()) {
             return;
         }
@@ -96,15 +83,11 @@ class AbstractAtom extends Renderer\AbstractRenderer
     /**
      * Set date feed was last modified
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      * @throws Writer\Exception\InvalidArgumentException
      */
-    // @codingStandardsIgnoreStart
     protected function _setDateModified(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         if (! $this->getDataContainer()->getDateModified()) {
             $message   = 'Atom 1.0 feed elements MUST contain exactly one'
                 . ' atom:updated element but a modification date has not been set';
@@ -128,14 +111,10 @@ class AbstractAtom extends Renderer\AbstractRenderer
     /**
      * Set feed generator string
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _setGenerator(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         if (! $this->getDataContainer()->getGenerator()) {
             $this->getDataContainer()->setGenerator(
                 'Laminas_Feed_Writer',
@@ -160,14 +139,10 @@ class AbstractAtom extends Renderer\AbstractRenderer
     /**
      * Set link to feed
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _setLink(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         if (! $this->getDataContainer()->getLink()) {
             return;
         }
@@ -181,15 +156,11 @@ class AbstractAtom extends Renderer\AbstractRenderer
     /**
      * Set feed links
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      * @throws Writer\Exception\InvalidArgumentException
      */
-    // @codingStandardsIgnoreStart
     protected function _setFeedLinks(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         $flinks = $this->getDataContainer()->getFeedLinks();
         if (! $flinks || ! array_key_exists('atom', $flinks)) {
             $message   = 'Atom 1.0 feed elements SHOULD contain one atom:link '
@@ -218,14 +189,10 @@ class AbstractAtom extends Renderer\AbstractRenderer
     /**
      * Set feed authors
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _setAuthors(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         $authors = $this->container->getAuthors();
         if (! $authors || empty($authors)) {
             /**
@@ -260,16 +227,13 @@ class AbstractAtom extends Renderer\AbstractRenderer
     /**
      * Set feed identifier
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      * @throws Writer\Exception\InvalidArgumentException
      */
-    // @codingStandardsIgnoreStart
     protected function _setId(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
-        if (! $this->getDataContainer()->getId()
+        if (
+            ! $this->getDataContainer()->getId()
             && ! $this->getDataContainer()->getLink()
         ) {
             $message   = 'Atom 1.0 feed elements MUST contain exactly one '
@@ -299,14 +263,10 @@ class AbstractAtom extends Renderer\AbstractRenderer
     /**
      * Set feed copyright
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _setCopyright(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         $copyright = $this->getDataContainer()->getCopyright();
         if (! $copyright) {
             return;
@@ -320,14 +280,10 @@ class AbstractAtom extends Renderer\AbstractRenderer
     /**
      * Set feed level logo (image)
      *
-     * @param DOMDocument $dom
-     * @param DOMElement $root
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _setImage(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         $image = $this->getDataContainer()->getImage();
         if (! $image) {
             return;
@@ -341,14 +297,10 @@ class AbstractAtom extends Renderer\AbstractRenderer
     /**
      * Set date feed was created
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _setDateCreated(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         if (! $this->getDataContainer()->getDateCreated()) {
             return;
         }
@@ -362,14 +314,10 @@ class AbstractAtom extends Renderer\AbstractRenderer
     /**
      * Set base URL to feed links
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _setBaseUrl(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         $baseUrl = $this->getDataContainer()->getBaseUrl();
         if (! $baseUrl) {
             return;
@@ -380,14 +328,10 @@ class AbstractAtom extends Renderer\AbstractRenderer
     /**
      * Set hubs to which this feed pushes
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _setHubs(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         $hubs = $this->getDataContainer()->getHubs();
         if (! $hubs) {
             return;
@@ -403,14 +347,10 @@ class AbstractAtom extends Renderer\AbstractRenderer
     /**
      * Set feed categories
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _setCategories(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         $categories = $this->getDataContainer()->getCategories();
         if (! $categories) {
             return;
@@ -429,4 +369,6 @@ class AbstractAtom extends Renderer\AbstractRenderer
             $root->appendChild($category);
         }
     }
+
+    // phpcs:enable PSR2.Methods.MethodDeclaration.Underscore
 }

--- a/src/Writer/Renderer/Feed/Atom.php
+++ b/src/Writer/Renderer/Feed/Atom.php
@@ -1,16 +1,14 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Writer\Renderer\Feed;
 
 use DOMDocument;
 use Laminas\Feed\Writer;
 use Laminas\Feed\Writer\Renderer;
+
+use function version_compare;
+
+use const PHP_VERSION;
 
 class Atom extends AbstractAtom implements Renderer\RendererInterface
 {

--- a/src/Writer/Renderer/Feed/Atom/AbstractAtom.php
+++ b/src/Writer/Renderer/Feed/Atom/AbstractAtom.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Writer\Renderer\Feed\Atom;
 
 use DateTime;
@@ -13,6 +7,9 @@ use DOMDocument;
 use DOMElement;
 use Laminas\Feed;
 use Laminas\Feed\Writer\Version;
+
+use function array_key_exists;
+use function strtolower;
 
 class AbstractAtom extends Feed\Writer\Renderer\AbstractRenderer
 {
@@ -24,17 +21,15 @@ class AbstractAtom extends Feed\Writer\Renderer\AbstractRenderer
         parent::__construct($container);
     }
 
+    // phpcs:disable PSR2.Methods.MethodDeclaration.Underscore
+
     /**
      * Set feed language
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _setLanguage(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         if ($this->getDataContainer()->getLanguage()) {
             $root->setAttribute('xml:lang', $this->getDataContainer()->getLanguage());
         }
@@ -43,15 +38,11 @@ class AbstractAtom extends Feed\Writer\Renderer\AbstractRenderer
     /**
      * Set feed title
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      * @throws Feed\Exception\InvalidArgumentException
      */
-    // @codingStandardsIgnoreStart
     protected function _setTitle(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         if (! $this->getDataContainer()->getTitle()) {
             $message   = 'Atom 1.0 feed elements MUST contain exactly one'
                 . ' atom:title element but a title has not been set';
@@ -74,14 +65,10 @@ class AbstractAtom extends Feed\Writer\Renderer\AbstractRenderer
     /**
      * Set feed description
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _setDescription(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         if (! $this->getDataContainer()->getDescription()) {
             return;
         }
@@ -95,15 +82,11 @@ class AbstractAtom extends Feed\Writer\Renderer\AbstractRenderer
     /**
      * Set date feed was last modified
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      * @throws Feed\Exception\InvalidArgumentException
      */
-    // @codingStandardsIgnoreStart
     protected function _setDateModified(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         if (! $this->getDataContainer()->getDateModified()) {
             $message   = 'Atom 1.0 feed elements MUST contain exactly one'
                 . ' atom:updated element but a modification date has not been set';
@@ -127,14 +110,10 @@ class AbstractAtom extends Feed\Writer\Renderer\AbstractRenderer
     /**
      * Set feed generator string
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _setGenerator(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         if (! $this->getDataContainer()->getGenerator()) {
             $this->getDataContainer()->setGenerator(
                 'Laminas_Feed_Writer',
@@ -159,14 +138,10 @@ class AbstractAtom extends Feed\Writer\Renderer\AbstractRenderer
     /**
      * Set link to feed
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _setLink(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         if (! $this->getDataContainer()->getLink()) {
             return;
         }
@@ -180,15 +155,11 @@ class AbstractAtom extends Feed\Writer\Renderer\AbstractRenderer
     /**
      * Set feed links
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      * @throws Feed\Exception\InvalidArgumentException
      */
-    // @codingStandardsIgnoreStart
     protected function _setFeedLinks(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         $flinks = $this->getDataContainer()->getFeedLinks();
         if (! $flinks || ! array_key_exists('atom', $flinks)) {
             $message   = 'Atom 1.0 feed elements SHOULD contain one atom:link '
@@ -217,14 +188,10 @@ class AbstractAtom extends Feed\Writer\Renderer\AbstractRenderer
     /**
      * Set feed authors
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _setAuthors(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         $authors = $this->container->getAuthors();
         if (! $authors || empty($authors)) {
             /**
@@ -259,16 +226,13 @@ class AbstractAtom extends Feed\Writer\Renderer\AbstractRenderer
     /**
      * Set feed identifier
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      * @throws Feed\Exception\InvalidArgumentException
      */
-    // @codingStandardsIgnoreStart
     protected function _setId(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
-        if (! $this->getDataContainer()->getId()
+        if (
+            ! $this->getDataContainer()->getId()
             && ! $this->getDataContainer()->getLink()
         ) {
             $message   = 'Atom 1.0 feed elements MUST contain exactly one '
@@ -298,14 +262,10 @@ class AbstractAtom extends Feed\Writer\Renderer\AbstractRenderer
     /**
      * Set feed copyright
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _setCopyright(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         $copyright = $this->getDataContainer()->getCopyright();
         if (! $copyright) {
             return;
@@ -319,14 +279,10 @@ class AbstractAtom extends Feed\Writer\Renderer\AbstractRenderer
     /**
      * Set feed level logo (image)
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _setImage(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         $image = $this->getDataContainer()->getImage();
         if (! $image) {
             return;
@@ -340,14 +296,10 @@ class AbstractAtom extends Feed\Writer\Renderer\AbstractRenderer
     /**
      * Set date feed was created
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _setDateCreated(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         if (! $this->getDataContainer()->getDateCreated()) {
             return;
         }
@@ -361,14 +313,10 @@ class AbstractAtom extends Feed\Writer\Renderer\AbstractRenderer
     /**
      * Set base URL to feed links
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _setBaseUrl(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         $baseUrl = $this->getDataContainer()->getBaseUrl();
         if (! $baseUrl) {
             return;
@@ -379,14 +327,10 @@ class AbstractAtom extends Feed\Writer\Renderer\AbstractRenderer
     /**
      * Set hubs to which this feed pushes
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _setHubs(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         $hubs = $this->getDataContainer()->getHubs();
         if (! $hubs) {
             return;
@@ -402,14 +346,10 @@ class AbstractAtom extends Feed\Writer\Renderer\AbstractRenderer
     /**
      * Set feed categories
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _setCategories(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         $categories = $this->getDataContainer()->getCategories();
         if (! $categories) {
             return;
@@ -428,4 +368,6 @@ class AbstractAtom extends Feed\Writer\Renderer\AbstractRenderer
             $root->appendChild($category);
         }
     }
+
+    // phpcs:enable PSR2.Methods.MethodDeclaration.Underscore
 }

--- a/src/Writer/Renderer/Feed/Atom/Source.php
+++ b/src/Writer/Renderer/Feed/Atom/Source.php
@@ -1,17 +1,13 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Writer\Renderer\Feed\Atom;
 
 use DOMDocument;
 use DOMElement;
 use Laminas\Feed\Writer;
 use Laminas\Feed\Writer\Renderer;
+
+use function array_key_exists;
 
 class Source extends AbstractAtom implements Renderer\RendererInterface
 {
@@ -61,14 +57,11 @@ class Source extends AbstractAtom implements Renderer\RendererInterface
     /**
      * Set feed generator string
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      */
-    // @codingStandardsIgnoreStart
+    // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     protected function _setGenerator(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         if (! $this->getDataContainer()->getGenerator()) {
             return;
         }

--- a/src/Writer/Renderer/Feed/AtomSource.php
+++ b/src/Writer/Renderer/Feed/AtomSource.php
@@ -1,17 +1,13 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Writer\Renderer\Feed;
 
 use DOMDocument;
 use DOMElement;
 use Laminas\Feed\Writer;
 use Laminas\Feed\Writer\Renderer;
+
+use function array_key_exists;
 
 class AtomSource extends AbstractAtom implements Renderer\RendererInterface
 {
@@ -61,14 +57,11 @@ class AtomSource extends AbstractAtom implements Renderer\RendererInterface
     /**
      * Set feed generator string
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      */
-    // @codingStandardsIgnoreStart
+    // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
     protected function _setGenerator(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         if (! $this->getDataContainer()->getGenerator()) {
             return;
         }

--- a/src/Writer/Renderer/Feed/Rss.php
+++ b/src/Writer/Renderer/Feed/Rss.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Writer\Renderer\Feed;
 
 use DateTime;
@@ -15,6 +9,13 @@ use Laminas\Feed\Uri;
 use Laminas\Feed\Writer;
 use Laminas\Feed\Writer\Renderer;
 use Laminas\Feed\Writer\Version;
+
+use function array_key_exists;
+use function ctype_digit;
+use function is_string;
+use function version_compare;
+
+use const PHP_VERSION;
 
 class Rss extends Renderer\AbstractRenderer implements Renderer\RendererInterface
 {
@@ -84,17 +85,15 @@ class Rss extends Renderer\AbstractRenderer implements Renderer\RendererInterfac
         return $this;
     }
 
+    // phpcs:disable PSR2.Methods.MethodDeclaration.Underscore
+
     /**
      * Set feed language
      *
-     * @param DOMDocument $dom
-     * @param DOMElement $root
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _setLanguage(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         $lang = $this->getDataContainer()->getLanguage();
         if (! $lang) {
             return;
@@ -107,15 +106,11 @@ class Rss extends Renderer\AbstractRenderer implements Renderer\RendererInterfac
     /**
      * Set feed title
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      * @throws Writer\Exception\InvalidArgumentException
      */
-    // @codingStandardsIgnoreStart
     protected function _setTitle(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         if (! $this->getDataContainer()->getTitle()) {
             $message   = 'RSS 2.0 feed elements MUST contain exactly one'
                 . ' title element but a title has not been set';
@@ -137,15 +132,11 @@ class Rss extends Renderer\AbstractRenderer implements Renderer\RendererInterfac
     /**
      * Set feed description
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      * @throws Writer\Exception\InvalidArgumentException
      */
-    // @codingStandardsIgnoreStart
     protected function _setDescription(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         if (! $this->getDataContainer()->getDescription()) {
             $message   = 'RSS 2.0 feed elements MUST contain exactly one'
                 . ' description element but one has not been set';
@@ -166,14 +157,10 @@ class Rss extends Renderer\AbstractRenderer implements Renderer\RendererInterfac
     /**
      * Set date feed was last modified
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _setDateModified(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         if (! $this->getDataContainer()->getDateModified()) {
             return;
         }
@@ -189,14 +176,10 @@ class Rss extends Renderer\AbstractRenderer implements Renderer\RendererInterfac
     /**
      * Set feed generator string
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _setGenerator(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         if (! $this->getDataContainer()->getGenerator()) {
             $this->getDataContainer()->setGenerator(
                 'Laminas_Feed_Writer',
@@ -222,15 +205,11 @@ class Rss extends Renderer\AbstractRenderer implements Renderer\RendererInterfac
     /**
      * Set link to feed
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      * @throws Writer\Exception\InvalidArgumentException
      */
-    // @codingStandardsIgnoreStart
     protected function _setLink(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         $value = $this->getDataContainer()->getLink();
         if (! $value) {
             $message   = 'RSS 2.0 feed elements MUST contain exactly one'
@@ -255,14 +234,10 @@ class Rss extends Renderer\AbstractRenderer implements Renderer\RendererInterfac
     /**
      * Set feed authors
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _setAuthors(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         $authors = $this->getDataContainer()->getAuthors();
         if (! $authors || empty($authors)) {
             return;
@@ -282,14 +257,10 @@ class Rss extends Renderer\AbstractRenderer implements Renderer\RendererInterfac
     /**
      * Set feed copyright
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _setCopyright(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         $copyright = $this->getDataContainer()->getCopyright();
         if (! $copyright) {
             return;
@@ -303,21 +274,18 @@ class Rss extends Renderer\AbstractRenderer implements Renderer\RendererInterfac
     /**
      * Set feed channel image
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      * @throws Writer\Exception\InvalidArgumentException
      */
-    // @codingStandardsIgnoreStart
     protected function _setImage(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         $image = $this->getDataContainer()->getImage();
         if (! $image) {
             return;
         }
 
-        if (! isset($image['title']) || empty($image['title'])
+        if (
+            ! isset($image['title']) || empty($image['title'])
             || ! is_string($image['title'])
         ) {
             $message   = 'RSS 2.0 feed images must include a title';
@@ -330,7 +298,8 @@ class Rss extends Renderer\AbstractRenderer implements Renderer\RendererInterfac
             }
         }
 
-        if (empty($image['link']) || ! is_string($image['link'])
+        if (
+            empty($image['link']) || ! is_string($image['link'])
             || ! Uri::factory($image['link'])->isValid()
         ) {
             $message   = 'Invalid parameter: parameter \'link\''
@@ -419,14 +388,10 @@ class Rss extends Renderer\AbstractRenderer implements Renderer\RendererInterfac
     /**
      * Set date feed was created
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _setDateCreated(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         if (! $this->getDataContainer()->getDateCreated()) {
             return;
         }
@@ -440,14 +405,10 @@ class Rss extends Renderer\AbstractRenderer implements Renderer\RendererInterfac
     /**
      * Set date feed last build date
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _setLastBuildDate(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         if (! $this->getDataContainer()->getLastBuildDate()) {
             return;
         }
@@ -463,14 +424,10 @@ class Rss extends Renderer\AbstractRenderer implements Renderer\RendererInterfac
     /**
      * Set base URL to feed links
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _setBaseUrl(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         $baseUrl = $this->getDataContainer()->getBaseUrl();
         if (! $baseUrl) {
             return;
@@ -481,14 +438,10 @@ class Rss extends Renderer\AbstractRenderer implements Renderer\RendererInterfac
     /**
      * Set feed categories
      *
-     * @param  DOMDocument $dom
-     * @param  DOMElement $root
      * @return void
      */
-    // @codingStandardsIgnoreStart
     protected function _setCategories(DOMDocument $dom, DOMElement $root)
     {
-        // @codingStandardsIgnoreEnd
         $categories = $this->getDataContainer()->getCategories();
         if (! $categories) {
             return;
@@ -503,4 +456,6 @@ class Rss extends Renderer\AbstractRenderer implements Renderer\RendererInterfac
             $root->appendChild($category);
         }
     }
+
+    // phpcs:enable PSR2.Methods.MethodDeclaration.Underscore
 }

--- a/src/Writer/Renderer/RendererInterface.php
+++ b/src/Writer/Renderer/RendererInterface.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Writer\Renderer;
 
 use DOMDocument;

--- a/src/Writer/Source.php
+++ b/src/Writer/Source.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Writer;
 
 class Source extends AbstractFeed

--- a/src/Writer/StandaloneExtensionManager.php
+++ b/src/Writer/StandaloneExtensionManager.php
@@ -1,17 +1,18 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Writer;
 
 use Laminas\Feed\Writer\Exception\InvalidArgumentException;
 
+use function array_key_exists;
+use function is_a;
+use function is_string;
+use function sprintf;
+use function substr;
+
 class StandaloneExtensionManager implements ExtensionManagerInterface
 {
+    /** @var array<string, class-string> */
     private $extensions = [
         'Atom\Renderer\Feed'               => Extension\Atom\Renderer\Feed::class,
         'Content\Renderer\Entry'           => Extension\Content\Renderer\Entry::class,
@@ -62,11 +63,13 @@ class StandaloneExtensionManager implements ExtensionManagerInterface
      *
      * @param string $name
      * @param string $class
+     * @psalm-param class-string $class
      * @return void
      */
     public function add($name, $class)
     {
-        if (is_string($class)
+        if (
+            is_string($class)
             && (is_a($class, Extension\AbstractRenderer::class, true)
                 || 'Feed' === substr($class, -4)
                 || 'Entry' === substr($class, -5))

--- a/src/Writer/Version.php
+++ b/src/Writer/Version.php
@@ -1,14 +1,9 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Writer;
 
+// phpcs:ignore WebimpressCodingStandard.NamingConventions.AbstractClass.Prefix
 abstract class Version
 {
-    const VERSION = '2';
+    public const VERSION = '2';
 }

--- a/src/Writer/Writer.php
+++ b/src/Writer/Writer.php
@@ -1,45 +1,44 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\Feed\Writer;
+
+use function in_array;
+use function lcfirst;
+use function sprintf;
+use function trigger_error;
+
+use const E_USER_NOTICE;
 
 class Writer
 {
     /**
      * Namespace constants
      */
-    const NAMESPACE_ATOM_03 = 'http://purl.org/atom/ns#';
-    const NAMESPACE_ATOM_10 = 'http://www.w3.org/2005/Atom';
-    const NAMESPACE_RDF     = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#';
-    const NAMESPACE_RSS_090 = 'http://my.netscape.com/rdf/simple/0.9/';
-    const NAMESPACE_RSS_10  = 'http://purl.org/rss/1.0/';
+    public const NAMESPACE_ATOM_03 = 'http://purl.org/atom/ns#';
+    public const NAMESPACE_ATOM_10 = 'http://www.w3.org/2005/Atom';
+    public const NAMESPACE_RDF     = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#';
+    public const NAMESPACE_RSS_090 = 'http://my.netscape.com/rdf/simple/0.9/';
+    public const NAMESPACE_RSS_10  = 'http://purl.org/rss/1.0/';
 
     /**
      * Feed type constants
      */
-    const TYPE_ANY              = 'any';
-    const TYPE_ATOM_03          = 'atom-03';
-    const TYPE_ATOM_10          = 'atom-10';
-    const TYPE_ATOM_ANY         = 'atom';
-    const TYPE_RSS_090          = 'rss-090';
-    const TYPE_RSS_091          = 'rss-091';
-    const TYPE_RSS_091_NETSCAPE = 'rss-091n';
-    const TYPE_RSS_091_USERLAND = 'rss-091u';
-    const TYPE_RSS_092          = 'rss-092';
-    const TYPE_RSS_093          = 'rss-093';
-    const TYPE_RSS_094          = 'rss-094';
-    const TYPE_RSS_10           = 'rss-10';
-    const TYPE_RSS_20           = 'rss-20';
-    const TYPE_RSS_ANY          = 'rss';
+    public const TYPE_ANY              = 'any';
+    public const TYPE_ATOM_03          = 'atom-03';
+    public const TYPE_ATOM_10          = 'atom-10';
+    public const TYPE_ATOM_ANY         = 'atom';
+    public const TYPE_RSS_090          = 'rss-090';
+    public const TYPE_RSS_091          = 'rss-091';
+    public const TYPE_RSS_091_NETSCAPE = 'rss-091n';
+    public const TYPE_RSS_091_USERLAND = 'rss-091u';
+    public const TYPE_RSS_092          = 'rss-092';
+    public const TYPE_RSS_093          = 'rss-093';
+    public const TYPE_RSS_094          = 'rss-094';
+    public const TYPE_RSS_10           = 'rss-10';
+    public const TYPE_RSS_20           = 'rss-20';
+    public const TYPE_RSS_ANY          = 'rss';
 
-    /**
-     * @var ExtensionManagerInterface
-     */
+    /** @var ExtensionManagerInterface */
     protected static $extensionManager;
 
     /**
@@ -58,8 +57,6 @@ class Writer
 
     /**
      * Set plugin loader for use with Extensions
-     *
-     * @param ExtensionManagerInterface
      *
      * @return void
      */
@@ -86,7 +83,7 @@ class Writer
      *
      * @param  string $name
      * @return void
-     * @throws Exception\RuntimeException if unable to resolve Extension class
+     * @throws Exception\RuntimeException If unable to resolve Extension class.
      */
     public static function registerExtension($name)
     {
@@ -137,7 +134,8 @@ class Writer
         $entryName         = $extensionName . '\Entry';
         $feedRendererName  = $extensionName . '\Renderer\Feed';
         $entryRendererName = $extensionName . '\Renderer\Entry';
-        if (in_array($feedName, static::$extensions['feed'])
+        if (
+            in_array($feedName, static::$extensions['feed'])
             || in_array($entryName, static::$extensions['entry'])
             || in_array($feedRendererName, static::$extensions['feedRenderer'])
             || in_array($entryRendererName, static::$extensions['entryRenderer'])
@@ -200,7 +198,7 @@ class Writer
                     . ' and %1$s\Extension\GooglePlayPodcast\Renderer\Feed.',
                     __NAMESPACE__
                 ),
-                \E_USER_NOTICE
+                E_USER_NOTICE
             );
 
         // Added in development; check for it conditionally
@@ -215,7 +213,7 @@ class Writer
                     . ' and %1$s\Extension\PodcastIndex\Renderer\Feed.',
                     __NAMESPACE__
                 ),
-                \E_USER_NOTICE
+                E_USER_NOTICE
             );
     }
 

--- a/test/PubSubHubbub/AbstractCallbackTest.php
+++ b/test/PubSubHubbub/AbstractCallbackTest.php
@@ -1,15 +1,11 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Feed\PubSubHubbub;
 
 use PHPUnit\Framework\TestCase;
 use ReflectionMethod;
+
+use function array_merge;
 
 class AbstractCallbackTest extends TestCase
 {

--- a/test/PubSubHubbub/ClientNotReset.php
+++ b/test/PubSubHubbub/ClientNotReset.php
@@ -1,24 +1,25 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Feed\PubSubHubbub;
 
 use Laminas\Http\Client as HttpClient;
 use Laminas\Http\Request;
+use Laminas\Http\Response;
 
 class ClientNotReset extends HttpClient
 {
+    /**
+     * @param bool $clearCookies
+     * @param bool $clearAuth
+     * @return static
+     */
     public function resetParameters($clearCookies = false, $clearAuth = true)
     {
-        // Do nothing
+        return $this;
     }
 
-    public function send(Request $request = null)
+    /** @return Response */
+    public function send(?Request $request = null)
     {
         return $this->response;
     }

--- a/test/PubSubHubbub/Model/SubscriptionTest.php
+++ b/test/PubSubHubbub/Model/SubscriptionTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Feed\PubSubHubbub\Model;
 
 use DateTime;
@@ -16,6 +10,11 @@ use Laminas\Feed\PubSubHubbub\Model\SubscriptionPersistenceInterface;
 use PDO;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
+
+use function array_keys;
+use function extension_loaded;
+use function in_array;
+use function uniqid;
 
 /**
  * @group Laminas_Feed
@@ -76,9 +75,10 @@ class SubscriptionTest extends TestCase
         $this->assertSame($subscription->getNow(), $now);
     }
 
-    protected function initDb()
+    protected function initDb(): DbAdapter
     {
-        if (! extension_loaded('pdo')
+        if (
+            ! extension_loaded('pdo')
             || ! in_array('sqlite', PDO::getAvailableDrivers())
         ) {
             $this->markTestSkipped('Test only with pdo_sqlite');

--- a/test/PubSubHubbub/PubSubHubbubTest.php
+++ b/test/PubSubHubbub/PubSubHubbubTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Feed\PubSubHubbub;
 
 use Laminas\Feed\PubSubHubbub\PubSubHubbub;

--- a/test/PubSubHubbub/PublisherTest.php
+++ b/test/PubSubHubbub/PublisherTest.php
@@ -297,7 +297,6 @@ class PublisherTest extends TestCase
     public function testNotifiesHubAndReportsSuccess(): void
     {
         PubSubHubbub::setHttpClient($this->getClientSuccess());
-        PubSubHubbub::getHttpClient();
 
         $this->publisher->addHubUrl('http://www.example.com/hub');
         $this->publisher->addUpdatedTopicUrl('http://www.example.com/topic');
@@ -309,7 +308,6 @@ class PublisherTest extends TestCase
     public function testNotifiesHubAndReportsFail(): void
     {
         PubSubHubbub::setHttpClient($this->getClientFail());
-        PubSubHubbub::getHttpClient();
 
         $this->publisher->addHubUrl('http://www.example.com/hub');
         $this->publisher->addUpdatedTopicUrl('http://www.example.com/topic');

--- a/test/PubSubHubbub/PublisherTest.php
+++ b/test/PubSubHubbub/PublisherTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Feed\PubSubHubbub;
 
 use Laminas\Feed\PubSubHubbub\Exception\ExceptionInterface;
@@ -303,7 +297,8 @@ class PublisherTest extends TestCase
     public function testNotifiesHubAndReportsSuccess(): void
     {
         PubSubHubbub::setHttpClient($this->getClientSuccess());
-        $client = PubSubHubbub::getHttpClient();
+        PubSubHubbub::getHttpClient();
+
         $this->publisher->addHubUrl('http://www.example.com/hub');
         $this->publisher->addUpdatedTopicUrl('http://www.example.com/topic');
         $this->publisher->setParameter('foo', 'bar');
@@ -314,7 +309,8 @@ class PublisherTest extends TestCase
     public function testNotifiesHubAndReportsFail(): void
     {
         PubSubHubbub::setHttpClient($this->getClientFail());
-        $client = PubSubHubbub::getHttpClient();
+        PubSubHubbub::getHttpClient();
+
         $this->publisher->addHubUrl('http://www.example.com/hub');
         $this->publisher->addUpdatedTopicUrl('http://www.example.com/topic');
         $this->publisher->setParameter('foo', 'bar');

--- a/test/PubSubHubbub/Subscriber/CallbackTest.php
+++ b/test/PubSubHubbub/Subscriber/CallbackTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Feed\PubSubHubbub\Subscriber;
 
 use ArrayObject;
@@ -19,10 +13,20 @@ use Laminas\Feed\PubSubHubbub\Exception\ExceptionInterface;
 use Laminas\Feed\PubSubHubbub\HttpResponse;
 use Laminas\Feed\PubSubHubbub\Model;
 use Laminas\Feed\PubSubHubbub\Subscriber\Callback as CallbackSubscriber;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use ReflectionProperty;
 use stdClass;
+
+use function file_get_contents;
+use function fopen;
+use function fwrite;
+use function hash;
+use function rewind;
+use function str_replace;
+use function time;
+use function uniqid;
 
 /**
  * @group Laminas_Feed
@@ -30,47 +34,45 @@ use stdClass;
  */
 class CallbackTest extends TestCase
 {
-    // @codingStandardsIgnoreStart
     /** @var CallbackSubscriber */
-    public $_callback;
-    /** @var \Laminas\Db\Adapter\Adapter|\PHPUnit_Framework_MockObject_MockObject */
-    public $_adapter;
-    /** @var \Laminas\Db\TableGateway\TableGateway|\PHPUnit_Framework_MockObject_MockObject */
-    public $_tableGateway;
-    /** @var \Laminas\Db\ResultSet\ResultSet|\PHPUnit_Framework_MockObject_MockObject */
-    public $_rowset;
+    public $callback;
+    /** @var Adapter&MockObject */
+    public $adapter;
+    /** @var TableGateway&MockObject */
+    public $tableGateway;
+    /** @var ResultSet&MockObject */
+    public $rowset;
     /** @var array */
-    public $_get;
-    // @codingStandardsIgnoreEnd
+    public $get;
 
     /** @var DateTime */
     public $now;
 
     protected function setUp(): void
     {
-        $this->_callback = new CallbackSubscriber();
+        $this->callback = new CallbackSubscriber();
 
-        $this->_adapter      = $this->_getCleanMock(
+        $this->adapter      = $this->getCleanMock(
             Adapter::class
         );
-        $this->_tableGateway = $this->_getCleanMock(
+        $this->tableGateway = $this->getCleanMock(
             TableGateway::class
         );
-        $this->_rowset       = $this->_getCleanMock(
+        $this->rowset       = $this->getCleanMock(
             ResultSet::class
         );
 
-        $this->_tableGateway->expects($this->any())
+        $this->tableGateway->expects($this->any())
             ->method('getAdapter')
-            ->will($this->returnValue($this->_adapter));
-        $storage = new Model\Subscription($this->_tableGateway);
+            ->will($this->returnValue($this->adapter));
+        $storage = new Model\Subscription($this->tableGateway);
 
         $this->now = new DateTime();
         $storage->setNow(clone $this->now);
 
-        $this->_callback->setStorage($storage);
+        $this->callback->setStorage($storage);
 
-        $this->_get = [
+        $this->get = [
             'hub_mode'          => 'subscribe',
             'hub_topic'         => 'http://www.example.com/topic',
             'hub_challenge'     => 'abc',
@@ -103,61 +105,61 @@ class CallbackTest extends TestCase
 
     public function testCanSetHttpResponseObject(): void
     {
-        $this->_callback->setHttpResponse(new HttpResponse());
-        $this->assertInstanceOf(HttpResponse::class, $this->_callback->getHttpResponse());
+        $this->callback->setHttpResponse(new HttpResponse());
+        $this->assertInstanceOf(HttpResponse::class, $this->callback->getHttpResponse());
     }
 
     public function testCanUsesDefaultHttpResponseObject(): void
     {
-        $this->assertInstanceOf(HttpResponse::class, $this->_callback->getHttpResponse());
+        $this->assertInstanceOf(HttpResponse::class, $this->callback->getHttpResponse());
     }
 
     public function testThrowsExceptionOnInvalidHttpResponseObjectSet(): void
     {
         $this->expectException(ExceptionInterface::class);
-        $this->_callback->setHttpResponse(new stdClass());
+        $this->callback->setHttpResponse(new stdClass());
     }
 
     public function testThrowsExceptionIfNonObjectSetAsHttpResponseObject(): void
     {
         $this->expectException(ExceptionInterface::class);
-        $this->_callback->setHttpResponse('');
+        $this->callback->setHttpResponse('');
     }
 
     public function testCanSetSubscriberCount(): void
     {
-        $this->_callback->setSubscriberCount('10000');
-        $this->assertEquals(10000, $this->_callback->getSubscriberCount());
+        $this->callback->setSubscriberCount('10000');
+        $this->assertEquals(10000, $this->callback->getSubscriberCount());
     }
 
     public function testDefaultSubscriberCountIsOne(): void
     {
-        $this->assertEquals(1, $this->_callback->getSubscriberCount());
+        $this->assertEquals(1, $this->callback->getSubscriberCount());
     }
 
     public function testThrowsExceptionOnSettingZeroAsSubscriberCount(): void
     {
         $this->expectException(ExceptionInterface::class);
-        $this->_callback->setSubscriberCount(0);
+        $this->callback->setSubscriberCount(0);
     }
 
     public function testThrowsExceptionOnSettingLessThanZeroAsSubscriberCount(): void
     {
         $this->expectException(ExceptionInterface::class);
-        $this->_callback->setSubscriberCount(-1);
+        $this->callback->setSubscriberCount(-1);
     }
 
     public function testThrowsExceptionOnSettingAnyScalarTypeCastToAZeroOrLessIntegerAsSubscriberCount(): void
     {
         $this->expectException(ExceptionInterface::class);
-        $this->_callback->setSubscriberCount('0aa');
+        $this->callback->setSubscriberCount('0aa');
     }
 
     public function testCanSetStorageImplementation(): void
     {
-        $storage = new Model\Subscription($this->_tableGateway);
-        $this->_callback->setStorage($storage);
-        $this->assertThat($this->_callback->getStorage(), $this->identicalTo($storage));
+        $storage = new Model\Subscription($this->tableGateway);
+        $this->callback->setStorage($storage);
+        $this->assertThat($this->callback->getStorage(), $this->identicalTo($storage));
     }
 
     /**
@@ -172,48 +174,48 @@ class CallbackTest extends TestCase
                 'verify_token' => hash('sha256', 'cba'),
             ]));
 
-        $this->_tableGateway->expects($this->any())
+        $this->tableGateway->expects($this->any())
             ->method('select')
             ->with($this->equalTo(['id' => 'verifytokenkey']))
-            ->will($this->returnValue($this->_rowset));
-        $this->_rowset->expects($this->any())
+            ->will($this->returnValue($this->rowset));
+        $this->rowset->expects($this->any())
             ->method('current')
             ->will($this->returnValue($mockReturnValue));
-        $this->_rowset->expects($this->any())
+        $this->rowset->expects($this->any())
             ->method('count')
             ->will($this->returnValue(1));
 
-        $this->assertTrue($this->_callback->isValidHubVerification($this->_get));
+        $this->assertTrue($this->callback->isValidHubVerification($this->get));
     }
 
     public function testReturnsFalseIfHubVerificationNotAGetRequest(): void
     {
         $_SERVER['REQUEST_METHOD'] = 'POST';
-        $this->assertFalse($this->_callback->isValidHubVerification($this->_get));
+        $this->assertFalse($this->callback->isValidHubVerification($this->get));
     }
 
     public function testReturnsFalseIfModeMissingFromHttpGetData(): void
     {
-        unset($this->_get['hub_mode']);
-        $this->assertFalse($this->_callback->isValidHubVerification($this->_get));
+        unset($this->get['hub_mode']);
+        $this->assertFalse($this->callback->isValidHubVerification($this->get));
     }
 
     public function testReturnsFalseIfTopicMissingFromHttpGetData(): void
     {
-        unset($this->_get['hub_topic']);
-        $this->assertFalse($this->_callback->isValidHubVerification($this->_get));
+        unset($this->get['hub_topic']);
+        $this->assertFalse($this->callback->isValidHubVerification($this->get));
     }
 
     public function testReturnsFalseIfChallengeMissingFromHttpGetData(): void
     {
-        unset($this->_get['hub_challenge']);
-        $this->assertFalse($this->_callback->isValidHubVerification($this->_get));
+        unset($this->get['hub_challenge']);
+        $this->assertFalse($this->callback->isValidHubVerification($this->get));
     }
 
     public function testReturnsFalseIfVerifyTokenMissingFromHttpGetData(): void
     {
-        unset($this->_get['hub_verify_token']);
-        $this->assertFalse($this->_callback->isValidHubVerification($this->_get));
+        unset($this->get['hub_verify_token']);
+        $this->assertFalse($this->callback->isValidHubVerification($this->get));
     }
 
     public function testReturnsTrueIfModeSetAsUnsubscribeFromHttpGetData(): void
@@ -225,64 +227,64 @@ class CallbackTest extends TestCase
                 'verify_token' => hash('sha256', 'cba'),
             ]));
 
-        $this->_get['hub_mode'] = 'unsubscribe';
-        $this->_tableGateway->expects($this->any())
+        $this->get['hub_mode'] = 'unsubscribe';
+        $this->tableGateway->expects($this->any())
             ->method('select')
             ->with($this->equalTo(['id' => 'verifytokenkey']))
-            ->will($this->returnValue($this->_rowset));
-        $this->_rowset->expects($this->any())
+            ->will($this->returnValue($this->rowset));
+        $this->rowset->expects($this->any())
             ->method('current')
             ->will($this->returnValue($mockReturnValue));
         // require for the count call on the rowset in Model/Subscription
-        $this->_rowset->expects($this->any())
+        $this->rowset->expects($this->any())
             ->method('count')
             ->will($this->returnValue(1));
 
-        $this->assertTrue($this->_callback->isValidHubVerification($this->_get));
+        $this->assertTrue($this->callback->isValidHubVerification($this->get));
     }
 
     public function testReturnsFalseIfModeNotRecognisedFromHttpGetData(): void
     {
-        $this->_get['hub_mode'] = 'abc';
-        $this->assertFalse($this->_callback->isValidHubVerification($this->_get));
+        $this->get['hub_mode'] = 'abc';
+        $this->assertFalse($this->callback->isValidHubVerification($this->get));
     }
 
     public function testReturnsFalseIfLeaseSecondsMissedWhenModeIsSubscribeFromHttpGetData(): void
     {
-        unset($this->_get['hub_lease_seconds']);
-        $this->assertFalse($this->_callback->isValidHubVerification($this->_get));
+        unset($this->get['hub_lease_seconds']);
+        $this->assertFalse($this->callback->isValidHubVerification($this->get));
     }
 
     public function testReturnsFalseIfHubTopicInvalidFromHttpGetData(): void
     {
-        $this->_get['hub_topic'] = 'http://';
-        $this->assertFalse($this->_callback->isValidHubVerification($this->_get));
+        $this->get['hub_topic'] = 'http://';
+        $this->assertFalse($this->callback->isValidHubVerification($this->get));
     }
 
     public function testReturnsFalseIfVerifyTokenRecordDoesNotExistForConfirmRequest(): void
     {
-        $this->assertFalse($this->_callback->isValidHubVerification($this->_get));
+        $this->assertFalse($this->callback->isValidHubVerification($this->get));
     }
 
     public function testReturnsFalseIfVerifyTokenRecordDoesNotAgreeWithConfirmRequest(): void
     {
-        $this->assertFalse($this->_callback->isValidHubVerification($this->_get));
+        $this->assertFalse($this->callback->isValidHubVerification($this->get));
     }
 
     public function testRespondsToInvalidConfirmationWith404Response(): void
     {
-        unset($this->_get['hub_mode']);
-        $this->_callback->handle($this->_get);
-        $this->assertEquals(404, $this->_callback->getHttpResponse()->getStatusCode());
+        unset($this->get['hub_mode']);
+        $this->callback->handle($this->get);
+        $this->assertEquals(404, $this->callback->getHttpResponse()->getStatusCode());
     }
 
     public function testRespondsToValidConfirmationWith200Response(): void
     {
-        $this->_get['hub_mode'] = 'unsubscribe';
-        $this->_tableGateway->expects($this->any())
+        $this->get['hub_mode'] = 'unsubscribe';
+        $this->tableGateway->expects($this->any())
             ->method('select')
             ->with($this->equalTo(['id' => 'verifytokenkey']))
-            ->will($this->returnValue($this->_rowset));
+            ->will($this->returnValue($this->rowset));
 
         $t       = clone $this->now;
         $rowdata = [
@@ -294,29 +296,29 @@ class CallbackTest extends TestCase
 
         $row = new ArrayObject($rowdata, ArrayObject::ARRAY_AS_PROPS);
 
-        $this->_rowset->expects($this->any())
+        $this->rowset->expects($this->any())
             ->method('current')
             ->will($this->returnValue($row));
         // require for the count call on the rowset in Model/Subscription
-        $this->_rowset->expects($this->any())
+        $this->rowset->expects($this->any())
             ->method('count')
             ->will($this->returnValue(1));
 
-        $this->_tableGateway->expects($this->once())
+        $this->tableGateway->expects($this->once())
             ->method('delete')
             ->with($this->equalTo(['id' => 'verifytokenkey']))
             ->will($this->returnValue(true));
 
-        $this->_callback->handle($this->_get);
-        $this->assertEquals(200, $this->_callback->getHttpResponse()->getStatusCode());
+        $this->callback->handle($this->get);
+        $this->assertEquals(200, $this->callback->getHttpResponse()->getStatusCode());
     }
 
     public function testRespondsToValidConfirmationWithBodyContainingHubChallenge(): void
     {
-        $this->_tableGateway->expects($this->any())
+        $this->tableGateway->expects($this->any())
             ->method('select')
             ->with($this->equalTo(['id' => 'verifytokenkey']))
-            ->will($this->returnValue($this->_rowset));
+            ->will($this->returnValue($this->rowset));
 
         $t       = clone $this->now;
         $rowdata = [
@@ -328,15 +330,15 @@ class CallbackTest extends TestCase
 
         $row = new ArrayObject($rowdata, ArrayObject::ARRAY_AS_PROPS);
 
-        $this->_rowset->expects($this->any())
+        $this->rowset->expects($this->any())
             ->method('current')
             ->will($this->returnValue($row));
         // require for the count call on the rowset in Model/Subscription
-        $this->_rowset->expects($this->any())
+        $this->rowset->expects($this->any())
             ->method('count')
             ->will($this->returnValue(1));
 
-        $this->_tableGateway->expects($this->once())
+        $this->tableGateway->expects($this->once())
             ->method('update')
             ->with(
                 $this->equalTo([
@@ -350,8 +352,8 @@ class CallbackTest extends TestCase
                 $this->equalTo(['id' => 'verifytokenkey'])
             );
 
-        $this->_callback->handle($this->_get);
-        $this->assertEquals('abc', $this->_callback->getHttpResponse()->getContent());
+        $this->callback->handle($this->get);
+        $this->assertEquals('abc', $this->callback->getHttpResponse()->getContent());
     }
 
     public function testRespondsToValidFeedUpdateRequestWith200Response(): void
@@ -361,12 +363,12 @@ class CallbackTest extends TestCase
         $_SERVER['CONTENT_TYPE']   = 'application/atom+xml';
         $feedXml                   = file_get_contents(__DIR__ . '/_files/atom10.xml');
 
-        $this->mockInputStream($this->_callback, $feedXml);
+        $this->mockInputStream($this->callback, $feedXml);
 
-        $this->_tableGateway->expects($this->any())
+        $this->tableGateway->expects($this->any())
             ->method('select')
             ->with($this->equalTo(['id' => 'verifytokenkey']))
-            ->will($this->returnValue($this->_rowset));
+            ->will($this->returnValue($this->rowset));
 
         $rowdata = [
             'id'           => 'verifytokenkey',
@@ -376,16 +378,16 @@ class CallbackTest extends TestCase
 
         $row = new ArrayObject($rowdata, ArrayObject::ARRAY_AS_PROPS);
 
-        $this->_rowset->expects($this->any())
+        $this->rowset->expects($this->any())
             ->method('current')
             ->will($this->returnValue($row));
         // require for the count call on the rowset in Model/Subscription
-        $this->_rowset->expects($this->any())
+        $this->rowset->expects($this->any())
             ->method('count')
             ->will($this->returnValue(1));
 
-        $this->_callback->handle([]);
-        $this->assertEquals(200, $this->_callback->getHttpResponse()->getStatusCode());
+        $this->callback->handle([]);
+        $this->assertEquals(200, $this->callback->getHttpResponse()->getStatusCode());
     }
 
     public function testRespondsToInvalidFeedUpdateNotPostWith404Response(): void
@@ -396,10 +398,10 @@ class CallbackTest extends TestCase
         $_SERVER['CONTENT_TYPE']   = 'application/atom+xml';
         $feedXml                   = file_get_contents(__DIR__ . '/_files/atom10.xml');
 
-        $this->mockInputStream($this->_callback, $feedXml);
+        $this->mockInputStream($this->callback, $feedXml);
 
-        $this->_callback->handle([]);
-        $this->assertEquals(404, $this->_callback->getHttpResponse()->getStatusCode());
+        $this->callback->handle([]);
+        $this->assertEquals(404, $this->callback->getHttpResponse()->getStatusCode());
     }
 
     public function testRespondsToInvalidFeedUpdateWrongMimeWith404Response(): void
@@ -409,10 +411,10 @@ class CallbackTest extends TestCase
         $_SERVER['CONTENT_TYPE']   = 'application/kml+xml';
         $feedXml                   = file_get_contents(__DIR__ . '/_files/atom10.xml');
 
-        $this->mockInputStream($this->_callback, $feedXml);
+        $this->mockInputStream($this->callback, $feedXml);
 
-        $this->_callback->handle([]);
-        $this->assertEquals(404, $this->_callback->getHttpResponse()->getStatusCode());
+        $this->callback->handle([]);
+        $this->assertEquals(404, $this->callback->getHttpResponse()->getStatusCode());
     }
 
     /**
@@ -428,12 +430,12 @@ class CallbackTest extends TestCase
         $_SERVER['CONTENT_TYPE']   = 'application/rss+xml';
         $feedXml                   = file_get_contents(__DIR__ . '/_files/atom10.xml');
 
-        $this->mockInputStream($this->_callback, $feedXml);
+        $this->mockInputStream($this->callback, $feedXml);
 
-        $this->_tableGateway->expects($this->any())
+        $this->tableGateway->expects($this->any())
             ->method('select')
             ->with($this->equalTo(['id' => 'verifytokenkey']))
-            ->will($this->returnValue($this->_rowset));
+            ->will($this->returnValue($this->rowset));
 
         $rowdata = [
             'id'            => 'verifytokenkey',
@@ -444,16 +446,16 @@ class CallbackTest extends TestCase
 
         $row = new ArrayObject($rowdata, ArrayObject::ARRAY_AS_PROPS);
 
-        $this->_rowset->expects($this->any())
+        $this->rowset->expects($this->any())
             ->method('current')
             ->will($this->returnValue($row));
         // require for the count call on the rowset in Model/Subscription
-        $this->_rowset->expects($this->any())
+        $this->rowset->expects($this->any())
             ->method('count')
             ->will($this->returnValue(1));
 
-        $this->_callback->handle([]);
-        $this->assertEquals(200, $this->_callback->getHttpResponse()->getStatusCode());
+        $this->callback->handle([]);
+        $this->assertEquals(200, $this->callback->getHttpResponse()->getStatusCode());
     }
 
     public function testRespondsToValidFeedUpdateWithXHubOnBehalfOfHeader(): void
@@ -463,12 +465,12 @@ class CallbackTest extends TestCase
         $_SERVER['CONTENT_TYPE']   = 'application/atom+xml';
         $feedXml                   = file_get_contents(__DIR__ . '/_files/atom10.xml');
 
-        $this->mockInputStream($this->_callback, $feedXml);
+        $this->mockInputStream($this->callback, $feedXml);
 
-        $this->_tableGateway->expects($this->any())
+        $this->tableGateway->expects($this->any())
             ->method('select')
             ->with($this->equalTo(['id' => 'verifytokenkey']))
-            ->will($this->returnValue($this->_rowset));
+            ->will($this->returnValue($this->rowset));
 
         $rowdata = [
             'id'            => 'verifytokenkey',
@@ -479,38 +481,36 @@ class CallbackTest extends TestCase
 
         $row = new ArrayObject($rowdata, ArrayObject::ARRAY_AS_PROPS);
 
-        $this->_rowset->expects($this->any())
+        $this->rowset->expects($this->any())
             ->method('current')
             ->will($this->returnValue($row));
         // require for the count call on the rowset in Model/Subscription
-        $this->_rowset->expects($this->any())
+        $this->rowset->expects($this->any())
             ->method('count')
             ->will($this->returnValue(1));
 
-        $this->_callback->handle([]);
-        $this->assertEquals(1, $this->_callback->getHttpResponse()->getHeader('X-Hub-On-Behalf-Of'));
+        $this->callback->handle([]);
+        $this->assertEquals(1, $this->callback->getHttpResponse()->getHeader('X-Hub-On-Behalf-Of'));
     }
 
-    // @codingStandardsIgnoreStart
-    protected function _getCleanMock(string $className): \PHPUnit\Framework\MockObject\MockObject
+    protected function getCleanMock(string $className): MockObject
     {
-        // @codingStandardsIgnoreEnd
         $class       = new ReflectionClass($className);
         $methods     = $class->getMethods();
         $stubMethods = [];
         foreach ($methods as $method) {
-            if ($method->isPublic()
+            if (
+                $method->isPublic()
                 || ($method->isProtected() && $method->isAbstract())
             ) {
                 $stubMethods[] = $method->getName();
             }
         }
-        $mocked = $this->getMockBuilder($className)
+        return $this->getMockBuilder($className)
             ->setMethods($stubMethods)
             ->setConstructorArgs([])
             ->setMockClassName(str_replace('\\', '_', $className . '_PubsubSubscriberMock_' . uniqid()))
             ->disableOriginalConstructor()
             ->getMock();
-        return $mocked;
     }
 }

--- a/test/PubSubHubbub/TestAsset/Callback.php
+++ b/test/PubSubHubbub/TestAsset/Callback.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Feed\PubSubHubbub\TestAsset;
 
 use Laminas\Feed\PubSubHubbub\AbstractCallback;
@@ -17,7 +11,7 @@ class Callback extends AbstractCallback
      *
      * @return false
      */
-    public function handle(array $httpData = null, $sendResponseNow = false)
+    public function handle(?array $httpData = null, $sendResponseNow = false)
     {
         return false;
     }

--- a/test/Reader/Entry/AtomStandaloneEntryTest.php
+++ b/test/Reader/Entry/AtomStandaloneEntryTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Feed\Reader\Entry;
 
 use DateTime;
@@ -14,16 +8,23 @@ use Laminas\Feed\Reader\Entry\Atom;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
+use function array_values;
+use function dirname;
+use function file_get_contents;
+
 /**
  * @group Laminas_Feed
  * @group Laminas_Feed_Reader
  */
 class AtomStandaloneEntryTest extends TestCase
 {
+    /** @var string */
     protected $feedSamplePath;
 
+    /** @var array<array-key, array<string, null|string>> */
     protected $expectedCats = [];
 
+    /** @var array<array-key, array<string, null|string>> */
     protected $expectedCatsDc = [];
 
     protected function setUp(): void
@@ -101,7 +102,6 @@ class AtomStandaloneEntryTest extends TestCase
      * Get modification date (Unencoded Text)
      *
      * @group LaminasR002
-     *
      */
     public function testGetsDateModifiedFromAtom10(): void
     {
@@ -116,7 +116,6 @@ class AtomStandaloneEntryTest extends TestCase
      * Get Title (Unencoded Text)
      *
      * @group LaminasR002
-     *
      */
     public function testGetsTitleFromAtom10(): void
     {
@@ -130,7 +129,6 @@ class AtomStandaloneEntryTest extends TestCase
      * Get Authors (Unencoded Text)
      *
      * @group LaminasR002
-     *
      */
     public function testGetsAuthorsFromAtom10(): void
     {
@@ -154,7 +152,6 @@ class AtomStandaloneEntryTest extends TestCase
      * Get Author (Unencoded Text)
      *
      * @group LaminasR002
-     *
      */
     public function testGetsAuthorFromAtom10(): void
     {
@@ -171,7 +168,6 @@ class AtomStandaloneEntryTest extends TestCase
      * Get Description (Unencoded Text)
      *
      * @group LaminasR002
-     *
      */
     public function testGetsDescriptionFromAtom10(): void
     {
@@ -185,7 +181,6 @@ class AtomStandaloneEntryTest extends TestCase
      * Get enclosure
      *
      * @group LaminasR002
-     *
      */
     public function testGetsEnclosureFromAtom10(): void
     {
@@ -205,7 +200,6 @@ class AtomStandaloneEntryTest extends TestCase
      * TEXT
      *
      * @group LaminasRATOMCONTENT
-     *
      */
     public function testGetsContentFromAtom10(): void
     {
@@ -219,7 +213,6 @@ class AtomStandaloneEntryTest extends TestCase
      * HTML Escaped
      *
      * @group LaminasRATOMCONTENT
-     *
      */
     public function testGetsContentFromAtom10Html(): void
     {
@@ -233,7 +226,6 @@ class AtomStandaloneEntryTest extends TestCase
      * HTML CDATA Escaped
      *
      * @group LaminasRATOMCONTENT
-     *
      */
     public function testGetsContentFromAtom10HtmlCdata(): void
     {
@@ -247,7 +239,6 @@ class AtomStandaloneEntryTest extends TestCase
      * XHTML
      *
      * @group LaminasRATOMCONTENT
-     *
      */
     public function testGetsContentFromAtom10XhtmlNamespaced(): void
     {
@@ -261,7 +252,6 @@ class AtomStandaloneEntryTest extends TestCase
      * Get Link (Unencoded Text)
      *
      * @group LaminasR002
-     *
      */
     public function testGetsLinkFromAtom10(): void
     {
@@ -275,7 +265,6 @@ class AtomStandaloneEntryTest extends TestCase
      * Get Comment HTML Link
      *
      * @group LaminasR002
-     *
      */
     public function testGetsCommentLinkFromAtom10(): void
     {
@@ -289,7 +278,6 @@ class AtomStandaloneEntryTest extends TestCase
      * Get category data
      *
      * @group LaminasR002
-     *
      */
     public function testGetsCategoriesFromAtom10(): void
     {

--- a/test/Reader/Entry/AtomTest.php
+++ b/test/Reader/Entry/AtomTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Feed\Reader\Entry;
 
 use DateTime;
@@ -13,16 +7,23 @@ use Laminas\Feed\Reader;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
+use function array_values;
+use function dirname;
+use function file_get_contents;
+
 /**
  * @group Laminas_Feed
  * @group Laminas_Feed_Reader
  */
 class AtomTest extends TestCase
 {
+    /** @var string */
     protected $feedSamplePath;
 
+    /** @var array<array-key, array<string, null|string>> */
     protected $expectedCats = [];
 
+    /** @var array<array-key, array<string, null|string>> */
     protected $expectedCatsDc = [];
 
     protected function setUp(): void
@@ -64,7 +65,6 @@ class AtomTest extends TestCase
      * Get Id (Unencoded Text)
      *
      * @group LaminasR003
-     *
      */
     public function testGetsIdFromAtom03(): void
     {
@@ -86,7 +86,6 @@ class AtomTest extends TestCase
 
     /**
      * Get creation date (Unencoded Text)
-     *
      */
     public function testGetsDateCreatedFromAtom03(): void
     {
@@ -120,7 +119,6 @@ class AtomTest extends TestCase
 
     /**
      * Get modification date (Unencoded Text)
-     *
      */
     public function testGetsDateModifiedFromAtom03(): void
     {
@@ -154,7 +152,6 @@ class AtomTest extends TestCase
 
     /**
      * Get Title (Unencoded Text)
-     *
      */
     public function testGetsTitleFromAtom03(): void
     {
@@ -176,7 +173,6 @@ class AtomTest extends TestCase
 
     /**
      * Get Authors (Unencoded Text)
-     *
      */
     public function testGetsAuthorsFromAtom03(): void
     {
@@ -218,7 +214,6 @@ class AtomTest extends TestCase
 
     /**
      * Get Author (Unencoded Text)
-     *
      */
     public function testGetsAuthorFromAtom03(): void
     {
@@ -246,7 +241,6 @@ class AtomTest extends TestCase
 
     /**
      * Get Description (Unencoded Text)
-     *
      */
     public function testGetsDescriptionFromAtom03(): void
     {
@@ -268,7 +262,6 @@ class AtomTest extends TestCase
 
     /**
      * Get enclosure
-     *
      */
     public function testGetsEnclosureFromAtom03(): void
     {
@@ -302,7 +295,6 @@ class AtomTest extends TestCase
 
     /**
      * Get Content (Unencoded Text)
-     *
      */
     public function testGetsContentFromAtom03(): void
     {
@@ -317,7 +309,6 @@ class AtomTest extends TestCase
      * TEXT
      *
      * @group LaminasRATOMCONTENT
-     *
      */
     public function testGetsContentFromAtom10(): void
     {
@@ -332,7 +323,6 @@ class AtomTest extends TestCase
      * HTML Escaped
      *
      * @group LaminasRATOMCONTENT
-     *
      */
     public function testGetsContentFromAtom10Html(): void
     {
@@ -347,7 +337,6 @@ class AtomTest extends TestCase
      * HTML CDATA Escaped
      *
      * @group LaminasRATOMCONTENT
-     *
      */
     public function testGetsContentFromAtom10HtmlCdata(): void
     {
@@ -362,7 +351,6 @@ class AtomTest extends TestCase
      * XHTML
      *
      * @group LaminasRATOMCONTENT
-     *
      */
     public function testGetsContentFromAtom10XhtmlNamespaced(): void
     {
@@ -384,7 +372,6 @@ class AtomTest extends TestCase
 
     /**
      * Get Link (Unencoded Text)
-     *
      */
     public function testGetsLinkFromAtom03(): void
     {
@@ -424,7 +411,6 @@ class AtomTest extends TestCase
 
     /**
      * Get Base Uri
-     *
      */
     public function testGetsBaseUriFromAtom10FromFeedElement(): void
     {
@@ -446,7 +432,6 @@ class AtomTest extends TestCase
 
     /**
      * Get Comment HTML Link
-     *
      */
     public function testGetsCommentLinkFromAtom03(): void
     {
@@ -477,7 +462,6 @@ class AtomTest extends TestCase
 
     /**
      * Get category data
-     *
      */
     public function testGetsCategoriesFromAtom10(): void
     {
@@ -501,6 +485,7 @@ class AtomTest extends TestCase
 
     // DC 1.0/1.1 for Atom 0.3
 
+    // phpcs:ignore Squiz.Commenting.FunctionComment.WrongStyle
     public function testGetsCategoriesFromAtom03Dc10(): void
     {
         $feed  = Reader\Reader::importString(
@@ -523,6 +508,7 @@ class AtomTest extends TestCase
 
     // No Categories In Entry
 
+    // phpcs:ignore Squiz.Commenting.FunctionComment.WrongStyle
     public function testGetsCategoriesFromAtom10None(): void
     {
         $feed  = Reader\Reader::importString(

--- a/test/Reader/Entry/CommonTest.php
+++ b/test/Reader/Entry/CommonTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Feed\Reader\Entry;
 
 use DOMDocument;
@@ -16,12 +10,17 @@ use Laminas\Feed\Reader\Entry\AbstractEntry;
 use Laminas\Feed\Reader\Extension\Atom\Entry;
 use PHPUnit\Framework\TestCase;
 
+use function dirname;
+use function file_get_contents;
+use function str_replace;
+
 /**
  * @group Laminas_Feed
  * @group Laminas_Feed_Reader
  */
 class CommonTest extends TestCase
 {
+    /** @var string */
     protected $feedSamplePath;
 
     protected function setUp(): void
@@ -32,7 +31,6 @@ class CommonTest extends TestCase
 
     /**
      * Check DOM Retrieval and Information Methods
-     *
      */
     public function testGetsDomDocumentObject(): void
     {
@@ -101,7 +99,6 @@ class CommonTest extends TestCase
 
     /**
      * @group Laminas-8213
-     *
      */
     public function testReturnsEncodingOfFeed(): void
     {
@@ -114,7 +111,6 @@ class CommonTest extends TestCase
 
     /**
      * @group Laminas-8213
-     *
      */
     public function testReturnsEncodingOfFeedAsUtf8IfUndefined(): void
     {
@@ -127,7 +123,6 @@ class CommonTest extends TestCase
 
     /**
      * When not passing the optional argument type
-     *
      */
     public function testFeedEntryCanDetectFeedType(): void
     {
@@ -144,7 +139,6 @@ class CommonTest extends TestCase
 
     /**
      * When passing a newly created DOMElement without any DOMDocument assigned
-     *
      */
     public function testFeedEntryCanSetAnyType(): void
     {

--- a/test/Reader/Entry/RssTest.php
+++ b/test/Reader/Entry/RssTest.php
@@ -1,10 +1,4 @@
-<?php
-
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
+<?php // phpcs:disable Squiz.Commenting.FunctionComment.WrongStyle
 
 namespace LaminasTest\Feed\Reader\Entry;
 
@@ -14,18 +8,27 @@ use Laminas\Feed\Reader;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
+use function array_values;
+use function assert;
+use function dirname;
+use function file_get_contents;
+
 /**
  * @group Laminas_Feed
  * @group Laminas_Feed_Reader
  */
 class RssTest extends TestCase
 {
+    /** @var string */
     protected $feedSamplePath;
 
+    /** @var array<array-key, array<string, null|string>> */
     protected $expectedCats = [];
 
+    /** @var array<array-key, array<string, null|string>> */
     protected $expectedCatsRdf = [];
 
+    /** @var array<array-key, array<string, null|string>> */
     protected $expectedCatsAtom = [];
 
     protected function setUp(): void
@@ -83,7 +86,6 @@ class RssTest extends TestCase
 
     /**
      * Get Id (Unencoded Text)
-     *
      */
     public function testGetsIdFromRss20(): void
     {
@@ -410,7 +412,6 @@ class RssTest extends TestCase
 
     /**
      * Get Title (Unencoded Text)
-     *
      */
     public function testGetsTitleFromRss20(): void
     {
@@ -672,7 +673,6 @@ class RssTest extends TestCase
 
     /**
      * Get Authors (Unencoded Text)
-     *
      */
     public function testGetsAuthorsFromRss20(): void
     {
@@ -994,7 +994,6 @@ class RssTest extends TestCase
 
     /**
      * Get Author (Unencoded Text)
-     *
      */
     public function testGetsAuthorFromRss20(): void
     {
@@ -1256,7 +1255,6 @@ class RssTest extends TestCase
 
     /**
      * Get Description (Unencoded Text)
-     *
      */
     public function testGetsDescriptionFromRss20(): void
     {
@@ -1518,7 +1516,6 @@ class RssTest extends TestCase
 
     /**
      * Get enclosure
-     *
      */
     public function testGetsEnclosureFromRss20(): void
     {
@@ -1546,7 +1543,6 @@ class RssTest extends TestCase
 
     /**
      * Get Content (Unencoded Text)
-     *
      */
     public function testGetsContentFromRss20(): void
     {
@@ -1743,7 +1739,6 @@ class RssTest extends TestCase
 
     /**
      * Get Link (Unencoded Text)
-     *
      */
     public function testGetsLinkFromRss20(): void
     {
@@ -1877,9 +1872,8 @@ class RssTest extends TestCase
      * Get DateModified (Unencoded Text)
      *
      * @dataProvider dateModifiedProvider
-     *
      */
-    public function testGetsDateModified($path, $edate): void
+    public function testGetsDateModified(string $path, ?DateTimeInterface $edate): void
     {
         $feed  = Reader\Reader::importString(
             file_get_contents($this->feedSamplePath . $path)
@@ -1896,7 +1890,7 @@ class RssTest extends TestCase
     {
         $iso = DateTime::createFromFormat(DateTimeInterface::ISO8601, '2009-03-07T08:03:50Z');
         assert($iso instanceof DateTimeInterface);
-        $us  = DateTime::createFromFormat(DateTimeInterface::ISO8601, '2010-01-04T02:14:00-0600');
+        $us = DateTime::createFromFormat(DateTimeInterface::ISO8601, '2010-01-04T02:14:00-0600');
         assert($us instanceof DateTimeInterface);
         $rss = DateTime::createFromFormat(DateTimeInterface::RSS, 'Sun, 11 Jan 2009 09:55:59 GMT');
         assert($rss instanceof DateTimeInterface);
@@ -2191,7 +2185,6 @@ class RssTest extends TestCase
 
     /**
      * Get CommentLink (Unencoded Text)
-     *
      */
     public function testGetsCommentLinkFromRss20(): void
     {
@@ -2370,7 +2363,6 @@ class RssTest extends TestCase
 
     /**
      * Get CommentFeedLink (Unencoded Text)
-     *
      */
     public function testGetsCommentFeedLinkFromRss20WellFormedWeb10(): void
     {
@@ -2567,7 +2559,6 @@ class RssTest extends TestCase
 
     /**
      * Get category data
-     *
      */
     public function testGetsCategoriesFromRss20(): void
     {

--- a/test/Reader/ExtensionPluginManagerCompatibilityTest.php
+++ b/test/Reader/ExtensionPluginManagerCompatibilityTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Feed\Reader;
 
 use Laminas\Feed\Reader\Exception\InvalidArgumentException;
@@ -14,15 +8,22 @@ use Laminas\ServiceManager\ServiceManager;
 use Laminas\ServiceManager\Test\CommonPluginManagerTrait;
 use PHPUnit\Framework\TestCase;
 
+use function sprintf;
+
 class ExtensionPluginManagerCompatibilityTest extends TestCase
 {
     use CommonPluginManagerTrait;
 
+    /**
+     * @psalm-suppress ImplementedReturnTypeMismatch
+     * @return ExtensionPluginManager
+     */
     protected function getPluginManager()
     {
         return new ExtensionPluginManager(new ServiceManager());
     }
 
+    /** @return class-string */
     protected function getV2InvalidPluginException()
     {
         return InvalidArgumentException::class;
@@ -30,7 +31,6 @@ class ExtensionPluginManagerCompatibilityTest extends TestCase
 
     protected function getInstanceOf()
     {
-        return;
     }
 
     public function testInstanceOfMatches(): void

--- a/test/Reader/Feed/AtomSourceTest.php
+++ b/test/Reader/Feed/AtomSourceTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Feed\Reader\Feed;
 
 use DateTime;
@@ -13,18 +7,26 @@ use Laminas\Feed\Reader;
 use Laminas\Feed\Reader\Feed\Atom\Source;
 use PHPUnit\Framework\TestCase;
 
+use function array_values;
+use function dirname;
+use function file_get_contents;
+
 /**
  * @group Laminas_Feed
  * @group Laminas_Feed_Reader
  */
 class AtomSourceTest extends TestCase
 {
+    /** @var string */
     protected $feedSamplePath;
 
+    /** @var array<string, mixed> */
     protected $options = [];
 
+    /** @var array<array-key, array<string, null|string>> */
     protected $expectedCats = [];
 
+    /** @var array<array-key, array<string, null|string>> */
     protected $expectedCatsDc = [];
 
     protected function setUp(): void
@@ -73,7 +75,6 @@ class AtomSourceTest extends TestCase
 
     /**
      * Get Title (Unencoded Text)
-     *
      */
     public function testGetsTitleFromAtom10(): void
     {
@@ -86,7 +87,6 @@ class AtomSourceTest extends TestCase
 
     /**
      * Get Authors (Unencoded Text)
-     *
      */
     public function testGetsAuthorArrayFromAtom10(): void
     {
@@ -109,14 +109,13 @@ class AtomSourceTest extends TestCase
 
     /**
      * Get Single Author (Unencoded Text)
-     *
      */
     public function testGetsSingleAuthorFromAtom10(): void
     {
-        $feed   = Reader\Reader::importString(
+        $feed = Reader\Reader::importString(
             file_get_contents($this->feedSamplePath . '/author/atom10.xml')
         );
-        $source = $feed->current()->getSource();
+        $feed->current()->getSource();
 
         $this->assertEquals(
             ['name' => 'Joe Bloggs', 'email' => 'joe@example.com', 'uri' => 'http://www.example.com'],
@@ -126,7 +125,6 @@ class AtomSourceTest extends TestCase
 
     /**
      * Get creation date (Unencoded Text)
-     *
      */
     public function testGetsDateCreatedFromAtom10(): void
     {
@@ -141,7 +139,6 @@ class AtomSourceTest extends TestCase
 
     /**
      * Get modification date (Unencoded Text)
-     *
      */
     public function testGetsDateModifiedFromAtom10(): void
     {
@@ -156,7 +153,6 @@ class AtomSourceTest extends TestCase
 
     /**
      * Get Generator (Unencoded Text)
-     *
      */
     public function testGetsGeneratorFromAtom10(): void
     {
@@ -169,7 +165,6 @@ class AtomSourceTest extends TestCase
 
     /**
      * Get Copyright (Unencoded Text)
-     *
      */
     public function testGetsCopyrightFromAtom10(): void
     {
@@ -182,7 +177,6 @@ class AtomSourceTest extends TestCase
 
     /**
      * Get Description (Unencoded Text)
-     *
      */
     public function testGetsDescriptionFromAtom10(): void
     {
@@ -195,7 +189,6 @@ class AtomSourceTest extends TestCase
 
     /**
      * Get Id (Unencoded Text)
-     *
      */
     public function testGetsIdFromAtom10(): void
     {
@@ -208,7 +201,6 @@ class AtomSourceTest extends TestCase
 
     /**
      * Get Language (Unencoded Text)
-     *
      */
     public function testGetsLanguageFromAtom10(): void
     {
@@ -221,7 +213,6 @@ class AtomSourceTest extends TestCase
 
     /**
      * Get Link (Unencoded Text)
-     *
      */
     public function testGetsLinkFromAtom10(): void
     {
@@ -234,7 +225,6 @@ class AtomSourceTest extends TestCase
 
     /**
      * Get Feed Link (Unencoded Text)
-     *
      */
     public function testGetsFeedLinkFromAtom10(): void
     {
@@ -247,7 +237,6 @@ class AtomSourceTest extends TestCase
 
     /**
      * Get Pubsubhubbub Hubs
-     *
      */
     public function testGetsHubsFromAtom10(): void
     {
@@ -263,7 +252,6 @@ class AtomSourceTest extends TestCase
 
     /**
      * Get category data
-     *
      */
     public function testGetsCategoriesFromAtom10(): void
     {

--- a/test/Reader/Feed/AtomTest.php
+++ b/test/Reader/Feed/AtomTest.php
@@ -1,16 +1,14 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Feed\Reader\Feed;
 
 use DateTime;
 use Laminas\Feed\Reader;
 use PHPUnit\Framework\TestCase;
+
+use function array_values;
+use function dirname;
+use function file_get_contents;
 
 /**
  * @group Laminas_Feed
@@ -18,12 +16,16 @@ use PHPUnit\Framework\TestCase;
  */
 class AtomTest extends TestCase
 {
+    /** @var string */
     protected $feedSamplePath;
 
+    /** @var array<string, mixed> */
     protected $options = [];
 
+    /** @var array<array-key, array<string, null|string>> */
     protected $expectedCats = [];
 
+    /** @var array<array-key, array<string, null|string>> */
     protected $expectedCatsDc = [];
 
     protected function setUp(): void
@@ -64,7 +66,6 @@ class AtomTest extends TestCase
 
     /**
      * Get Title (Unencoded Text)
-     *
      */
     public function testGetsTitleFromAtom03(): void
     {
@@ -92,7 +93,6 @@ class AtomTest extends TestCase
 
     /**
      * Get Authors (Unencoded Text)
-     *
      */
     public function testGetsAuthorArrayFromAtom03(): void
     {
@@ -132,7 +132,6 @@ class AtomTest extends TestCase
 
     /**
      * Get Single Author (Unencoded Text)
-     *
      */
     public function testGetsSingleAuthorFromAtom03(): void
     {
@@ -168,7 +167,6 @@ class AtomTest extends TestCase
 
     /**
      * Get creation date (Unencoded Text)
-     *
      */
     public function testGetsDateCreatedFromAtom03(): void
     {
@@ -198,7 +196,6 @@ class AtomTest extends TestCase
 
     /**
      * Get modification date (Unencoded Text)
-     *
      */
     public function testGetsDateModifiedFromAtom03(): void
     {
@@ -228,7 +225,6 @@ class AtomTest extends TestCase
 
     /**
      * Get Last Build Date (Unencoded Text)
-     *
      */
     public function testGetsLastBuildDateAlwaysReturnsNullForAtom(): void
     {
@@ -240,7 +236,6 @@ class AtomTest extends TestCase
 
     /**
      * Get Generator (Unencoded Text)
-     *
      */
     public function testGetsGeneratorFromAtom03(): void
     {
@@ -268,7 +263,6 @@ class AtomTest extends TestCase
 
     /**
      * Get Copyright (Unencoded Text)
-     *
      */
     public function testGetsCopyrightFromAtom03(): void
     {
@@ -296,7 +290,6 @@ class AtomTest extends TestCase
 
     /**
      * Get Description (Unencoded Text)
-     *
      */
     public function testGetsDescriptionFromAtom03(): void
     {
@@ -324,7 +317,6 @@ class AtomTest extends TestCase
 
     /**
      * Get Id (Unencoded Text)
-     *
      */
     public function testGetsIdFromAtom03(): void
     {
@@ -352,7 +344,6 @@ class AtomTest extends TestCase
 
     /**
      * Get Language (Unencoded Text)
-     *
      */
     public function testGetsLanguageFromAtom03(): void
     {
@@ -380,7 +371,6 @@ class AtomTest extends TestCase
 
     /**
      * Get Link (Unencoded Text)
-     *
      */
     public function testGetsLinkFromAtom03(): void
     {
@@ -424,7 +414,6 @@ class AtomTest extends TestCase
 
     /**
      * Get Base Uri
-     *
      */
     public function testGetsBaseUriFromAtom10(): void
     {
@@ -436,7 +425,6 @@ class AtomTest extends TestCase
 
     /**
      * Get Feed Link (Unencoded Text)
-     *
      */
     public function testGetsFeedLinkFromAtom03(): void
     {
@@ -481,7 +469,6 @@ class AtomTest extends TestCase
 
     /**
      * Get Pubsubhubbub Hubs
-     *
      */
     public function testGetsHubsFromAtom03(): void
     {
@@ -507,7 +494,6 @@ class AtomTest extends TestCase
 
     /**
      * Implements Countable
-     *
      */
     public function testCountableInterface(): void
     {
@@ -519,7 +505,6 @@ class AtomTest extends TestCase
 
     /**
      * Get category data
-     *
      */
     public function testGetsCategoriesFromAtom10(): void
     {
@@ -541,6 +526,7 @@ class AtomTest extends TestCase
 
     // DC 1.0/1.1 for Atom 0.3
 
+    // phpcs:ignore Squiz.Commenting.FunctionComment.WrongStyle
     public function testGetsCategoriesFromAtom03Dc10(): void
     {
         $feed = Reader\Reader::importString(
@@ -561,6 +547,7 @@ class AtomTest extends TestCase
 
     // No Categories In Entry
 
+    // phpcs:ignore Squiz.Commenting.FunctionComment.WrongStyle
     public function testGetsCategoriesFromAtom10None(): void
     {
         $feed = Reader\Reader::importString(
@@ -581,7 +568,6 @@ class AtomTest extends TestCase
 
     /**
      * Get Image (Unencoded Text)
-     *
      */
     public function testGetsImageFromAtom03(): void
     {
@@ -601,7 +587,6 @@ class AtomTest extends TestCase
 
     /**
      * Get Image (Unencoded Text) When Missing
-     *
      */
     public function testGetsImageFromAtom03None(): void
     {

--- a/test/Reader/Feed/CommonTest.php
+++ b/test/Reader/Feed/CommonTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Feed\Reader\Feed;
 
 use DOMDocument;
@@ -15,12 +9,17 @@ use Laminas\Feed\Reader;
 use Laminas\Feed\Reader\Extension\Atom\Feed;
 use PHPUnit\Framework\TestCase;
 
+use function dirname;
+use function file_get_contents;
+use function str_replace;
+
 /**
  * @group Laminas_Feed
  * @group Reader\Reader
  */
 class CommonTest extends TestCase
 {
+    /** @var string */
     protected $feedSamplePath;
 
     protected function setUp(): void
@@ -31,7 +30,6 @@ class CommonTest extends TestCase
 
     /**
      * Check DOM Retrieval and Information Methods
-     *
      */
     public function testGetsDomDocumentObject(): void
     {
@@ -93,7 +91,6 @@ class CommonTest extends TestCase
 
     /**
      * @group Laminas-8213
-     *
      */
     public function testReturnsEncodingOfFeed(): void
     {
@@ -105,7 +102,6 @@ class CommonTest extends TestCase
 
     /**
      * @group Laminas-8213
-     *
      */
     public function testReturnsEncodingOfFeedAsUtf8IfUndefined(): void
     {

--- a/test/Reader/Feed/RssTest.php
+++ b/test/Reader/Feed/RssTest.php
@@ -1,10 +1,4 @@
-<?php
-
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
+<?php // phpcs:disable Squiz.Commenting.FunctionComment.WrongStyle
 
 namespace LaminasTest\Feed\Reader\Feed;
 
@@ -12,6 +6,11 @@ use DateTime;
 use DateTimeInterface;
 use Laminas\Feed\Reader;
 use PHPUnit\Framework\TestCase;
+
+use function array_values;
+use function assert;
+use function dirname;
+use function file_get_contents;
 
 /**
  * @group Laminas_Feed
@@ -22,10 +21,13 @@ class RssTest extends TestCase
     /** @var string */
     protected $feedSamplePath;
 
+    /** @var array<array-key, array<string, null|string>> */
     protected $expectedCats = [];
 
+    /** @var array<array-key, array<string, null|string>> */
     protected $expectedCatsRdf = [];
 
+    /** @var array<array-key, array<string, null|string>> */
     protected $expectedCatsAtom = [];
 
     protected function setUp(): void
@@ -83,7 +85,6 @@ class RssTest extends TestCase
 
     /**
      * Get Title (Unencoded Text)
-     *
      */
     public function testGetsTitleFromRss20(): void
     {
@@ -375,7 +376,6 @@ class RssTest extends TestCase
 
     /**
      * Get Authors (Unencoded Text)
-     *
      */
     public function testGetsAuthorArrayFromRss20(): void
     {
@@ -779,7 +779,6 @@ class RssTest extends TestCase
 
     /**
      * Get Single Author (Unencoded Text)
-     *
      */
     public function testGetsSingleAuthorFromRss20(): void
     {
@@ -1013,7 +1012,6 @@ class RssTest extends TestCase
 
     /**
      * Get Copyright (Unencoded Text)
-     *
      */
     public function testGetsCopyrightFromRss20(): void
     {
@@ -1247,7 +1245,6 @@ class RssTest extends TestCase
 
     /**
      * Get Description (Unencoded Text)
-     *
      */
     public function testGetsDescriptionFromRss20(): void
     {
@@ -1481,7 +1478,6 @@ class RssTest extends TestCase
 
     /**
      * Get Language (Unencoded Text)
-     *
      */
     public function testGetsLanguageFromRss20(): void
     {
@@ -1725,7 +1721,6 @@ class RssTest extends TestCase
 
     /**
      * Get Link (Unencoded Text)
-     *
      */
     public function testGetsLinkFromRss20(): void
     {
@@ -1843,7 +1838,6 @@ class RssTest extends TestCase
 
     /**
      * Implements Countable
-     *
      */
     public function testCountableInterface(): void
     {
@@ -1855,7 +1849,6 @@ class RssTest extends TestCase
 
     /**
      * Get Feed Link (Unencoded Text)
-     *
      */
     public function testGetsFeedLinkFromRss20(): void
     {
@@ -1982,7 +1975,6 @@ class RssTest extends TestCase
 
     /**
      * Get Generator (Unencoded Text)
-     *
      */
     public function testGetsGeneratorFromRss20(): void
     {
@@ -2100,7 +2092,6 @@ class RssTest extends TestCase
 
     /**
      * Get Last Build Date (Unencoded Text)
-     *
      */
     public function testGetsLastBuildDateFromRss20(): void
     {
@@ -2142,7 +2133,7 @@ class RssTest extends TestCase
     {
         $iso = DateTime::createFromFormat(DateTimeInterface::ISO8601, '2009-03-07T08:03:50Z');
         assert($iso instanceof DateTimeInterface);
-        $us  = DateTime::createFromFormat(DateTimeInterface::ISO8601, '2010-01-04T02:14:00-0600');
+        $us = DateTime::createFromFormat(DateTimeInterface::ISO8601, '2010-01-04T02:14:00-0600');
         assert($us instanceof DateTimeInterface);
 
         return [
@@ -2197,7 +2188,6 @@ class RssTest extends TestCase
 
     /**
      * Get Hubs (Unencoded Text)
-     *
      */
     public function testGetsHubsFromRss20(): void
     {
@@ -2336,7 +2326,6 @@ class RssTest extends TestCase
 
     /**
      * Get category data
-     *
      */
     public function testGetsCategoriesFromRss20(): void
     {
@@ -2582,7 +2571,6 @@ class RssTest extends TestCase
 
     /**
      * Get Image data (Unencoded Text)
-     *
      */
     public function testGetsImageFromRss20(): void
     {
@@ -2691,7 +2679,6 @@ class RssTest extends TestCase
 
     /**
      * Get Image data (Unencoded Text) Missing
-     *
      */
     public function testGetsImageFromRss20None(): void
     {

--- a/test/Reader/FeedSetTest.php
+++ b/test/Reader/FeedSetTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Feed\Reader;
 
 use Laminas\Feed\Reader\FeedSet;
@@ -14,9 +8,7 @@ use ReflectionMethod;
 
 class FeedSetTest extends TestCase
 {
-    /**
-     * @var FeedSet
-     */
+    /** @var FeedSet */
     protected $feedSet;
 
     protected function setUp(): void

--- a/test/Reader/Http/LaminasHttpClientDecoratorTest.php
+++ b/test/Reader/Http/LaminasHttpClientDecoratorTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Feed\Reader\Http;
 
 use Laminas\Feed\Reader\Exception\InvalidArgumentException;
@@ -15,6 +9,7 @@ use Laminas\Http\Client;
 use Laminas\Http\Headers;
 use Laminas\Http\Request as HttpRequest;
 use Laminas\Http\Response as HttpResponse;
+use Laminas\Uri\Http;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -23,9 +18,7 @@ use PHPUnit\Framework\TestCase;
  */
 class LaminasHttpClientDecoratorTest extends TestCase
 {
-    /**
-     * @var Client|mixed|\PHPUnit\Framework\MockObject\MockObject
-     */
+    /** @var Client|mixed|MockObject */
     private $client;
 
     protected function setUp(): void
@@ -33,6 +26,7 @@ class LaminasHttpClientDecoratorTest extends TestCase
         $this->client = $this->createMock(Client::class);
     }
 
+    /** @param string|Http $uri */
     public function prepareDefaultClientInteractions($uri, MockObject $response): void
     {
         $this->client
@@ -64,11 +58,9 @@ class LaminasHttpClientDecoratorTest extends TestCase
     }
 
     /**
-     * @return MockObject
-     *
      * @psalm-return MockObject<HttpResponse>
      */
-    public function createMockHttpResponse(int $statusCode, string $body, Headers $headers = null): MockObject
+    public function createMockHttpResponse(int $statusCode, string $body, ?Headers $headers = null): MockObject
     {
         $response = $this->createMock(HttpResponse::class);
         $response
@@ -90,7 +82,6 @@ class LaminasHttpClientDecoratorTest extends TestCase
 
     /**
      * @param array $headers
-     *
      * @return MockObject<Headers>
      */
     public function createMockHttpHeaders(array $headers): Headers
@@ -163,7 +154,13 @@ class LaminasHttpClientDecoratorTest extends TestCase
         $this->assertEquals(1234.56, $response->getHeaderLine('X-Content-Length'));
     }
 
-    public function invalidHeaders(): \Generator
+    /**
+     * @psalm-return iterable<string, array{
+     *     0: array<int|string, mixed>,
+     *     1: string
+     * }>
+     */
+    public function invalidHeaders(): iterable
     {
         $basicTests = [
             'zero-name'        => [
@@ -238,11 +235,10 @@ class LaminasHttpClientDecoratorTest extends TestCase
     }
 
     /**
-     * @psalm-param array<array-key,string> $headers
-     * @param string $contains
      * @dataProvider invalidHeaders
+     * @psalm-param array<array-key, mixed> $headers
      */
-    public function testDecoratorRaisesExceptionForInvalidHeaders($headers, $contains): void
+    public function testDecoratorRaisesExceptionForInvalidHeaders($headers, string $contains): void
     {
         $this->client
             ->expects($this->atLeastOnce())

--- a/test/Reader/Http/Psr7ResponseDecoratorTest.php
+++ b/test/Reader/Http/Psr7ResponseDecoratorTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Feed\Reader\Http;
 
 use Laminas\Feed\Reader\Http\HeaderAwareResponseInterface;

--- a/test/Reader/Http/ResponseTest.php
+++ b/test/Reader/Http/ResponseTest.php
@@ -1,17 +1,12 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Feed\Reader\Http;
 
 use Laminas\Feed\Reader\Exception\InvalidArgumentException;
 use Laminas\Feed\Reader\Http\Response;
 use LaminasTest\Feed\Reader\TestAsset\Psr7Stream;
 use PHPUnit\Framework\TestCase;
+
 use function var_export;
 
 /**
@@ -35,7 +30,7 @@ class ResponseTest extends TestCase
 
     public function testConstructorCanAcceptAStringCastableObjectForTheResponseBody(): void
     {
-        $stream = new Psr7Stream('BODY');
+        $stream   = new Psr7Stream('BODY');
         $response = new Response(200, $stream);
         $this->assertEquals('BODY', $response->getBody());
     }
@@ -43,8 +38,8 @@ class ResponseTest extends TestCase
     public function testConstructorCanAcceptHeaders(): void
     {
         $response = new Response(204, '', [
-            'Location' => 'http://example.org/foo',
-            'Content-Length' => 1234,
+            'Location'         => 'http://example.org/foo',
+            'Content-Length'   => 1234,
             'X-Content-Length' => 1234.56,
         ]);
         $this->assertEquals(204, $response->getStatusCode());
@@ -54,7 +49,8 @@ class ResponseTest extends TestCase
         $this->assertEquals(1234.56, $response->getHeaderLine('X-Content-Length'));
     }
 
-    public function invalidStatusCodes()
+    /** @psalm-return iterable<int|string, array{0: mixed, 1: string}> */
+    public function invalidStatusCodes(): iterable
     {
         foreach ([-100, 0, 1, 99] as $statusCode) {
             yield $statusCode => [$statusCode, 'between 100 and 599'];
@@ -69,11 +65,11 @@ class ResponseTest extends TestCase
         }
 
         $invalidTypes = [
-            'null' => [null, 'numeric status code'],
-            'true' => [true, 'numeric status code'],
-            'false' => [false, 'numeric status code'],
+            'null'   => [null, 'numeric status code'],
+            'true'   => [true, 'numeric status code'],
+            'false'  => [false, 'numeric status code'],
             'string' => [' 100 ', 'numeric status code'],
-            'array' => [[200], 'numeric status code'],
+            'array'  => [[200], 'numeric status code'],
             'object' => [(object) [100], 'numeric status code'],
         ];
         foreach ($invalidTypes as $key => $value) {
@@ -83,31 +79,34 @@ class ResponseTest extends TestCase
 
     /**
      * @dataProvider invalidStatusCodes
+     * @param mixed $statusCode
      */
-    public function testConstructorRaisesExceptionForInvalidStatusCode($statusCode, $contains)
+    public function testConstructorRaisesExceptionForInvalidStatusCode($statusCode, string $contains)
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage($contains);
         new Response($statusCode);
     }
 
-    public function invalidBodies()
+    /** @psalm-return array<string, array{0: mixed}> */
+    public function invalidBodies(): array
     {
         return [
-            'null' => [null],
-            'true' => [true],
-            'false' => [false],
-            'zero' => [0],
-            'int' => [1],
+            'null'       => [null],
+            'true'       => [true],
+            'false'      => [false],
+            'zero'       => [0],
+            'int'        => [1],
             'zero-float' => [0.0],
-            'float' => [1.1],
-            'array' => [['BODY']],
-            'object' => [(object) ['body' => 'BODY']],
+            'float'      => [1.1],
+            'array'      => [['BODY']],
+            'object'     => [(object) ['body' => 'BODY']],
         ];
     }
 
     /**
      * @dataProvider invalidBodies
+     * @param mixed $body
      */
     public function testConstructorRaisesExceptionForInvalidBody($body)
     {
@@ -115,18 +114,19 @@ class ResponseTest extends TestCase
         new Response(200, $body);
     }
 
-    public function invalidHeaders()
+    /** @psalm-return array<string, array{0: array<array-key, mixed>, 1: string}> */
+    public function invalidHeaders(): array
     {
         return [
-            'empty-name' => [
+            'empty-name'   => [
                 ['' => 'value'],
                 'non-empty, non-numeric',
             ],
-            'zero-name' => [
+            'zero-name'    => [
                 ['value'],
                 'non-empty, non-numeric',
             ],
-            'int-name' => [
+            'int-name'     => [
                 [1 => 'value'],
                 'non-empty, non-numeric',
             ],
@@ -134,19 +134,19 @@ class ResponseTest extends TestCase
                 ['1.1' => 'value'],
                 'non-empty, non-numeric',
             ],
-            'null-value' => [
+            'null-value'   => [
                 ['X-Test' => null],
                 'must be a string or numeric',
             ],
-            'true-value' => [
+            'true-value'   => [
                 ['X-Test' => true],
                 'must be a string or numeric',
             ],
-            'false-value' => [
+            'false-value'  => [
                 ['X-Test' => false],
                 'must be a string or numeric',
             ],
-            'array-value' => [
+            'array-value'  => [
                 ['X-Test' => ['BODY']],
                 'must be a string or numeric',
             ],
@@ -160,7 +160,7 @@ class ResponseTest extends TestCase
     /**
      * @dataProvider invalidHeaders
      */
-    public function testConstructorRaisesExceptionForInvalidHeaderStructures($headers, $contains)
+    public function testConstructorRaisesExceptionForInvalidHeaderStructures(array $headers, string $contains)
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage($contains);

--- a/test/Reader/Integration/GooglePlayPodcastRss2Test.php
+++ b/test/Reader/Integration/GooglePlayPodcastRss2Test.php
@@ -1,19 +1,18 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Feed\Reader\Integration;
 
 use Laminas\Feed\Reader;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
-class GoolePlayPodcastRss2Test extends TestCase
+use function dirname;
+use function file_get_contents;
+use function str_replace;
+
+class GooglePlayPodcastRss2Test extends TestCase
 {
+    /** @var string */
     protected $feedSamplePath;
 
     protected function setUp(): void
@@ -24,7 +23,6 @@ class GoolePlayPodcastRss2Test extends TestCase
 
     /**
      * Feed level testing
-     *
      */
     public function testGetsNewFeedUrl(): void
     {
@@ -166,7 +164,6 @@ class GoolePlayPodcastRss2Test extends TestCase
 
     /**
      * Entry level testing
-     *
      */
     public function testGetsEntryBlock(): void
     {

--- a/test/Reader/Integration/HOnlineComAtom10Test.php
+++ b/test/Reader/Integration/HOnlineComAtom10Test.php
@@ -1,15 +1,12 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Feed\Reader\Integration;
 
 use Laminas\Feed\Reader;
 use PHPUnit\Framework\TestCase;
+
+use function dirname;
+use function file_get_contents;
 
 /**
  * @group Laminas_Feed
@@ -17,6 +14,7 @@ use PHPUnit\Framework\TestCase;
  */
 class HOnlineComAtom10Test extends TestCase
 {
+    /** @var string */
     protected $feedSamplePath;
 
     protected function setUp(): void
@@ -99,7 +97,6 @@ class HOnlineComAtom10Test extends TestCase
 
     /**
      * Entry level testing
-     *
      */
     public function testGetsEntryId(): void
     {

--- a/test/Reader/Integration/LautDeRdfTest.php
+++ b/test/Reader/Integration/LautDeRdfTest.php
@@ -1,15 +1,12 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Feed\Reader\Integration;
 
 use Laminas\Feed\Reader;
 use PHPUnit\Framework\TestCase;
+
+use function dirname;
+use function file_get_contents;
 
 /**
  * @group Laminas_Feed
@@ -17,6 +14,7 @@ use PHPUnit\Framework\TestCase;
  */
 class LautDeRdfTest extends TestCase
 {
+    /** @var string */
     protected $feedSamplePath;
 
     protected function setUp(): void
@@ -27,7 +25,6 @@ class LautDeRdfTest extends TestCase
 
     /**
      * Feed level testing
-     *
      */
     public function testGetsTitle(): void
     {
@@ -95,7 +92,6 @@ class LautDeRdfTest extends TestCase
 
     /**
      * Entry level testing
-     *
      */
     public function testGetsEntryId(): void
     {
@@ -138,6 +134,7 @@ class LautDeRdfTest extends TestCase
     // broken itself, or b) We should consider a fix in the future for similar feeds such
     // as using a more limited XML based decoding method (not html_entity_decode())
 
+    // phpcs:ignore Squiz.Commenting.FunctionComment.WrongStyle
     public function testGetsEntryDescription(): void
     {
         $feed  = Reader\Reader::importString(

--- a/test/Reader/Integration/PodcastIndexRss2Test.php
+++ b/test/Reader/Integration/PodcastIndexRss2Test.php
@@ -1,16 +1,13 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Feed\Reader\Integration;
 
 use Laminas\Feed\Reader;
 use PHPUnit\Framework\TestCase;
 use stdClass;
+
+use function dirname;
+use function file_get_contents;
 
 /**
  * @group Laminas_Feed
@@ -48,7 +45,6 @@ class PodcastIndexRss2Test extends TestCase
         $this->assertEquals('john.doe@example.com', $feed->getLockOwner());
     }
 
-
     public function testGetsFunding(): void
     {
         /** @var Reader\Extension\PodcastIndex\Feed $feed */
@@ -65,11 +61,10 @@ class PodcastIndexRss2Test extends TestCase
 
     /**
      * Entry level testing
-     *
      */
     public function testGetsEntryTranscript(): void
     {
-        $feed  = Reader\Reader::importString(
+        $feed = Reader\Reader::importString(
             file_get_contents($this->feedSamplePath)
         );
 
@@ -87,7 +82,7 @@ class PodcastIndexRss2Test extends TestCase
 
     public function testGetsEntryChapters(): void
     {
-        $feed  = Reader\Reader::importString(
+        $feed = Reader\Reader::importString(
             file_get_contents($this->feedSamplePath)
         );
 
@@ -103,7 +98,7 @@ class PodcastIndexRss2Test extends TestCase
 
     public function testGetsEntrySoundbites(): void
     {
-        $feed  = Reader\Reader::importString(
+        $feed = Reader\Reader::importString(
             file_get_contents($this->feedSamplePath)
         );
 
@@ -116,7 +111,7 @@ class PodcastIndexRss2Test extends TestCase
         $expected->duration  = '39.0';
 
         $this->assertEquals([
-            $expected
+            $expected,
         ], $entry->getSoundbites());
     }
 }

--- a/test/Reader/Integration/PodcastRss2Test.php
+++ b/test/Reader/Integration/PodcastRss2Test.php
@@ -1,16 +1,19 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Feed\Reader\Integration;
 
 use Laminas\Feed\Reader;
 use PHPUnit\Framework\TestCase;
 use stdClass;
+
+use function dirname;
+use function file_get_contents;
+use function preg_match;
+use function restore_error_handler;
+use function set_error_handler;
+use function str_replace;
+
+use const E_USER_DEPRECATED;
 
 /**
  * @group Laminas_Feed
@@ -18,6 +21,7 @@ use stdClass;
  */
 class PodcastRss2Test extends TestCase
 {
+    /** @var string */
     protected $feedSamplePath;
 
     protected function setUp(): void
@@ -28,7 +32,6 @@ class PodcastRss2Test extends TestCase
 
     /**
      * Feed level testing
-     *
      */
     public function testGetsNewFeedUrl(): void
     {
@@ -154,7 +157,6 @@ class PodcastRss2Test extends TestCase
 
     /**
      * Entry level testing
-     *
      */
     public function testGetsEntryBlock(): void
     {
@@ -246,9 +248,10 @@ class PodcastRss2Test extends TestCase
             ';
         $expected = str_replace("\r\n", "\n", $expected);
 
-        set_error_handler(static function ($errno, $errstr) {
+        /** @psalm-suppress UnusedClosureParam */
+        set_error_handler(static function (int $errno, string $errstr): bool {
             return (bool) preg_match('/itunes:keywords/', $errstr);
-        }, \E_USER_DEPRECATED);
+        }, E_USER_DEPRECATED);
         $keywords = $entry->getKeywords();
         restore_error_handler();
 

--- a/test/Reader/Integration/WordpressAtom10Test.php
+++ b/test/Reader/Integration/WordpressAtom10Test.php
@@ -1,15 +1,13 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Feed\Reader\Integration;
 
 use Laminas\Feed\Reader;
 use PHPUnit\Framework\TestCase;
+
+use function dirname;
+use function file_get_contents;
+use function str_replace;
 
 /**
  * @group Laminas_Feed
@@ -17,6 +15,7 @@ use PHPUnit\Framework\TestCase;
  */
 class WordpressAtom10Test extends TestCase
 {
+    /** @var string */
     protected $feedSamplePath;
 
     protected function setUp(): void
@@ -101,7 +100,6 @@ class WordpressAtom10Test extends TestCase
 
     /**
      * Entry level testing
-     *
      */
     public function testGetsEntryId(): void
     {
@@ -151,12 +149,9 @@ class WordpressAtom10Test extends TestCase
         );
         $entry = $feed->current();
 
-        /**
-         * Note: "’" is not the same as "'" - don't replace in error
-         */
-        // @codingStandardsIgnoreStart
-        $this->assertEquals('Being in New Zealand does strange things to a person. Everybody who knows me, knows I don&#8217;t much like that crazy invention called a Book. However, being here I&#8217;ve already finished 4 books, all of which I can highly recommend.'."\n\n".'Agile Software Development with Scrum, by Ken Schwaber and Mike Beedle'."\n".'Domain-Driven Design: Tackling Complexity in the [...]', $entry->getDescription());
-        // @codingStandardsIgnoreEnd
+        // Note: "’" is not the same as "'" - don't replace in error
+        // phpcs:ignore Generic.Files.LineLength.TooLong
+        $this->assertEquals('Being in New Zealand does strange things to a person. Everybody who knows me, knows I don&#8217;t much like that crazy invention called a Book. However, being here I&#8217;ve already finished 4 books, all of which I can highly recommend.' . "\n\n" . 'Agile Software Development with Scrum, by Ken Schwaber and Mike Beedle' . "\n" . 'Domain-Driven Design: Tackling Complexity in the [...]', $entry->getDescription());
     }
 
     public function testGetsEntryContent(): void
@@ -165,9 +160,8 @@ class WordpressAtom10Test extends TestCase
             file_get_contents($this->feedSamplePath)
         );
         $entry = $feed->current();
-        // @codingStandardsIgnoreStart
+        // phpcs:ignore Generic.Files.LineLength.TooLong
         $this->assertEquals('<p>Being in New Zealand does strange things to a person. Everybody who knows me, knows I don&#8217;t much like that crazy invention called a Book. However, being here I&#8217;ve already finished 4 books, all of which I can highly recommend.</p><ul><li><a href="http://www.amazon.com/Agile-Software-Development-Scrum/dp/0130676349/">Agile Software Development with Scrum, by Ken Schwaber and Mike Beedle</a></li><li><a href="http://www.amazon.com/Domain-Driven-Design-Tackling-Complexity-Software/dp/0321125215/">Domain-Driven Design: Tackling Complexity in the Heart of Software, by Eric Evans</a></li><li><a href="http://www.amazon.com/Enterprise-Application-Architecture-Addison-Wesley-Signature/dp/0321127420/">Patterns of Enterprise Application Architecture, by Martin Fowler</a></li><li><a href="http://www.amazon.com/Refactoring-Improving-Existing-Addison-Wesley-Technology/dp/0201485672/">Refactoring: Improving the Design of Existing Code by Martin Fowler</a></li></ul><p>Next up: <a href="http://www.amazon.com/Design-Patterns-Object-Oriented-Addison-Wesley-Professional/dp/0201633612/">Design Patterns: Elements of Reusable Object-Oriented Software, by the Gang of Four</a>. Yes, talk about classics and shame on me for not having ordered it sooner! Also reading <a href="http://www.amazon.com/Implementation-Patterns-Addison-Wesley-Signature-Kent/dp/0321413091/">Implementation Patterns, by Kent Beck</a> at the moment.</p>', str_replace("\n", '', $entry->getContent()));
-        // @codingStandardsIgnoreEnd
     }
 
     public function testGetsEntryLinks(): void

--- a/test/Reader/Integration/WordpressRss2DcAtomTest.php
+++ b/test/Reader/Integration/WordpressRss2DcAtomTest.php
@@ -1,15 +1,12 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Feed\Reader\Integration;
 
 use Laminas\Feed\Reader;
 use PHPUnit\Framework\TestCase;
+
+use function dirname;
+use function file_get_contents;
 
 /**
  * @group Laminas_Feed
@@ -17,6 +14,7 @@ use PHPUnit\Framework\TestCase;
  */
 class WordpressRss2DcAtomTest extends TestCase
 {
+    /** @var string */
     protected $feedSamplePath;
 
     protected function setUp(): void
@@ -27,7 +25,6 @@ class WordpressRss2DcAtomTest extends TestCase
 
     /**
      * Feed level testing
-     *
      */
     public function testGetsTitle(): void
     {
@@ -105,7 +102,6 @@ class WordpressRss2DcAtomTest extends TestCase
 
     /**
      * Entry level testing
-     *
      */
     public function testGetsEntryId(): void
     {
@@ -155,12 +151,9 @@ class WordpressRss2DcAtomTest extends TestCase
         );
         $entry = $feed->current();
 
-        /**
-         * Note: "’" is not the same as "'" - don't replace in error
-         */
-        // @codingStandardsIgnoreStart
-        $this->assertEquals('Being in New Zealand does strange things to a person. Everybody who knows me, knows I don&#8217;t much like that crazy invention called a Book. However, being here I&#8217;ve already finished 4 books, all of which I can highly recommend.'."\n\n".'Agile Software Development with Scrum, by Ken Schwaber and Mike Beedle'."\n".'Domain-Driven Design: Tackling Complexity in the [...]', $entry->getDescription());
-        // @codingStandardsIgnoreEnd
+        // Note: "’" is not the same as "'" - don't replace in error
+        // phpcs:ignore Generic.Files.LineLength.TooLong
+        $this->assertEquals('Being in New Zealand does strange things to a person. Everybody who knows me, knows I don&#8217;t much like that crazy invention called a Book. However, being here I&#8217;ve already finished 4 books, all of which I can highly recommend.' . "\n\n" . 'Agile Software Development with Scrum, by Ken Schwaber and Mike Beedle' . "\n" . 'Domain-Driven Design: Tackling Complexity in the [...]', $entry->getDescription());
     }
 
     public function testGetsEntryContent(): void
@@ -169,9 +162,8 @@ class WordpressRss2DcAtomTest extends TestCase
             file_get_contents($this->feedSamplePath)
         );
         $entry = $feed->current();
-        // @codingStandardsIgnoreStart
-        $this->assertEquals('<p>Being in New Zealand does strange things to a person. Everybody who knows me, knows I don&#8217;t much like that crazy invention called a Book. However, being here I&#8217;ve already finished 4 books, all of which I can highly recommend.</p>'."\n".'<ul>'."\n".'<li><a href="http://www.amazon.com/Agile-Software-Development-Scrum/dp/0130676349/">Agile Software Development with Scrum, by Ken Schwaber and Mike Beedle</a></li>'."\n".'<li><a href="http://www.amazon.com/Domain-Driven-Design-Tackling-Complexity-Software/dp/0321125215/">Domain-Driven Design: Tackling Complexity in the Heart of Software, by Eric Evans</a></li>'."\n".'<li><a href="http://www.amazon.com/Enterprise-Application-Architecture-Addison-Wesley-Signature/dp/0321127420/">Patterns of Enterprise Application Architecture, by Martin Fowler</a></li>'."\n".'<li><a href="http://www.amazon.com/Refactoring-Improving-Existing-Addison-Wesley-Technology/dp/0201485672/">Refactoring: Improving the Design of Existing Code by Martin Fowler</a></li>'."\n".'</ul>'."\n".'<p>Next up: <a href="http://www.amazon.com/Design-Patterns-Object-Oriented-Addison-Wesley-Professional/dp/0201633612/">Design Patterns: Elements of Reusable Object-Oriented Software, by the Gang of Four</a>. Yes, talk about classics and shame on me for not having ordered it sooner! Also reading <a href="http://www.amazon.com/Implementation-Patterns-Addison-Wesley-Signature-Kent/dp/0321413091/">Implementation Patterns, by Kent Beck</a> at the moment.</p>'."\n", $entry->getContent());
-        // @codingStandardsIgnoreEnd
+        // phpcs:ignore Generic.Files.LineLength.TooLong
+        $this->assertEquals('<p>Being in New Zealand does strange things to a person. Everybody who knows me, knows I don&#8217;t much like that crazy invention called a Book. However, being here I&#8217;ve already finished 4 books, all of which I can highly recommend.</p>' . "\n" . '<ul>' . "\n" . '<li><a href="http://www.amazon.com/Agile-Software-Development-Scrum/dp/0130676349/">Agile Software Development with Scrum, by Ken Schwaber and Mike Beedle</a></li>' . "\n" . '<li><a href="http://www.amazon.com/Domain-Driven-Design-Tackling-Complexity-Software/dp/0321125215/">Domain-Driven Design: Tackling Complexity in the Heart of Software, by Eric Evans</a></li>' . "\n" . '<li><a href="http://www.amazon.com/Enterprise-Application-Architecture-Addison-Wesley-Signature/dp/0321127420/">Patterns of Enterprise Application Architecture, by Martin Fowler</a></li>' . "\n" . '<li><a href="http://www.amazon.com/Refactoring-Improving-Existing-Addison-Wesley-Technology/dp/0201485672/">Refactoring: Improving the Design of Existing Code by Martin Fowler</a></li>' . "\n" . '</ul>' . "\n" . '<p>Next up: <a href="http://www.amazon.com/Design-Patterns-Object-Oriented-Addison-Wesley-Professional/dp/0201633612/">Design Patterns: Elements of Reusable Object-Oriented Software, by the Gang of Four</a>. Yes, talk about classics and shame on me for not having ordered it sooner! Also reading <a href="http://www.amazon.com/Implementation-Patterns-Addison-Wesley-Signature-Kent/dp/0321413091/">Implementation Patterns, by Kent Beck</a> at the moment.</p>' . "\n", $entry->getContent());
     }
 
     public function testGetsEntryLinks(): void

--- a/test/Reader/StandaloneExtensionManagerTest.php
+++ b/test/Reader/StandaloneExtensionManagerTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Feed\Reader;
 
 use Laminas\Feed\Reader\Exception\InvalidArgumentException;
@@ -16,10 +10,7 @@ use PHPUnit\Framework\TestCase;
 
 class StandaloneExtensionManagerTest extends TestCase
 {
-
-    /**
-     * @var StandaloneExtensionManager
-     */
+    /** @var StandaloneExtensionManager */
     private $extensions;
 
     protected function setUp(): void
@@ -32,6 +23,7 @@ class StandaloneExtensionManagerTest extends TestCase
         $this->assertInstanceOf(ExtensionManagerInterface::class, $this->extensions);
     }
 
+    /** @psalm-return array<string, array{0:string, 1: class-string}> */
     public function defaultPlugins(): array
     {
         return [
@@ -53,18 +45,17 @@ class StandaloneExtensionManagerTest extends TestCase
 
     /**
      * @dataProvider defaultPlugins
-     *
      */
-    public function testHasAllDefaultPlugins($pluginName, $pluginClass): void
+    public function testHasAllDefaultPlugins(string $pluginName): void
     {
         $this->assertTrue($this->extensions->has($pluginName));
     }
 
     /**
      * @dataProvider defaultPlugins
-     *
+     * @psalm-param class-string $pluginClass
      */
-    public function testCanRetrieveDefaultPluginInstances($pluginName, $pluginClass): void
+    public function testCanRetrieveDefaultPluginInstances(string $pluginName, string $pluginClass): void
     {
         $extension = $this->extensions->get($pluginName);
         $this->assertInstanceOf($pluginClass, $extension);
@@ -72,9 +63,9 @@ class StandaloneExtensionManagerTest extends TestCase
 
     /**
      * @dataProvider defaultPlugins
-     *
+     * @psalm-param class-string $pluginClass
      */
-    public function testEachPluginRetrievalReturnsNewInstance($pluginName, $pluginClass): void
+    public function testEachPluginRetrievalReturnsNewInstance(string $pluginName, string $pluginClass): void
     {
         $extension = $this->extensions->get($pluginName);
         $this->assertInstanceOf($pluginClass, $extension);

--- a/test/Reader/TestAsset/CustomExtensionManager.php
+++ b/test/Reader/TestAsset/CustomExtensionManager.php
@@ -1,21 +1,18 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Feed\Reader\TestAsset;
 
 use Laminas\Feed\Reader\Extension;
 use Laminas\Feed\Reader\ExtensionManagerInterface;
+
+use function array_key_exists;
 
 /**
  * Standalone extension manager that omits any extensions added after the 2.9 series.
  */
 class CustomExtensionManager implements ExtensionManagerInterface
 {
+    /** @var array<string, class-string> */
     private $extensions = [
         'Atom\Entry'            => Extension\Atom\Entry::class,
         'Atom\Feed'             => Extension\Atom\Feed::class,

--- a/test/Reader/TestAsset/Psr7Stream.php
+++ b/test/Reader/TestAsset/Psr7Stream.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Feed\Reader\TestAsset;
 
 /**
@@ -16,13 +10,16 @@ namespace LaminasTest\Feed\Reader\TestAsset;
  */
 class Psr7Stream
 {
+    /** @var mixed */
     private $streamValue;
 
+    /** @param mixed $streamValue */
     public function __construct($streamValue)
     {
         $this->streamValue = $streamValue;
     }
 
+    /** @return string */
     public function __toString()
     {
         return (string) $this->streamValue;

--- a/test/Reader/_files/My/Extension/JungleBooks/Entry.php
+++ b/test/Reader/_files/My/Extension/JungleBooks/Entry.php
@@ -1,27 +1,26 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace My\Extension\JungleBooks;
 
 use Laminas\Feed\Reader\Extension;
 
+use function is_string;
+
 class Entry extends Extension\AbstractEntry
 {
+    /** @return null|string */
     public function getIsbn()
     {
-        if (isset($this->data['isbn'])) {
+        if (isset($this->data['isbn']) && is_string($this->data['isbn'])) {
             return $this->data['isbn'];
         }
+
         $isbn = $this->xpath->evaluate('string(' . $this->getXpathPrefix() . '/jungle:isbn)');
-        if (! $isbn) {
+        if (! is_string($isbn)) {
             $isbn = null;
         }
-        $this->data['isbn'] = $title;
+
+        $this->data['isbn'] = $isbn;
         return $this->data['isbn'];
     }
 

--- a/test/Reader/_files/My/Extension/JungleBooks/Feed.php
+++ b/test/Reader/_files/My/Extension/JungleBooks/Feed.php
@@ -1,26 +1,25 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace My\Extension\JungleBooks;
 
 use Laminas\Feed\Reader\Extension;
 
+use function is_string;
+
 class Feed extends Extension\AbstractFeed
 {
+    /** @return null|string */
     public function getDaysPopularBookLink()
     {
         if (isset($this->data['dayPopular'])) {
             return $this->data['dayPopular'];
         }
+
         $dayPopular = $this->xpath->evaluate('string(' . $this->getXpathPrefix() . '/jungle:dayPopular)');
-        if (! $dayPopular) {
+        if (! is_string($dayPopular)) {
             $dayPopular = null;
         }
+
         $this->data['dayPopular'] = $dayPopular;
         return $this->data['dayPopular'];
     }

--- a/test/Writer/DeletedTest.php
+++ b/test/Writer/DeletedTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Feed\Writer;
 
 use DateTime;
@@ -224,6 +218,7 @@ class DeletedTest extends TestCase
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid parameter: parameter must be a non-empty string');
+        /** @psalm-suppress NullArgument */
         $entry->setEncoding(null);
     }
 

--- a/test/Writer/Extension/GooglePlayPodcast/EntryTest.php
+++ b/test/Writer/Extension/GooglePlayPodcast/EntryTest.php
@@ -1,16 +1,12 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Feed\Writer\Extension\GooglePlayPodcast;
 
 use Laminas\Feed\Writer;
 use Laminas\Feed\Writer\Exception\ExceptionInterface;
 use PHPUnit\Framework\TestCase;
+
+use function str_repeat;
 
 class EntryTest extends TestCase
 {

--- a/test/Writer/Extension/GooglePlayPodcast/FeedTest.php
+++ b/test/Writer/Extension/GooglePlayPodcast/FeedTest.php
@@ -1,16 +1,12 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Feed\Writer\Extension\GooglePlayPodcast;
 
 use Laminas\Feed\Writer;
 use Laminas\Feed\Writer\Exception\ExceptionInterface;
 use PHPUnit\Framework\TestCase;
+
+use function str_repeat;
 
 class FeedTest extends TestCase
 {
@@ -148,25 +144,25 @@ class FeedTest extends TestCase
         $feed->setPlayPodcastDescription(str_repeat('a', 4001));
     }
 
-    public function invalidImageUrls()
+    /** @psalm-return array<string, array{0: mixed}> */
+    public function invalidImageUrls(): array
     {
         return [
-            'null' => [null],
-            'true' => [true],
-            'false' => [false],
-            'zero' => [0],
-            'int' => [1],
+            'null'       => [null],
+            'true'       => [true],
+            'false'      => [false],
+            'zero'       => [0],
+            'int'        => [1],
             'zero-float' => [0.0],
-            'float' => [1.1],
-            'string' => ['scheme:/host.path'],
-            'array' => [['https://example.com/image.png']],
-            'object' => [(object) ['image' => 'https://example.com/image.png']],
+            'float'      => [1.1],
+            'string'     => ['scheme:/host.path'],
+            'array'      => [['https://example.com/image.png']],
+            'object'     => [(object) ['image' => 'https://example.com/image.png']],
         ];
     }
 
     /**
      * @dataProvider invalidImageUrls
-     *
      * @param mixed $url
      */
     public function testSetPlayPodcastImageRaisesExceptionForInvalidUrl($url)
@@ -177,7 +173,8 @@ class FeedTest extends TestCase
         $feed->setPlayPodcastImage($url);
     }
 
-    public function validImageUrls()
+    /** @psalm-return array<string, array{0: string}> */
+    public function validImageUrls(): array
     {
         return [
             'jpg' => ['https://example.com/image.jpg'],
@@ -187,7 +184,6 @@ class FeedTest extends TestCase
 
     /**
      * @dataProvider validImageUrls
-     *
      * @param string $url
      */
     public function testSetPlayPodcastImageSetsInternalDataWithValidUrl($url)

--- a/test/Writer/Extension/ITunes/EntryTest.php
+++ b/test/Writer/Extension/ITunes/EntryTest.php
@@ -1,16 +1,17 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Feed\Writer\Extension\ITunes;
 
 use Laminas\Feed\Writer;
 use Laminas\Feed\Writer\Exception\ExceptionInterface;
 use PHPUnit\Framework\TestCase;
+
+use function preg_match;
+use function restore_error_handler;
+use function set_error_handler;
+use function str_repeat;
+
+use const E_USER_DEPRECATED;
 
 /**
  * @group Laminas_Feed
@@ -110,7 +111,6 @@ class EntryTest extends TestCase
 
     /**
      * @dataProvider dataProviderForSetExplicit
-     *
      * @param string|bool $value
      * @param string      $result
      */
@@ -121,7 +121,8 @@ class EntryTest extends TestCase
         $this->assertEquals($result, $entry->getItunesExplicit());
     }
 
-    public function dataProviderForSetExplicit()
+    /** @psalm-return array<array-key, array{0: bool|string, 1: string}> */
+    public function dataProviderForSetExplicit(): array
     {
         return [
             // Current behaviour
@@ -162,9 +163,10 @@ class EntryTest extends TestCase
         $entry = new Writer\Entry();
         $words = ['a1', 'a2', 'a3', 'a4', 'a5', 'a6', 'a7', 'a8', 'a9', 'a10', 'a11', 'a12'];
 
-        set_error_handler(static function ($errno, $errstr) {
+        /** @psalm-suppress UnusedClosureParam */
+        set_error_handler(static function (int $errno, string $errstr): bool {
             return (bool) preg_match('/itunes:keywords/', $errstr);
-        }, \E_USER_DEPRECATED);
+        }, E_USER_DEPRECATED);
         $entry->setItunesKeywords($words);
         restore_error_handler();
 
@@ -176,9 +178,10 @@ class EntryTest extends TestCase
         $entry = new Writer\Entry();
         $words = ['a1', 'a2', 'a3', 'a4', 'a5', 'a6', 'a7', 'a8', 'a9', 'a10', 'a11', 'a12', 'a13'];
 
-        set_error_handler(static function ($errno, $errstr) {
+        /** @psalm-suppress UnusedClosureParam */
+        set_error_handler(static function (int $errno, string $errstr): bool {
             return (bool) preg_match('/itunes:keywords/', $errstr);
-        }, \E_USER_DEPRECATED);
+        }, E_USER_DEPRECATED);
 
         try {
             $this->expectException(ExceptionInterface::class);
@@ -196,9 +199,10 @@ class EntryTest extends TestCase
             str_repeat('b', 2),
         ];
 
-        set_error_handler(static function ($errno, $errstr) {
+        /** @psalm-suppress UnusedClosureParam */
+        set_error_handler(static function (int $errno, string $errstr): bool {
             return (bool) preg_match('/itunes:keywords/', $errstr);
-        }, \E_USER_DEPRECATED);
+        }, E_USER_DEPRECATED);
 
         try {
             $this->expectException(ExceptionInterface::class);
@@ -253,27 +257,27 @@ class EntryTest extends TestCase
         $entry->setItunesSummary(str_repeat('a', 4001));
     }
 
-    public function invalidImageUrls()
+    /** @psalm-return array<string, array{0: mixed}> */
+    public function invalidImageUrls(): array
     {
         return [
-            'null' => [null],
-            'true' => [true],
-            'false' => [false],
-            'zero' => [0],
-            'int' => [1],
-            'zero-float' => [0.0],
-            'float' => [1.1],
-            'string' => ['scheme:/host.path'],
+            'null'                  => [null],
+            'true'                  => [true],
+            'false'                 => [false],
+            'zero'                  => [0],
+            'int'                   => [1],
+            'zero-float'            => [0.0],
+            'float'                 => [1.1],
+            'string'                => ['scheme:/host.path'],
             'invalid-extension-gif' => ['https://example.com/image.gif', 'file extension'],
-            'invalid-extension-uc' => ['https://example.com/image.PNG', 'file extension'],
-            'array' => [['https://example.com/image.png']],
-            'object' => [(object) ['image' => 'https://example.com/image.png']],
+            'invalid-extension-uc'  => ['https://example.com/image.PNG', 'file extension'],
+            'array'                 => [['https://example.com/image.png']],
+            'object'                => [(object) ['image' => 'https://example.com/image.png']],
         ];
     }
 
     /**
      * @dataProvider invalidImageUrls
-     *
      * @param mixed  $url
      * @param string $expectedMessage
      */
@@ -286,7 +290,8 @@ class EntryTest extends TestCase
         $entry->setItunesImage($url);
     }
 
-    public function validImageUrls()
+    /** @psalm-return array<string, array{0: string}> */
+    public function validImageUrls(): array
     {
         return [
             'jpg' => ['https://example.com/image.jpg'],
@@ -296,7 +301,6 @@ class EntryTest extends TestCase
 
     /**
      * @dataProvider validImageUrls
-     *
      * @param string $url
      */
     public function testSetItunesImageSetsInternalDataWithValidUrl($url)
@@ -306,23 +310,23 @@ class EntryTest extends TestCase
         $this->assertEquals($url, $entry->getItunesImage());
     }
 
-    public function nonNumericEpisodeNumbers()
+    /** @psalm-return array<string, array{0: mixed}> */
+    public function nonNumericEpisodeNumbers(): array
     {
         return [
-            'null' => [null],
-            'true' => [true],
-            'false' => [false],
+            'null'       => [null],
+            'true'       => [true],
+            'false'      => [false],
             'zero-float' => [0.000],
-            'float' => [1.1],
-            'string' => ['not-a-number'],
-            'array' => [[1]],
-            'object' => [(object) ['number' => 1]],
+            'float'      => [1.1],
+            'string'     => ['not-a-number'],
+            'array'      => [[1]],
+            'object'     => [(object) ['number' => 1]],
         ];
     }
 
     /**
      * @dataProvider nonNumericEpisodeNumbers
-     *
      * @param mixed $number
      */
     public function testSetEpisodeRaisesExceptionForNonNumericEpisodeNumbers($number)
@@ -341,25 +345,25 @@ class EntryTest extends TestCase
         $this->assertEquals(42, $entry->getItunesEpisode());
     }
 
-    public function invalidEpisodeTypes()
+    /** @psalm-return array<string, array{0: mixed}> */
+    public function invalidEpisodeTypes(): array
     {
         return [
-            'null' => [null],
-            'true' => [true],
-            'false' => [false],
-            'zero' => [0],
-            'int' => [1],
+            'null'       => [null],
+            'true'       => [true],
+            'false'      => [false],
+            'zero'       => [0],
+            'int'        => [1],
             'zero-float' => [0.0],
-            'float' => [1.1],
-            'string' => ['not-a-type'],
-            'array' => [['full']],
-            'object' => [(object) ['type' => 'full']],
+            'float'      => [1.1],
+            'string'     => ['not-a-type'],
+            'array'      => [['full']],
+            'object'     => [(object) ['type' => 'full']],
         ];
     }
 
     /**
      * @dataProvider invalidEpisodeTypes
-     *
      * @param mixed $type
      */
     public function testSetEpisodeTypeRaisesExceptionForInvalidTypes($type)
@@ -371,18 +375,18 @@ class EntryTest extends TestCase
         $entry->setItunesEpisodeType($type);
     }
 
-    public function validEpisodeTypes()
+    /** @psalm-return array<string, array{0: string}> */
+    public function validEpisodeTypes(): array
     {
         return [
-            'full' => ['full'],
+            'full'    => ['full'],
             'trailer' => ['trailer'],
-            'bonus' => ['bonus'],
+            'bonus'   => ['bonus'],
         ];
     }
 
     /**
      * @dataProvider validEpisodeTypes
-     *
      * @param string $type
      */
     public function testEpisodeTypeMaybeMutatedWithAcceptedValues($type)
@@ -392,23 +396,23 @@ class EntryTest extends TestCase
         $this->assertEquals($type, $entry->getItunesEpisodeType());
     }
 
-    public function invalidClosedCaptioningFlags()
+    /** @psalm-return array<string, array{0: mixed}> */
+    public function invalidClosedCaptioningFlags(): array
     {
         return [
-            'null' => [null],
-            'zero' => [0],
-            'int' => [1],
+            'null'       => [null],
+            'zero'       => [0],
+            'int'        => [1],
             'zero-float' => [0.0],
-            'float' => [1.1],
-            'string' => ['Yes'],
-            'array' => [['Yes']],
-            'object' => [(object) ['isClosedCaptioned' => 'Yes']],
+            'float'      => [1.1],
+            'string'     => ['Yes'],
+            'array'      => [['Yes']],
+            'object'     => [(object) ['isClosedCaptioned' => 'Yes']],
         ];
     }
 
     /**
      * @dataProvider invalidClosedCaptioningFlags
-     *
      * @param mixed $status
      */
     public function testSettingClosedCaptioningToNonBooleanRaisesException($status)
@@ -436,7 +440,6 @@ class EntryTest extends TestCase
 
     /**
      * @dataProvider nonNumericEpisodeNumbers
-     *
      * @param mixed $number
      */
     public function testSetSeasonRaisesExceptionForNonNumericSeasonNumbers($number)

--- a/test/Writer/Extension/ITunes/FeedTest.php
+++ b/test/Writer/Extension/ITunes/FeedTest.php
@@ -1,16 +1,17 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Feed\Writer\Extension\ITunes;
 
 use Laminas\Feed\Writer;
 use Laminas\Feed\Writer\Exception\ExceptionInterface;
 use PHPUnit\Framework\TestCase;
+
+use function preg_match;
+use function restore_error_handler;
+use function set_error_handler;
+use function str_repeat;
+
+use const E_USER_DEPRECATED;
 
 /**
  * @group Laminas_Feed
@@ -163,7 +164,6 @@ class FeedTest extends TestCase
 
     /**
      * @dataProvider dataProviderForSetExplicit
-     *
      * @param string|bool $value
      * @param string $result
      */
@@ -174,7 +174,8 @@ class FeedTest extends TestCase
         $this->assertEquals($result, $feed->getItunesExplicit());
     }
 
-    public function dataProviderForSetExplicit()
+    /** @psalm-return array<array-key, array{0: bool|string, 1: string}> */
+    public function dataProviderForSetExplicit(): array
     {
         return [
             // Current behaviour
@@ -228,9 +229,10 @@ class FeedTest extends TestCase
             'a12',
         ];
 
-        set_error_handler(static function ($errno, $errstr) {
+        /** @psalm-suppress UnusedClosureParam */
+        set_error_handler(static function (int $errno, string $errstr): bool {
             return (bool) preg_match('/itunes:keywords/', $errstr);
-        }, \E_USER_DEPRECATED);
+        }, E_USER_DEPRECATED);
         $feed->setItunesKeywords($words);
         restore_error_handler();
 
@@ -256,9 +258,10 @@ class FeedTest extends TestCase
             'a13',
         ];
 
-        set_error_handler(static function ($errno, $errstr) {
+        /** @psalm-suppress UnusedClosureParam */
+        set_error_handler(static function (int $errno, string $errstr): bool {
             return (bool) preg_match('/itunes:keywords/', $errstr);
-        }, \E_USER_DEPRECATED);
+        }, E_USER_DEPRECATED);
 
         try {
             $this->expectException(ExceptionInterface::class);
@@ -276,9 +279,10 @@ class FeedTest extends TestCase
             str_repeat('b', 2),
         ];
 
-        set_error_handler(static function ($errno, $errstr) {
+        /** @psalm-suppress UnusedClosureParam */
+        set_error_handler(static function (int $errno, string $errstr): bool {
             return (bool) preg_match('/itunes:keywords/', $errstr);
-        }, \E_USER_DEPRECATED);
+        }, E_USER_DEPRECATED);
 
         try {
             $this->expectException(ExceptionInterface::class);
@@ -347,31 +351,31 @@ class FeedTest extends TestCase
         $feed->setItunesSummary(str_repeat('a', 4001));
     }
 
-    public function invalidImageUrls()
+    /** @psalm-return array<string, array{0: mixed, 1: string}> */
+    public function invalidImageUrls(): array
     {
+        $defaultExpectedMessage = 'valid URI';
         return [
-            'null'                  => [null],
-            'true'                  => [true],
-            'false'                 => [false],
-            'zero'                  => [0],
-            'int'                   => [1],
-            'zero-float'            => [0.0],
-            'float'                 => [1.1],
-            'string'                => ['scheme:/host.path'],
+            'null'                  => [null, $defaultExpectedMessage],
+            'true'                  => [true, $defaultExpectedMessage],
+            'false'                 => [false, $defaultExpectedMessage],
+            'zero'                  => [0, $defaultExpectedMessage],
+            'int'                   => [1, $defaultExpectedMessage],
+            'zero-float'            => [0.0, $defaultExpectedMessage],
+            'float'                 => [1.1, $defaultExpectedMessage],
+            'string'                => ['scheme:/host.path', $defaultExpectedMessage],
             'invalid-extension-gif' => ['https://example.com/image.gif', 'file extension'],
             'invalid-extension-uc'  => ['https://example.com/image.PNG', 'file extension'],
-            'array'                 => [['https://example.com/image.png']],
-            'object'                => [(object) ['image' => 'https://example.com/image.png']],
+            'array'                 => [['https://example.com/image.png'], $defaultExpectedMessage],
+            'object'                => [(object) ['image' => 'https://example.com/image.png'], $defaultExpectedMessage],
         ];
     }
 
     /**
      * @dataProvider invalidImageUrls
-     *
      * @param mixed $url
-     * @param string $expectedMessage
      */
-    public function testSetItunesImageRaisesExceptionForInvalidUrl($url, $expectedMessage = 'valid URI')
+    public function testSetItunesImageRaisesExceptionForInvalidUrl($url, string $expectedMessage)
     {
         $feed = new Writer\Feed();
 
@@ -380,7 +384,8 @@ class FeedTest extends TestCase
         $feed->setItunesImage($url);
     }
 
-    public function validImageUrls()
+    /** @psalm-return array<string, array{0: string}> */
+    public function validImageUrls(): array
     {
         return [
             'jpg' => ['https://example.com/image.jpg'],
@@ -390,7 +395,6 @@ class FeedTest extends TestCase
 
     /**
      * @dataProvider validImageUrls
-     *
      * @param string $url
      */
     public function testSetItunesImageSetsInternalDataWithValidUrl($url)
@@ -400,7 +404,8 @@ class FeedTest extends TestCase
         $this->assertEquals($url, $feed->getItunesImage());
     }
 
-    public function invalidPodcastTypes()
+    /** @psalm-return array<string, array{0: mixed}> */
+    public function invalidPodcastTypes(): array
     {
         return [
             'null'       => [null],
@@ -418,7 +423,6 @@ class FeedTest extends TestCase
 
     /**
      * @dataProvider invalidPodcastTypes
-     *
      * @param mixed $type
      */
     public function testSetItunesTypeWithInvalidTypeRaisesException($type)
@@ -430,7 +434,8 @@ class FeedTest extends TestCase
         $feed->setItunesType($type);
     }
 
-    public function validPodcastTypes()
+    /** @psalm-return array<string, array{0: string}> */
+    public function validPodcastTypes(): array
     {
         return [
             'episodic' => ['episodic'],
@@ -440,7 +445,6 @@ class FeedTest extends TestCase
 
     /**
      * @dataProvider validPodcastTypes
-     *
      * @param mixed $type
      */
     public function testSetItunesTypeMutatesTypeWithValidData($type)
@@ -450,7 +454,8 @@ class FeedTest extends TestCase
         $this->assertEquals($type, $feed->getItunesType());
     }
 
-    public function invalidCompleteStatuses()
+    /** @psalm-return array<string, array{0: mixed}> */
+    public function invalidCompleteStatuses(): array
     {
         return [
             'null'       => [null],
@@ -466,7 +471,6 @@ class FeedTest extends TestCase
 
     /**
      * @dataProvider invalidCompleteStatuses
-     *
      * @param mixed $status
      */
     public function testSetItunesCompleteRaisesExceptionForInvalidStatus($status)

--- a/test/Writer/Extension/PodcastIndex/EntryTest.php
+++ b/test/Writer/Extension/PodcastIndex/EntryTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Feed\Writer\Extension\PodcastIndex;
 
 use Laminas\Feed\Writer;
@@ -18,7 +12,7 @@ class EntryTest extends TestCase
         $entry = new Writer\Entry();
 
         $transcript = [
-            'url' => 'https://example.com/podcasts/everything/TranscriptEpisode3.html',
+            'url'  => 'https://example.com/podcasts/everything/TranscriptEpisode3.html',
             'type' => 'text/html',
         ];
         $entry->setPodcastIndexTranscript($transcript);
@@ -30,10 +24,10 @@ class EntryTest extends TestCase
         $entry = new Writer\Entry();
 
         $transcript = [
-            'url' => 'https://example.com/podcasts/everything/TranscriptEpisode3.html',
-            'type' => 'text/html',
+            'url'      => 'https://example.com/podcasts/everything/TranscriptEpisode3.html',
+            'type'     => 'text/html',
             'language' => 'en',
-            'rel' => 'captions',
+            'rel'      => 'captions',
         ];
         $entry->setPodcastIndexTranscript($transcript);
         $this->assertEquals($transcript, $entry->getPodcastIndexTranscript());
@@ -56,7 +50,7 @@ class EntryTest extends TestCase
         $entry = new Writer\Entry();
 
         $chapters = [
-            'url' => 'https://example.com/podcasts/everything/ChaptersEpisode3.json',
+            'url'  => 'https://example.com/podcasts/everything/ChaptersEpisode3.json',
             'type' => 'application/json+chapters',
         ];
         $entry->setPodcastIndexChapters($chapters);
@@ -98,14 +92,14 @@ class EntryTest extends TestCase
         $soundbites = [
             [
                 'startTime' => '66',
-                'duration' => '39.0',
-                'title' => 'Pepper shakers comparison',
+                'duration'  => '39.0',
+                'title'     => 'Pepper shakers comparison',
             ],
             [
                 'startTime' => '112.45',
-                'duration' => '24.83',
-                'title' => 'Pepper shakers comparison',
-            ]
+                'duration'  => '24.83',
+                'title'     => 'Pepper shakers comparison',
+            ],
         ];
 
         $entry->addPodcastIndexSoundbites($soundbites);
@@ -119,8 +113,8 @@ class EntryTest extends TestCase
         $soundbites = [
             [
                 'title' => 'Pepper shakers comparison',
-                'abc' => 'def',
-            ]
+                'abc'   => 'def',
+            ],
         ];
         $this->expectException(Writer\Exception\InvalidArgumentException::class);
         $entry->addPodcastIndexSoundbites($soundbites);
@@ -128,7 +122,6 @@ class EntryTest extends TestCase
 
     /**
      * @dataProvider invalidTimeValues
-     *
      * @param mixed $time
      */
     public function testAddSoundbitesThrowsExceptionOnNonNumericStartTimeValue($time): void
@@ -138,8 +131,8 @@ class EntryTest extends TestCase
         $soundbites = [
             [
                 'startTime' => $time,
-                'duration' => '39.0',
-                'title' => 'Pepper shakers comparison',
+                'duration'  => '39.0',
+                'title'     => 'Pepper shakers comparison',
             ],
         ];
         $this->expectException(Writer\Exception\InvalidArgumentException::class);
@@ -148,7 +141,6 @@ class EntryTest extends TestCase
 
     /**
      * @dataProvider invalidTimeValues
-     *
      * @param mixed $time
      */
     public function testAddSoundbitesThrowsExceptionOnNonNumericDurationValue($time): void
@@ -158,8 +150,8 @@ class EntryTest extends TestCase
         $soundbites = [
             [
                 'startTime' => '66',
-                'duration' => $time,
-                'title' => 'Pepper shakers comparison',
+                'duration'  => $time,
+                'title'     => 'Pepper shakers comparison',
             ],
         ];
         $this->expectException(Writer\Exception\InvalidArgumentException::class);
@@ -173,13 +165,13 @@ class EntryTest extends TestCase
         $soundbites = [
             [
                 'startTime' => '66',
-                'duration' => '39.0',
-                'title' => 'Pepper shakers comparison',
+                'duration'  => '39.0',
+                'title'     => 'Pepper shakers comparison',
             ],
             [
                 'startTime' => '112.45',
-                'duration' => '24.83',
-                'title' => 'Pepper shakers comparison',
+                'duration'  => '24.83',
+                'title'     => 'Pepper shakers comparison',
             ],
         ];
 
@@ -195,7 +187,7 @@ class EntryTest extends TestCase
 
         $soundbite = [
             'title' => 'Pepper shakers comparison',
-            'abc' => 'def',
+            'abc'   => 'def',
         ];
         $this->expectException(Writer\Exception\InvalidArgumentException::class);
         $entry->addPodcastIndexSoundbite($soundbite);
@@ -203,7 +195,6 @@ class EntryTest extends TestCase
 
     /**
      * @dataProvider invalidTimeValues
-     *
      * @param mixed $time
      */
     public function testAddSoundbiteThrowsExceptionOnNonNumericStartTimeValue($time): void
@@ -212,8 +203,8 @@ class EntryTest extends TestCase
 
         $soundbite = [
             'startTime' => $time,
-            'duration' => '39.0',
-            'title' => 'Pepper shakers comparison',
+            'duration'  => '39.0',
+            'title'     => 'Pepper shakers comparison',
         ];
         $this->expectException(Writer\Exception\InvalidArgumentException::class);
         $entry->addPodcastIndexSoundbite($soundbite);
@@ -221,7 +212,6 @@ class EntryTest extends TestCase
 
     /**
      * @dataProvider invalidTimeValues
-     *
      * @param mixed $time
      */
     public function testAddSoundbiteThrowsExceptionOnNonNumericDurationValue($time): void
@@ -230,8 +220,8 @@ class EntryTest extends TestCase
 
         $soundbite = [
             'startTime' => '66',
-            'duration' => $time,
-            'title' => 'Pepper shakers comparison',
+            'duration'  => $time,
+            'title'     => 'Pepper shakers comparison',
         ];
         $this->expectException(Writer\Exception\InvalidArgumentException::class);
         $entry->addPodcastIndexSoundbite($soundbite);

--- a/test/Writer/Extension/PodcastIndex/FeedTest.php
+++ b/test/Writer/Extension/PodcastIndex/FeedTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Feed\Writer\Extension\PodcastIndex;
 
 use Laminas\Feed\Writer;
@@ -55,7 +49,6 @@ class FeedTest extends TestCase
 
     /**
      * @dataProvider nonAlphaValues
-     *
      * @param mixed $value
      */
     public function testSetLockedThrowsExceptionOnNonAlphaValue($value): void
@@ -76,7 +69,7 @@ class FeedTest extends TestCase
 
         $funding = [
             'title' => 'Support the show!',
-            'url' => 'http://example.com/donate',
+            'url'   => 'http://example.com/donate',
         ];
         $feed->setPodcastIndexFunding($funding);
         $this->assertEquals($funding, $feed->getPodcastIndexFunding());

--- a/test/Writer/ExtensionPluginManagerCompatibilityTest.php
+++ b/test/Writer/ExtensionPluginManagerCompatibilityTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Feed\Writer;
 
 use Laminas\Feed\Writer\Exception\InvalidArgumentException;
@@ -14,15 +8,22 @@ use Laminas\ServiceManager\ServiceManager;
 use Laminas\ServiceManager\Test\CommonPluginManagerTrait;
 use PHPUnit\Framework\TestCase;
 
+use function sprintf;
+
 class ExtensionPluginManagerCompatibilityTest extends TestCase
 {
     use CommonPluginManagerTrait;
 
+    /**
+     * @psalm-suppress ImplementedReturnTypeMismatch
+     * @return ExtensionPluginManager
+     */
     protected function getPluginManager()
     {
         return new ExtensionPluginManager(new ServiceManager());
     }
 
+    /** @return class-string */
     protected function getV2InvalidPluginException()
     {
         return InvalidArgumentException::class;
@@ -30,7 +31,6 @@ class ExtensionPluginManagerCompatibilityTest extends TestCase
 
     protected function getInstanceOf(): void
     {
-        return;
     }
 
     public function testInstanceOfMatches(): void

--- a/test/Writer/FeedFactoryTest.php
+++ b/test/Writer/FeedFactoryTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Feed\Writer;
 
 use DateTime;

--- a/test/Writer/StandaloneExtensionManagerTest.php
+++ b/test/Writer/StandaloneExtensionManagerTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Feed\Writer;
 
 use Laminas\Feed\Writer\Exception\InvalidArgumentException;
@@ -16,10 +10,7 @@ use PHPUnit\Framework\TestCase;
 
 class StandaloneExtensionManagerTest extends TestCase
 {
-
-    /**
-     * @var StandaloneExtensionManager
-     */
+    /** @var StandaloneExtensionManager */
     private $extensions;
 
     protected function setUp(): void
@@ -32,8 +23,10 @@ class StandaloneExtensionManagerTest extends TestCase
         $this->assertInstanceOf(ExtensionManagerInterface::class, $this->extensions);
     }
 
+    /** @psalm-return array<string, array{0: string, 1: class-string}> */
     public function defaultPlugins(): array
     {
+        // phpcs:disable Generic.Files.LineLength.TooLong
         return [
             'Atom\Renderer\Feed'           => ['Atom\Renderer\Feed', Extension\Atom\Renderer\Feed::class],
             'Content\Renderer\Entry'       => ['Content\Renderer\Entry', Extension\Content\Renderer\Entry::class],
@@ -45,27 +38,24 @@ class StandaloneExtensionManagerTest extends TestCase
             'ITunes\Renderer\Feed'         => ['ITunes\Renderer\Feed', Extension\ITunes\Renderer\Feed::class],
             'Slash\Renderer\Entry'         => ['Slash\Renderer\Entry', Extension\Slash\Renderer\Entry::class],
             'Threading\Renderer\Entry'     => ['Threading\Renderer\Entry', Extension\Threading\Renderer\Entry::class],
-            'WellFormedWeb\Renderer\Entry' => [
-                'WellFormedWeb\Renderer\Entry',
-                Extension\WellFormedWeb\Renderer\Entry::class,
-            ],
+            'WellFormedWeb\Renderer\Entry' => ['WellFormedWeb\Renderer\Entry', Extension\WellFormedWeb\Renderer\Entry::class],
         ];
+        // phpcs:enable Generic.Files.LineLength.TooLong
     }
 
     /**
      * @dataProvider defaultPlugins
-     *
      */
-    public function testHasAllDefaultPlugins($pluginName, $pluginClass): void
+    public function testHasAllDefaultPlugins(string $pluginName): void
     {
         $this->assertTrue($this->extensions->has($pluginName));
     }
 
     /**
      * @dataProvider defaultPlugins
-     *
+     * @psalm-param class-string $pluginClass
      */
-    public function testCanRetrieveDefaultPluginInstances($pluginName, $pluginClass): void
+    public function testCanRetrieveDefaultPluginInstances(string $pluginName, string $pluginClass): void
     {
         $extension = $this->extensions->get($pluginName);
         $this->assertInstanceOf($pluginClass, $extension);
@@ -73,9 +63,9 @@ class StandaloneExtensionManagerTest extends TestCase
 
     /**
      * @dataProvider defaultPlugins
-     *
+     * @psalm-param class-string $pluginClass
      */
-    public function testEachPluginRetrievalReturnsNewInstance($pluginName, $pluginClass): void
+    public function testEachPluginRetrievalReturnsNewInstance(string $pluginName, string $pluginClass): void
     {
         $extension = $this->extensions->get($pluginName);
         $this->assertInstanceOf($pluginClass, $extension);
@@ -87,9 +77,11 @@ class StandaloneExtensionManagerTest extends TestCase
 
     public function testAddAcceptsValidExtensionClasses(): void
     {
+        /** @psalm-suppress UndefinedClass,ArgumentTypeCoercion */
         $this->extensions->add('Test/Feed', 'MyTestExtension_Feed');
         $this->assertTrue($this->extensions->has('Test/Feed'));
 
+        /** @psalm-suppress UndefinedClass,ArgumentTypeCoercion */
         $this->extensions->add('Test/Entry', 'MyTestExtension_Entry');
         $this->assertTrue($this->extensions->has('Test/Entry'));
 
@@ -100,11 +92,13 @@ class StandaloneExtensionManagerTest extends TestCase
     public function testAddRejectsInvalidExtensions(): void
     {
         $this->expectException(InvalidArgumentException::class);
+        /** @psalm-suppress UndefinedClass,ArgumentTypeCoercion */
         $this->extensions->add('Test/Feed', 'blah');
     }
 
     public function testExtensionRemoval(): void
     {
+        /** @psalm-suppress UndefinedClass,ArgumentTypeCoercion */
         $this->extensions->add('Test/Entry', 'MyTestExtension_Entry');
         $this->assertTrue($this->extensions->has('Test/Entry'));
         $this->extensions->remove('Test/Entry');

--- a/test/Writer/TestAsset/CustomExtensionManager.php
+++ b/test/Writer/TestAsset/CustomExtensionManager.php
@@ -1,19 +1,17 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-feed for the canonical source repository
- * @copyright https://github.com/laminas/laminas-feed/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-feed/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\Feed\Writer\TestAsset;
 
 use Laminas\Feed\Writer\Exception\InvalidArgumentException;
 use Laminas\Feed\Writer\Extension;
 use Laminas\Feed\Writer\ExtensionManagerInterface;
 
+use function array_key_exists;
+use function sprintf;
+
 class CustomExtensionManager implements ExtensionManagerInterface
 {
+    /** @var array<string, class-string> */
     private $extensions = [
         'Atom\Renderer\Feed'           => Extension\Atom\Renderer\Feed::class,
         'Content\Renderer\Entry'       => Extension\Content\Renderer\Entry::class,
@@ -50,9 +48,8 @@ class CustomExtensionManager implements ExtensionManagerInterface
         $class = $this->has($extension) ? $this->extensions[$extension] : false;
         if (! $class) {
             throw new InvalidArgumentException(sprintf(
-                'Cannot fetch extension "%s"; class "%s" does not exist',
-                $extension,
-                $class
+                'Cannot fetch extension "%s"; does not exist',
+                $extension
             ));
         }
         return new $class();


### PR DESCRIPTION
This patch prepares the component for use with PHP 8.1, via the following actions:

- Adds `~8.1.0` to the list of allowed PHP versions
- Changes how the package replaces zend-feed:
  - Removes the "replace" section of the package definition
  - Adds `"zendframework/zend-feed": "*"` to the list of package conflicts
- Bumps laminas-coding-standard to the 2.2 ruleset and applies it
- Bumps dependency versions to those known to work with 8.1 when possible
- Ensures all functionality works under 8.1, primarily by adding `#[ReturnTypeWillChange]` attributes to `Iterator`, `Countable`, and `ArrayObject` method implementations.
