### PR TITLE
Mention creation of Feeds in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,10 +1,12 @@
 {
     "name": "laminas/laminas-feed",
-    "description": "provides functionality for consuming RSS and Atom feeds",
+    "description": "provides functionality for creating and consuming RSS and Atom feeds",
     "license": "BSD-3-Clause",
     "keywords": [
         "laminas",
-        "feed"
+        "feed",
+        "rss",
+        "atom"
     ],
     "homepage": "https://laminas.dev",
     "support": {


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

This PR adds a mention that the package can also be used to create - and not only consume - feeds.

It also adds the "rss" and the "atom" keywords. Even though those two phrases are already part of the description it can not hurt to have them in the keywords as well.

