### PR TITLE
Mark more interface method returns with `#[ReturnTypeWillChange]` for PHP 8.1 compatibility

### DIFF
--- a/src/Reader/AbstractFeed.php
+++ b/src/Reader/AbstractFeed.php
@@ -5,6 +5,7 @@ namespace Laminas\Feed\Reader;
 use DOMDocument;
 use DOMElement;
 use DOMXPath;
+// phpcs:ignore SlevomatCodingStandard.Namespaces.UnusedUses.UnusedUse
 use ReturnTypeWillChange;
 
 use function call_user_func_array;

--- a/src/Reader/AbstractFeed.php
+++ b/src/Reader/AbstractFeed.php
@@ -5,6 +5,7 @@ namespace Laminas\Feed\Reader;
 use DOMDocument;
 use DOMElement;
 use DOMXPath;
+use ReturnTypeWillChange;
 
 use function call_user_func_array;
 use function count;
@@ -115,6 +116,7 @@ abstract class AbstractFeed implements Feed\FeedInterface
      *
      * @return int
      */
+    #[ReturnTypeWillChange]
     public function count()
     {
         return count($this->entries);
@@ -125,6 +127,7 @@ abstract class AbstractFeed implements Feed\FeedInterface
      *
      * @return Entry\AbstractEntry
      */
+    #[ReturnTypeWillChange]
     public function current()
     {
         if (0 === strpos($this->getType(), 'rss')) {
@@ -207,6 +210,7 @@ abstract class AbstractFeed implements Feed\FeedInterface
      *
      * @return int
      */
+    #[ReturnTypeWillChange]
     public function key()
     {
         return $this->entriesKey;
@@ -215,6 +219,7 @@ abstract class AbstractFeed implements Feed\FeedInterface
     /**
      * Move the feed pointer forward
      */
+    #[ReturnTypeWillChange]
     public function next()
     {
         ++$this->entriesKey;
@@ -223,6 +228,7 @@ abstract class AbstractFeed implements Feed\FeedInterface
     /**
      * Reset the pointer in the feed object
      */
+    #[ReturnTypeWillChange]
     public function rewind()
     {
         $this->entriesKey = 0;
@@ -233,6 +239,7 @@ abstract class AbstractFeed implements Feed\FeedInterface
      *
      * @return bool
      */
+    #[ReturnTypeWillChange]
     public function valid()
     {
         return 0 <= $this->entriesKey && $this->entriesKey < $this->count();


### PR DESCRIPTION
Some return type flags got missed for PHP 8.1.  Adding them now, to clean up my logs. :smiley: 

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | o
| RFC           | no
| QA            | no

