### PR TITLE
Update Laminas Coding Standard to 2.3, Remove Interop\Container, Drop Support for PHP 7.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
     "require-dev": {
         "laminas/laminas-cache": "^2.13.2 || ^3.1.3",
         "laminas/laminas-cache-storage-adapter-memory": "^1.1.0 || ^2.0.0",
-        "laminas/laminas-coding-standard": "~2.2.1",
+        "laminas/laminas-coding-standard": "~2.3.0",
         "laminas/laminas-db": "^2.13.3",
         "laminas/laminas-http": "^2.15",
         "laminas/laminas-servicemanager": "^3.7",

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
         "phpunit/phpunit": "^9.5.5",
         "psalm/plugin-phpunit": "^0.17.0",
         "psr/http-message": "^1.0.1",
-        "vimeo/psalm": "^4.1"
+        "vimeo/psalm": "^4.24.0"
     },
     "conflict": {
         "laminas/laminas-servicemanager": "<3.3",

--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
         "ext-dom": "*",
         "ext-libxml": "*",
         "laminas/laminas-escaper": "^2.9",
+        "laminas/laminas-servicemanager": "^3.14.0",
         "laminas/laminas-stdlib": "^3.6"
     },
     "require-dev": {
@@ -41,7 +42,6 @@
         "laminas/laminas-coding-standard": "~2.3.0",
         "laminas/laminas-db": "^2.13.3",
         "laminas/laminas-http": "^2.15",
-        "laminas/laminas-servicemanager": "^3.7",
         "laminas/laminas-validator": "^2.15",
         "phpunit/phpunit": "^9.5.5",
         "psalm/plugin-phpunit": "^0.17.0",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "config": {
         "sort-packages": true,
         "platform": {
-            "php": "7.3.99"
+            "php": "7.4.99"
         },
         "allow-plugins": {
             "dealerdirect/phpcodesniffer-composer-installer": true
@@ -29,7 +29,7 @@
     "extra": {
     },
     "require": {
-        "php": "^7.3 || ~8.0.0 || ~8.1.0",
+        "php": "^7.4 || ~8.0.0 || ~8.1.0",
         "ext-dom": "*",
         "ext-libxml": "*",
         "laminas/laminas-escaper": "^2.9",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8cdf8ceca2e38eb40afa7167f9712e0f",
+    "content-hash": "32d98c7bda75078c7ae21fa417b9962a",
     "packages": [
         {
             "name": "laminas/laminas-escaper",
@@ -5154,13 +5154,13 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.3 || ~8.0.0 || ~8.1.0",
+        "php": "^7.4 || ~8.0.0 || ~8.1.0",
         "ext-dom": "*",
         "ext-libxml": "*"
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "7.3.99"
+        "php": "7.4.99"
     },
     "plugin-api-version": "2.3.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1e1169c11e823b05116d7f20837b2d58",
+    "content-hash": "1fdc294e74a6149af1de9a5a2f5c88dc",
     "packages": [
         {
             "name": "laminas/laminas-escaper",
@@ -69,6 +69,97 @@
             "time": "2021-09-02T17:10:53+00:00"
         },
         {
+            "name": "laminas/laminas-servicemanager",
+            "version": "3.14.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-servicemanager.git",
+                "reference": "918de970b2c3d42acebff3d431d76db52b6a32a2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-servicemanager/zipball/918de970b2c3d42acebff3d431d76db52b6a32a2",
+                "reference": "918de970b2c3d42acebff3d431d76db52b6a32a2",
+                "shasum": ""
+            },
+            "require": {
+                "laminas/laminas-stdlib": "^3.2.1",
+                "php": "~7.4.0 || ~8.0.0 || ~8.1.0",
+                "psr/container": "^1.0"
+            },
+            "conflict": {
+                "ext-psr": "*",
+                "laminas/laminas-code": "<3.3.1",
+                "zendframework/zend-code": "<3.3.1",
+                "zendframework/zend-servicemanager": "*"
+            },
+            "provide": {
+                "psr/container-implementation": "^1.0"
+            },
+            "replace": {
+                "container-interop/container-interop": "^1.2.0"
+            },
+            "require-dev": {
+                "composer/package-versions-deprecated": "^1.0",
+                "laminas/laminas-coding-standard": "~2.3.0",
+                "laminas/laminas-container-config-test": "^0.6",
+                "laminas/laminas-dependency-plugin": "^2.1.2",
+                "mikey179/vfsstream": "^1.6.10@alpha",
+                "ocramius/proxy-manager": "^2.11",
+                "phpbench/phpbench": "^1.1",
+                "phpspec/prophecy-phpunit": "^2.0",
+                "phpunit/phpunit": "^9.5.5",
+                "psalm/plugin-phpunit": "^0.17.0",
+                "vimeo/psalm": "^4.8"
+            },
+            "suggest": {
+                "ocramius/proxy-manager": "ProxyManager ^2.1.1 to handle lazy initialization of services"
+            },
+            "bin": [
+                "bin/generate-deps-for-config-factory",
+                "bin/generate-factory-for-class"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/autoload.php"
+                ],
+                "psr-4": {
+                    "Laminas\\ServiceManager\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Factory-Driven Dependency Injection Container",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "PSR-11",
+                "dependency-injection",
+                "di",
+                "dic",
+                "laminas",
+                "service-manager",
+                "servicemanager"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-servicemanager/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-servicemanager/issues",
+                "rss": "https://github.com/laminas/laminas-servicemanager/releases.atom",
+                "source": "https://github.com/laminas/laminas-servicemanager"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2022-07-07T16:13:26+00:00"
+        },
+        {
             "name": "laminas/laminas-stdlib",
             "version": "3.6.0",
             "source": {
@@ -126,6 +217,54 @@
                 }
             ],
             "time": "2021-09-02T16:11:32+00:00"
+        },
+        {
+            "name": "psr/container",
+            "version": "1.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/container.git",
+                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/513e0666f7216c7459170d56df27dfcefe1689ea",
+                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.4.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Container\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common Container Interface (PHP FIG PSR-11)",
+            "homepage": "https://github.com/php-fig/container",
+            "keywords": [
+                "PSR-11",
+                "container",
+                "container-interface",
+                "container-interop",
+                "psr"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/container/issues",
+                "source": "https://github.com/php-fig/container/tree/1.1.2"
+            },
+            "time": "2021-11-05T16:50:12+00:00"
         }
     ],
     "packages-dev": [
@@ -585,42 +724,6 @@
                 }
             ],
             "time": "2022-02-25T21:32:43+00:00"
-        },
-        {
-            "name": "container-interop/container-interop",
-            "version": "1.2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/container-interop/container-interop.git",
-                "reference": "79cbf1341c22ec75643d841642dd5d6acd83bdb8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/container-interop/container-interop/zipball/79cbf1341c22ec75643d841642dd5d6acd83bdb8",
-                "reference": "79cbf1341c22ec75643d841642dd5d6acd83bdb8",
-                "shasum": ""
-            },
-            "require": {
-                "psr/container": "^1.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Interop\\Container\\": "src/Interop/Container/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "Promoting the interoperability of container objects (DIC, SL, etc.)",
-            "homepage": "https://github.com/container-interop/container-interop",
-            "support": {
-                "issues": "https://github.com/container-interop/container-interop/issues",
-                "source": "https://github.com/container-interop/container-interop/tree/master"
-            },
-            "abandoned": "psr/container",
-            "time": "2017-02-14T19:40:03+00:00"
         },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
@@ -1379,95 +1482,6 @@
             "time": "2021-09-02T18:30:53+00:00"
         },
         {
-            "name": "laminas/laminas-servicemanager",
-            "version": "3.7.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laminas/laminas-servicemanager.git",
-                "reference": "2b0aee477fdbd3191af7c302b93dbc5fda0626f4"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-servicemanager/zipball/2b0aee477fdbd3191af7c302b93dbc5fda0626f4",
-                "reference": "2b0aee477fdbd3191af7c302b93dbc5fda0626f4",
-                "shasum": ""
-            },
-            "require": {
-                "container-interop/container-interop": "^1.2",
-                "laminas/laminas-stdlib": "^3.2.1",
-                "laminas/laminas-zendframework-bridge": "^1.0",
-                "php": "^7.3 || ~8.0.0",
-                "psr/container": "^1.0"
-            },
-            "conflict": {
-                "laminas/laminas-code": "<3.3.1",
-                "zendframework/zend-code": "<3.3.1"
-            },
-            "provide": {
-                "container-interop/container-interop-implementation": "^1.2",
-                "psr/container-implementation": "^1.0"
-            },
-            "replace": {
-                "zendframework/zend-servicemanager": "^3.4.0"
-            },
-            "require-dev": {
-                "composer/package-versions-deprecated": "^1.0",
-                "laminas/laminas-coding-standard": "~2.2.0",
-                "laminas/laminas-container-config-test": "^0.3",
-                "laminas/laminas-dependency-plugin": "^2.1.2",
-                "mikey179/vfsstream": "^1.6.8",
-                "ocramius/proxy-manager": "^2.2.3",
-                "phpbench/phpbench": "^1.0.4",
-                "phpspec/prophecy-phpunit": "^2.0",
-                "phpunit/phpunit": "^9.4",
-                "psalm/plugin-phpunit": "^0.16.1",
-                "vimeo/psalm": "^4.8"
-            },
-            "suggest": {
-                "ocramius/proxy-manager": "ProxyManager ^2.1.1 to handle lazy initialization of services"
-            },
-            "bin": [
-                "bin/generate-deps-for-config-factory",
-                "bin/generate-factory-for-class"
-            ],
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Laminas\\ServiceManager\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "Factory-Driven Dependency Injection Container",
-            "homepage": "https://laminas.dev",
-            "keywords": [
-                "PSR-11",
-                "dependency-injection",
-                "di",
-                "dic",
-                "laminas",
-                "service-manager",
-                "servicemanager"
-            ],
-            "support": {
-                "chat": "https://laminas.dev/chat",
-                "docs": "https://docs.laminas.dev/laminas-servicemanager/",
-                "forum": "https://discourse.laminas.dev",
-                "issues": "https://github.com/laminas/laminas-servicemanager/issues",
-                "rss": "https://github.com/laminas/laminas-servicemanager/releases.atom",
-                "source": "https://github.com/laminas/laminas-servicemanager"
-            },
-            "funding": [
-                {
-                    "url": "https://funding.communitybridge.org/projects/laminas-project",
-                    "type": "community_bridge"
-                }
-            ],
-            "time": "2021-07-24T19:33:07+00:00"
-        },
-        {
             "name": "laminas/laminas-uri",
             "version": "2.9.1",
             "source": {
@@ -1614,68 +1628,6 @@
                 }
             ],
             "time": "2021-09-08T23:16:56+00:00"
-        },
-        {
-            "name": "laminas/laminas-zendframework-bridge",
-            "version": "1.4.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laminas/laminas-zendframework-bridge.git",
-                "reference": "bf180a382393e7db5c1e8d0f2ec0c4af9c724baf"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-zendframework-bridge/zipball/bf180a382393e7db5c1e8d0f2ec0c4af9c724baf",
-                "reference": "bf180a382393e7db5c1e8d0f2ec0c4af9c724baf",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.3 || ~8.0.0 || ~8.1.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.3",
-                "psalm/plugin-phpunit": "^0.15.1",
-                "squizlabs/php_codesniffer": "^3.5",
-                "vimeo/psalm": "^4.6"
-            },
-            "type": "library",
-            "extra": {
-                "laminas": {
-                    "module": "Laminas\\ZendFrameworkBridge"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "src/autoload.php"
-                ],
-                "psr-4": {
-                    "Laminas\\ZendFrameworkBridge\\": "src//"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "Alias legacy ZF class names to Laminas Project equivalents.",
-            "keywords": [
-                "ZendFramework",
-                "autoloading",
-                "laminas",
-                "zf"
-            ],
-            "support": {
-                "forum": "https://discourse.laminas.dev/",
-                "issues": "https://github.com/laminas/laminas-zendframework-bridge/issues",
-                "rss": "https://github.com/laminas/laminas-zendframework-bridge/releases.atom",
-                "source": "https://github.com/laminas/laminas-zendframework-bridge"
-            },
-            "funding": [
-                {
-                    "url": "https://funding.communitybridge.org/projects/laminas-project",
-                    "type": "community_bridge"
-                }
-            ],
-            "time": "2021-09-03T17:53:30+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -2804,54 +2756,6 @@
                 "source": "https://github.com/php-fig/cache/tree/master"
             },
             "time": "2016-08-06T20:24:11+00:00"
-        },
-        {
-            "name": "psr/container",
-            "version": "1.1.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/container.git",
-                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/container/zipball/513e0666f7216c7459170d56df27dfcefe1689ea",
-                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.4.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Container\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "https://www.php-fig.org/"
-                }
-            ],
-            "description": "Common Container Interface (PHP FIG PSR-11)",
-            "homepage": "https://github.com/php-fig/container",
-            "keywords": [
-                "PSR-11",
-                "container",
-                "container-interface",
-                "container-interop",
-                "psr"
-            ],
-            "support": {
-                "issues": "https://github.com/php-fig/container/issues",
-                "source": "https://github.com/php-fig/container/tree/1.1.2"
-            },
-            "time": "2021-11-05T16:50:12+00:00"
         },
         {
             "name": "psr/http-message",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "32d98c7bda75078c7ae21fa417b9962a",
+    "content-hash": "1e1169c11e823b05116d7f20837b2d58",
     "packages": [
         {
             "name": "laminas/laminas-escaper",
@@ -131,16 +131,16 @@
     "packages-dev": [
         {
             "name": "amphp/amp",
-            "version": "v2.6.0",
+            "version": "v2.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/amphp/amp.git",
-                "reference": "caa95edeb1ca1bf7532e9118ede4a3c3126408cc"
+                "reference": "9d5100cebffa729aaffecd3ad25dc5aeea4f13bb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/amphp/amp/zipball/caa95edeb1ca1bf7532e9118ede4a3c3126408cc",
-                "reference": "caa95edeb1ca1bf7532e9118ede4a3c3126408cc",
+                "url": "https://api.github.com/repos/amphp/amp/zipball/9d5100cebffa729aaffecd3ad25dc5aeea4f13bb",
+                "reference": "9d5100cebffa729aaffecd3ad25dc5aeea4f13bb",
                 "shasum": ""
             },
             "require": {
@@ -193,7 +193,7 @@
                 }
             ],
             "description": "A non-blocking concurrency framework for PHP applications.",
-            "homepage": "http://amphp.org/amp",
+            "homepage": "https://amphp.org/amp",
             "keywords": [
                 "async",
                 "asynchronous",
@@ -208,7 +208,7 @@
             "support": {
                 "irc": "irc://irc.freenode.org/amphp",
                 "issues": "https://github.com/amphp/amp/issues",
-                "source": "https://github.com/amphp/amp/tree/v2.6.0"
+                "source": "https://github.com/amphp/amp/tree/v2.6.2"
             },
             "funding": [
                 {
@@ -216,7 +216,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-07-16T20:06:06+00:00"
+            "time": "2022-02-20T17:52:18+00:00"
         },
         {
             "name": "amphp/byte-stream",
@@ -369,6 +369,77 @@
             "time": "2022-01-17T14:14:24+00:00"
         },
         {
+            "name": "composer/pcre",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/pcre.git",
+                "reference": "e300eb6c535192decd27a85bc72a9290f0d6b3bd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/pcre/zipball/e300eb6c535192decd27a85bc72a9290f0d6b3bd",
+                "reference": "e300eb6c535192decd27a85bc72a9290f0d6b3bd",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.3",
+                "phpstan/phpstan-strict-rules": "^1.1",
+                "symfony/phpunit-bridge": "^5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Pcre\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                }
+            ],
+            "description": "PCRE wrapping library that offers type-safe preg_* replacements.",
+            "keywords": [
+                "PCRE",
+                "preg",
+                "regex",
+                "regular expression"
+            ],
+            "support": {
+                "issues": "https://github.com/composer/pcre/issues",
+                "source": "https://github.com/composer/pcre/tree/3.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-02-25T20:21:48+00:00"
+        },
+        {
             "name": "composer/semver",
             "version": "3.3.2",
             "source": {
@@ -451,25 +522,27 @@
         },
         {
             "name": "composer/xdebug-handler",
-            "version": "2.0.2",
+            "version": "3.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/xdebug-handler.git",
-                "reference": "84674dd3a7575ba617f5a76d7e9e29a7d3891339"
+                "reference": "ced299686f41dce890debac69273b47ffe98a40c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/84674dd3a7575ba617f5a76d7e9e29a7d3891339",
-                "reference": "84674dd3a7575ba617f5a76d7e9e29a7d3891339",
+                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/ced299686f41dce890debac69273b47ffe98a40c",
+                "reference": "ced299686f41dce890debac69273b47ffe98a40c",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.2 || ^7.0 || ^8.0",
+                "composer/pcre": "^1 || ^2 || ^3",
+                "php": "^7.2.5 || ^8.0",
                 "psr/log": "^1 || ^2 || ^3"
             },
             "require-dev": {
-                "phpstan/phpstan": "^0.12.55",
-                "symfony/phpunit-bridge": "^4.2 || ^5"
+                "phpstan/phpstan": "^1.0",
+                "phpstan/phpstan-strict-rules": "^1.1",
+                "symfony/phpunit-bridge": "^6.0"
             },
             "type": "library",
             "autoload": {
@@ -495,7 +568,7 @@
             "support": {
                 "irc": "irc://irc.freenode.org/composer",
                 "issues": "https://github.com/composer/xdebug-handler/issues",
-                "source": "https://github.com/composer/xdebug-handler/tree/2.0.2"
+                "source": "https://github.com/composer/xdebug-handler/tree/3.0.3"
             },
             "funding": [
                 {
@@ -511,7 +584,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-07-31T17:03:58+00:00"
+            "time": "2022-02-25T21:32:43+00:00"
         },
         {
             "name": "container-interop/container-interop",
@@ -777,16 +850,16 @@
         },
         {
             "name": "felixfbecker/language-server-protocol",
-            "version": "1.5.1",
+            "version": "v1.5.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/felixfbecker/php-language-server-protocol.git",
-                "reference": "9d846d1f5cf101deee7a61c8ba7caa0a975cd730"
+                "reference": "6e82196ffd7c62f7794d778ca52b69feec9f2842"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/felixfbecker/php-language-server-protocol/zipball/9d846d1f5cf101deee7a61c8ba7caa0a975cd730",
-                "reference": "9d846d1f5cf101deee7a61c8ba7caa0a975cd730",
+                "url": "https://api.github.com/repos/felixfbecker/php-language-server-protocol/zipball/6e82196ffd7c62f7794d778ca52b69feec9f2842",
+                "reference": "6e82196ffd7c62f7794d778ca52b69feec9f2842",
                 "shasum": ""
             },
             "require": {
@@ -827,9 +900,9 @@
             ],
             "support": {
                 "issues": "https://github.com/felixfbecker/php-language-server-protocol/issues",
-                "source": "https://github.com/felixfbecker/php-language-server-protocol/tree/1.5.1"
+                "source": "https://github.com/felixfbecker/php-language-server-protocol/tree/v1.5.2"
             },
-            "time": "2021-02-22T14:02:09+00:00"
+            "time": "2022-03-02T22:36:06+00:00"
         },
         {
             "name": "laminas/laminas-cache",
@@ -1712,16 +1785,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.13.0",
+            "version": "v4.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "50953a2691a922aa1769461637869a0a2faa3f53"
+                "reference": "34bea19b6e03d8153165d8f30bba4c3be86184c1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/50953a2691a922aa1769461637869a0a2faa3f53",
-                "reference": "50953a2691a922aa1769461637869a0a2faa3f53",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/34bea19b6e03d8153165d8f30bba4c3be86184c1",
+                "reference": "34bea19b6e03d8153165d8f30bba4c3be86184c1",
                 "shasum": ""
             },
             "require": {
@@ -1762,9 +1835,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.13.0"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.14.0"
             },
-            "time": "2021-09-20T12:20:58+00:00"
+            "time": "2022-05-31T20:59:12+00:00"
         },
         {
             "name": "openlss/lib-array2xml",
@@ -1985,16 +2058,16 @@
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "5.2.2",
+            "version": "5.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "069a785b2141f5bcf49f3e353548dc1cce6df556"
+                "reference": "622548b623e81ca6d78b721c5e029f4ce664f170"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/069a785b2141f5bcf49f3e353548dc1cce6df556",
-                "reference": "069a785b2141f5bcf49f3e353548dc1cce6df556",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/622548b623e81ca6d78b721c5e029f4ce664f170",
+                "reference": "622548b623e81ca6d78b721c5e029f4ce664f170",
                 "shasum": ""
             },
             "require": {
@@ -2005,7 +2078,8 @@
                 "webmozart/assert": "^1.9.1"
             },
             "require-dev": {
-                "mockery/mockery": "~1.3.2"
+                "mockery/mockery": "~1.3.2",
+                "psalm/phar": "^4.8"
             },
             "type": "library",
             "extra": {
@@ -2035,22 +2109,22 @@
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
             "support": {
                 "issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
-                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/master"
+                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/5.3.0"
             },
-            "time": "2020-09-03T19:13:55+00:00"
+            "time": "2021-10-19T17:43:47+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "1.5.0",
+            "version": "1.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "30f38bffc6f24293dadd1823936372dfa9e86e2f"
+                "reference": "77a32518733312af16a44300404e945338981de3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/30f38bffc6f24293dadd1823936372dfa9e86e2f",
-                "reference": "30f38bffc6f24293dadd1823936372dfa9e86e2f",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/77a32518733312af16a44300404e945338981de3",
+                "reference": "77a32518733312af16a44300404e945338981de3",
                 "shasum": ""
             },
             "require": {
@@ -2085,9 +2159,9 @@
             "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
             "support": {
                 "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
-                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.5.0"
+                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.6.1"
             },
-            "time": "2021-09-17T15:28:14+00:00"
+            "time": "2022-03-15T21:29:03+00:00"
         },
         {
             "name": "phpspec/prophecy",
@@ -2733,20 +2807,20 @@
         },
         {
             "name": "psr/container",
-            "version": "1.1.1",
+            "version": "1.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/container.git",
-                "reference": "8622567409010282b7aeebe4bb841fe98b58dcaf"
+                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/container/zipball/8622567409010282b7aeebe4bb841fe98b58dcaf",
-                "reference": "8622567409010282b7aeebe4bb841fe98b58dcaf",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/513e0666f7216c7459170d56df27dfcefe1689ea",
+                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.0"
+                "php": ">=7.4.0"
             },
             "type": "library",
             "autoload": {
@@ -2775,9 +2849,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-fig/container/issues",
-                "source": "https://github.com/php-fig/container/tree/1.1.1"
+                "source": "https://github.com/php-fig/container/tree/1.1.2"
             },
-            "time": "2021-03-05T17:36:06+00:00"
+            "time": "2021-11-05T16:50:12+00:00"
         },
         {
             "name": "psr/http-message",
@@ -4016,26 +4090,26 @@
         },
         {
             "name": "symfony/console",
-            "version": "v5.3.7",
+            "version": "v5.4.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "8b1008344647462ae6ec57559da166c2bfa5e16a"
+                "reference": "4d671ab4ddac94ee439ea73649c69d9d200b5000"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/8b1008344647462ae6ec57559da166c2bfa5e16a",
-                "reference": "8b1008344647462ae6ec57559da166c2bfa5e16a",
+                "url": "https://api.github.com/repos/symfony/console/zipball/4d671ab4ddac94ee439ea73649c69d9d200b5000",
+                "reference": "4d671ab4ddac94ee439ea73649c69d9d200b5000",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2.5",
-                "symfony/deprecation-contracts": "^2.1",
+                "symfony/deprecation-contracts": "^2.1|^3",
                 "symfony/polyfill-mbstring": "~1.0",
-                "symfony/polyfill-php73": "^1.8",
+                "symfony/polyfill-php73": "^1.9",
                 "symfony/polyfill-php80": "^1.16",
-                "symfony/service-contracts": "^1.1|^2",
-                "symfony/string": "^5.1"
+                "symfony/service-contracts": "^1.1|^2|^3",
+                "symfony/string": "^5.1|^6.0"
             },
             "conflict": {
                 "psr/log": ">=3",
@@ -4050,12 +4124,12 @@
             },
             "require-dev": {
                 "psr/log": "^1|^2",
-                "symfony/config": "^4.4|^5.0",
-                "symfony/dependency-injection": "^4.4|^5.0",
-                "symfony/event-dispatcher": "^4.4|^5.0",
-                "symfony/lock": "^4.4|^5.0",
-                "symfony/process": "^4.4|^5.0",
-                "symfony/var-dumper": "^4.4|^5.0"
+                "symfony/config": "^4.4|^5.0|^6.0",
+                "symfony/dependency-injection": "^4.4|^5.0|^6.0",
+                "symfony/event-dispatcher": "^4.4|^5.0|^6.0",
+                "symfony/lock": "^4.4|^5.0|^6.0",
+                "symfony/process": "^4.4|^5.0|^6.0",
+                "symfony/var-dumper": "^4.4|^5.0|^6.0"
             },
             "suggest": {
                 "psr/log": "For using the console logger",
@@ -4095,7 +4169,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v5.3.7"
+                "source": "https://github.com/symfony/console/tree/v5.4.10"
             },
             "funding": [
                 {
@@ -4111,20 +4185,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-08-25T20:02:16+00:00"
+            "time": "2022-06-26T13:00:04+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v2.4.0",
+            "version": "v2.5.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "5f38c8804a9e97d23e0c8d63341088cd8a22d627"
+                "reference": "e8b495ea28c1d97b5e0c121748d6f9b53d075c66"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/5f38c8804a9e97d23e0c8d63341088cd8a22d627",
-                "reference": "5f38c8804a9e97d23e0c8d63341088cd8a22d627",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/e8b495ea28c1d97b5e0c121748d6f9b53d075c66",
+                "reference": "e8b495ea28c1d97b5e0c121748d6f9b53d075c66",
                 "shasum": ""
             },
             "require": {
@@ -4133,7 +4207,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.4-dev"
+                    "dev-main": "2.5-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -4162,7 +4236,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v2.4.0"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v2.5.2"
             },
             "funding": [
                 {
@@ -4178,24 +4252,27 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-03-23T23:28:01+00:00"
+            "time": "2022-01-02T09:53:40+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.23.0",
+            "version": "v1.26.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "46cd95797e9df938fdd2b03693b5fca5e64b01ce"
+                "reference": "6fd1b9a79f6e3cf65f9e679b23af304cd9e010d4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/46cd95797e9df938fdd2b03693b5fca5e64b01ce",
-                "reference": "46cd95797e9df938fdd2b03693b5fca5e64b01ce",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/6fd1b9a79f6e3cf65f9e679b23af304cd9e010d4",
+                "reference": "6fd1b9a79f6e3cf65f9e679b23af304cd9e010d4",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.1"
+            },
+            "provide": {
+                "ext-ctype": "*"
             },
             "suggest": {
                 "ext-ctype": "For best performance"
@@ -4203,7 +4280,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.23-dev"
+                    "dev-main": "1.26-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -4241,7 +4318,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.23.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.26.0"
             },
             "funding": [
                 {
@@ -4257,20 +4334,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-02-19T12:13:01+00:00"
+            "time": "2022-05-24T11:49:31+00:00"
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.23.1",
+            "version": "v1.26.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
-                "reference": "16880ba9c5ebe3642d1995ab866db29270b36535"
+                "reference": "433d05519ce6990bf3530fba6957499d327395c2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/16880ba9c5ebe3642d1995ab866db29270b36535",
-                "reference": "16880ba9c5ebe3642d1995ab866db29270b36535",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/433d05519ce6990bf3530fba6957499d327395c2",
+                "reference": "433d05519ce6990bf3530fba6957499d327395c2",
                 "shasum": ""
             },
             "require": {
@@ -4282,7 +4359,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.23-dev"
+                    "dev-main": "1.26-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -4322,7 +4399,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.23.1"
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.26.0"
             },
             "funding": [
                 {
@@ -4338,20 +4415,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-05-27T12:26:48+00:00"
+            "time": "2022-05-24T11:49:31+00:00"
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.23.0",
+            "version": "v1.26.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
-                "reference": "8590a5f561694770bdcd3f9b5c69dde6945028e8"
+                "reference": "219aa369ceff116e673852dce47c3a41794c14bd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/8590a5f561694770bdcd3f9b5c69dde6945028e8",
-                "reference": "8590a5f561694770bdcd3f9b5c69dde6945028e8",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/219aa369ceff116e673852dce47c3a41794c14bd",
+                "reference": "219aa369ceff116e673852dce47c3a41794c14bd",
                 "shasum": ""
             },
             "require": {
@@ -4363,7 +4440,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.23-dev"
+                    "dev-main": "1.26-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -4406,7 +4483,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.23.0"
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.26.0"
             },
             "funding": [
                 {
@@ -4422,24 +4499,27 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-02-19T12:13:01+00:00"
+            "time": "2022-05-24T11:49:31+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.23.1",
+            "version": "v1.26.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "9174a3d80210dca8daa7f31fec659150bbeabfc6"
+                "reference": "9344f9cb97f3b19424af1a21a3b0e75b0a7d8d7e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/9174a3d80210dca8daa7f31fec659150bbeabfc6",
-                "reference": "9174a3d80210dca8daa7f31fec659150bbeabfc6",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/9344f9cb97f3b19424af1a21a3b0e75b0a7d8d7e",
+                "reference": "9344f9cb97f3b19424af1a21a3b0e75b0a7d8d7e",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.1"
+            },
+            "provide": {
+                "ext-mbstring": "*"
             },
             "suggest": {
                 "ext-mbstring": "For best performance"
@@ -4447,7 +4527,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.23-dev"
+                    "dev-main": "1.26-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -4486,7 +4566,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.23.1"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.26.0"
             },
             "funding": [
                 {
@@ -4502,20 +4582,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-05-27T12:26:48+00:00"
+            "time": "2022-05-24T11:49:31+00:00"
         },
         {
             "name": "symfony/polyfill-php73",
-            "version": "v1.23.0",
+            "version": "v1.26.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php73.git",
-                "reference": "fba8933c384d6476ab14fb7b8526e5287ca7e010"
+                "reference": "e440d35fa0286f77fb45b79a03fedbeda9307e85"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/fba8933c384d6476ab14fb7b8526e5287ca7e010",
-                "reference": "fba8933c384d6476ab14fb7b8526e5287ca7e010",
+                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/e440d35fa0286f77fb45b79a03fedbeda9307e85",
+                "reference": "e440d35fa0286f77fb45b79a03fedbeda9307e85",
                 "shasum": ""
             },
             "require": {
@@ -4524,7 +4604,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.23-dev"
+                    "dev-main": "1.26-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -4565,7 +4645,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php73/tree/v1.23.0"
+                "source": "https://github.com/symfony/polyfill-php73/tree/v1.26.0"
             },
             "funding": [
                 {
@@ -4581,20 +4661,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-02-19T12:13:01+00:00"
+            "time": "2022-05-24T11:49:31+00:00"
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.23.1",
+            "version": "v1.26.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "1100343ed1a92e3a38f9ae122fc0eb21602547be"
+                "reference": "cfa0ae98841b9e461207c13ab093d76b0fa7bace"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/1100343ed1a92e3a38f9ae122fc0eb21602547be",
-                "reference": "1100343ed1a92e3a38f9ae122fc0eb21602547be",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/cfa0ae98841b9e461207c13ab093d76b0fa7bace",
+                "reference": "cfa0ae98841b9e461207c13ab093d76b0fa7bace",
                 "shasum": ""
             },
             "require": {
@@ -4603,7 +4683,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.23-dev"
+                    "dev-main": "1.26-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -4648,7 +4728,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.23.1"
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.26.0"
             },
             "funding": [
                 {
@@ -4664,25 +4744,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-07-28T13:41:28+00:00"
+            "time": "2022-05-10T07:21:04+00:00"
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v2.4.0",
+            "version": "v2.5.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "f040a30e04b57fbcc9c6cbcf4dbaa96bd318b9bb"
+                "reference": "4b426aac47d6427cc1a1d0f7e2ac724627f5966c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/f040a30e04b57fbcc9c6cbcf4dbaa96bd318b9bb",
-                "reference": "f040a30e04b57fbcc9c6cbcf4dbaa96bd318b9bb",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/4b426aac47d6427cc1a1d0f7e2ac724627f5966c",
+                "reference": "4b426aac47d6427cc1a1d0f7e2ac724627f5966c",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2.5",
-                "psr/container": "^1.1"
+                "psr/container": "^1.1",
+                "symfony/deprecation-contracts": "^2.1|^3"
+            },
+            "conflict": {
+                "ext-psr": "<1.1|>=2"
             },
             "suggest": {
                 "symfony/service-implementation": ""
@@ -4690,7 +4774,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.4-dev"
+                    "dev-main": "2.5-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -4727,7 +4811,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v2.4.0"
+                "source": "https://github.com/symfony/service-contracts/tree/v2.5.2"
             },
             "funding": [
                 {
@@ -4743,20 +4827,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-04-01T10:43:52+00:00"
+            "time": "2022-05-30T19:17:29+00:00"
         },
         {
             "name": "symfony/string",
-            "version": "v5.3.7",
+            "version": "v5.4.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "8d224396e28d30f81969f083a58763b8b9ceb0a5"
+                "reference": "4432bc7df82a554b3e413a8570ce2fea90e94097"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/8d224396e28d30f81969f083a58763b8b9ceb0a5",
-                "reference": "8d224396e28d30f81969f083a58763b8b9ceb0a5",
+                "url": "https://api.github.com/repos/symfony/string/zipball/4432bc7df82a554b3e413a8570ce2fea90e94097",
+                "reference": "4432bc7df82a554b3e413a8570ce2fea90e94097",
                 "shasum": ""
             },
             "require": {
@@ -4767,11 +4851,14 @@
                 "symfony/polyfill-mbstring": "~1.0",
                 "symfony/polyfill-php80": "~1.15"
             },
+            "conflict": {
+                "symfony/translation-contracts": ">=3.0"
+            },
             "require-dev": {
-                "symfony/error-handler": "^4.4|^5.0",
-                "symfony/http-client": "^4.4|^5.0",
+                "symfony/error-handler": "^4.4|^5.0|^6.0",
+                "symfony/http-client": "^4.4|^5.0|^6.0",
                 "symfony/translation-contracts": "^1.1|^2",
-                "symfony/var-exporter": "^4.4|^5.0"
+                "symfony/var-exporter": "^4.4|^5.0|^6.0"
             },
             "type": "library",
             "autoload": {
@@ -4810,7 +4897,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v5.3.7"
+                "source": "https://github.com/symfony/string/tree/v5.4.10"
             },
             "funding": [
                 {
@@ -4826,7 +4913,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-08-26T08:00:08+00:00"
+            "time": "2022-06-26T15:57:47+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -4880,16 +4967,16 @@
         },
         {
             "name": "vimeo/psalm",
-            "version": "4.10.0",
+            "version": "4.24.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vimeo/psalm.git",
-                "reference": "916b098b008f6de4543892b1e0651c1c3b92cbfa"
+                "reference": "06dd975cb55d36af80f242561738f16c5f58264f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vimeo/psalm/zipball/916b098b008f6de4543892b1e0651c1c3b92cbfa",
-                "reference": "916b098b008f6de4543892b1e0651c1c3b92cbfa",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/06dd975cb55d36af80f242561738f16c5f58264f",
+                "reference": "06dd975cb55d36af80f242561738f16c5f58264f",
                 "shasum": ""
             },
             "require": {
@@ -4897,7 +4984,7 @@
                 "amphp/byte-stream": "^1.5",
                 "composer/package-versions-deprecated": "^1.8.0",
                 "composer/semver": "^1.4 || ^2.0 || ^3.0",
-                "composer/xdebug-handler": "^1.1 || ^2.0",
+                "composer/xdebug-handler": "^1.1 || ^2.0 || ^3.0",
                 "dnoegel/php-xdg-base-dir": "^0.1.1",
                 "ext-ctype": "*",
                 "ext-dom": "*",
@@ -4909,11 +4996,12 @@
                 "felixfbecker/advanced-json-rpc": "^3.0.3",
                 "felixfbecker/language-server-protocol": "^1.5",
                 "netresearch/jsonmapper": "^1.0 || ^2.0 || ^3.0 || ^4.0",
-                "nikic/php-parser": "^4.12",
+                "nikic/php-parser": "^4.13",
                 "openlss/lib-array2xml": "^1.0",
                 "php": "^7.1|^8",
                 "sebastian/diff": "^3.0 || ^4.0",
-                "symfony/console": "^3.4.17 || ^4.1.6 || ^5.0",
+                "symfony/console": "^3.4.17 || ^4.1.6 || ^5.0 || ^6.0",
+                "symfony/polyfill-php80": "^1.25",
                 "webmozart/path-util": "^2.3"
             },
             "provide": {
@@ -4931,11 +5019,12 @@
                 "psalm/plugin-phpunit": "^0.16",
                 "slevomat/coding-standard": "^7.0",
                 "squizlabs/php_codesniffer": "^3.5",
-                "symfony/process": "^4.3 || ^5.0",
+                "symfony/process": "^4.3 || ^5.0 || ^6.0",
                 "weirdan/prophecy-shim": "^1.0 || ^2.0"
             },
             "suggest": {
-                "ext-igbinary": "^2.0.5"
+                "ext-curl": "In order to send data to shepherd",
+                "ext-igbinary": "^2.0.5 is required, used to serialize caching data"
             },
             "bin": [
                 "psalm",
@@ -4979,9 +5068,9 @@
             ],
             "support": {
                 "issues": "https://github.com/vimeo/psalm/issues",
-                "source": "https://github.com/vimeo/psalm/tree/4.10.0"
+                "source": "https://github.com/vimeo/psalm/tree/4.24.0"
             },
-            "time": "2021-09-04T21:00:09+00:00"
+            "time": "2022-06-26T11:47:54+00:00"
         },
         {
             "name": "webimpress/coding-standard",
@@ -5040,21 +5129,21 @@
         },
         {
             "name": "webmozart/assert",
-            "version": "1.10.0",
+            "version": "1.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozarts/assert.git",
-                "reference": "6964c76c7804814a842473e0c8fd15bab0f18e25"
+                "reference": "11cb2199493b2f8a3b53e7f19068fc6aac760991"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozarts/assert/zipball/6964c76c7804814a842473e0c8fd15bab0f18e25",
-                "reference": "6964c76c7804814a842473e0c8fd15bab0f18e25",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/11cb2199493b2f8a3b53e7f19068fc6aac760991",
+                "reference": "11cb2199493b2f8a3b53e7f19068fc6aac760991",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2 || ^8.0",
-                "symfony/polyfill-ctype": "^1.8"
+                "ext-ctype": "*",
+                "php": "^7.2 || ^8.0"
             },
             "conflict": {
                 "phpstan/phpstan": "<0.12.20",
@@ -5092,9 +5181,9 @@
             ],
             "support": {
                 "issues": "https://github.com/webmozarts/assert/issues",
-                "source": "https://github.com/webmozarts/assert/tree/1.10.0"
+                "source": "https://github.com/webmozarts/assert/tree/1.11.0"
             },
-            "time": "2021-03-09T10:59:23+00:00"
+            "time": "2022-06-03T18:03:27+00:00"
         },
         {
             "name": "webmozart/path-util",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "38aff1c66a85bedcc73b3b0cd356f7e3",
+    "content-hash": "8cdf8ceca2e38eb40afa7167f9712e0f",
     "packages": [
         {
             "name": "laminas/laminas-escaper",
@@ -551,27 +551,27 @@
         },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
-            "version": "v0.7.1",
+            "version": "v0.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer.git",
-                "reference": "fe390591e0241955f22eb9ba327d137e501c771c"
+                "reference": "1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/fe390591e0241955f22eb9ba327d137e501c771c",
-                "reference": "fe390591e0241955f22eb9ba327d137e501c771c",
+                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db",
+                "reference": "1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db",
                 "shasum": ""
             },
             "require": {
                 "composer-plugin-api": "^1.0 || ^2.0",
                 "php": ">=5.3",
-                "squizlabs/php_codesniffer": "^2.0 || ^3.0 || ^4.0"
+                "squizlabs/php_codesniffer": "^2.0 || ^3.1.0 || ^4.0"
             },
             "require-dev": {
                 "composer/composer": "*",
-                "phpcompatibility/php-compatibility": "^9.0",
-                "sensiolabs/security-checker": "^4.1.0"
+                "php-parallel-lint/php-parallel-lint": "^1.3.1",
+                "phpcompatibility/php-compatibility": "^9.0"
             },
             "type": "composer-plugin",
             "extra": {
@@ -592,6 +592,10 @@
                     "email": "franck.nijhof@dealerdirect.com",
                     "homepage": "http://www.frenck.nl",
                     "role": "Developer / IT Manager"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer/graphs/contributors"
                 }
             ],
             "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
@@ -603,6 +607,7 @@
                 "codesniffer",
                 "composer",
                 "installer",
+                "phpcbf",
                 "phpcs",
                 "plugin",
                 "qa",
@@ -617,7 +622,7 @@
                 "issues": "https://github.com/dealerdirect/phpcodesniffer-composer-installer/issues",
                 "source": "https://github.com/dealerdirect/phpcodesniffer-composer-installer"
             },
-            "time": "2020-12-07T18:04:37+00:00"
+            "time": "2022-02-04T12:51:07+00:00"
         },
         {
             "name": "dnoegel/php-xdg-base-dir",
@@ -992,24 +997,24 @@
         },
         {
             "name": "laminas/laminas-coding-standard",
-            "version": "2.2.1",
+            "version": "2.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-coding-standard.git",
-                "reference": "c953ecb1d37034f4aa326046e2c24a10fe0a2845"
+                "reference": "bcf6e07fe4690240be7beb6d884d0b0fafa6a251"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-coding-standard/zipball/c953ecb1d37034f4aa326046e2c24a10fe0a2845",
-                "reference": "c953ecb1d37034f4aa326046e2c24a10fe0a2845",
+                "url": "https://api.github.com/repos/laminas/laminas-coding-standard/zipball/bcf6e07fe4690240be7beb6d884d0b0fafa6a251",
+                "reference": "bcf6e07fe4690240be7beb6d884d0b0fafa6a251",
                 "shasum": ""
             },
             "require": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7",
-                "php": "^7.3 || ~8.0.0",
-                "slevomat/coding-standard": "^6.4.1",
-                "squizlabs/php_codesniffer": "^3.5.8",
-                "webimpress/coding-standard": "^1.1.6"
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
+                "php": "^7.3 || ^8.0",
+                "slevomat/coding-standard": "^7.0",
+                "squizlabs/php_codesniffer": "^3.6",
+                "webimpress/coding-standard": "^1.2"
             },
             "type": "phpcodesniffer-standard",
             "autoload": {
@@ -1041,7 +1046,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2021-05-17T17:39:41+00:00"
+            "time": "2021-05-29T15:53:59+00:00"
         },
         {
             "name": "laminas/laminas-db",
@@ -2153,39 +2158,31 @@
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "0.4.9",
+            "version": "1.6.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "98a088b17966bdf6ee25c8a4b634df313d8aa531"
+                "reference": "135607f9ccc297d6923d49c2bcf309f509413215"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/98a088b17966bdf6ee25c8a4b634df313d8aa531",
-                "reference": "98a088b17966bdf6ee25c8a4b634df313d8aa531",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/135607f9ccc297d6923d49c2bcf309f509413215",
+                "reference": "135607f9ccc297d6923d49c2bcf309f509413215",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1 || ^8.0"
+                "php": "^7.2 || ^8.0"
             },
             "require-dev": {
-                "consistence/coding-standard": "^3.5",
-                "ergebnis/composer-normalize": "^2.0.2",
-                "jakub-onderka/php-parallel-lint": "^0.9.2",
-                "phing/phing": "^2.16.0",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
                 "phpstan/extension-installer": "^1.0",
-                "phpstan/phpstan": "^0.12.26",
-                "phpstan/phpstan-strict-rules": "^0.12",
-                "phpunit/phpunit": "^6.3",
-                "slevomat/coding-standard": "^4.7.2",
-                "symfony/process": "^4.0"
+                "phpstan/phpstan": "^1.5",
+                "phpstan/phpstan-phpunit": "^1.1",
+                "phpstan/phpstan-strict-rules": "^1.0",
+                "phpunit/phpunit": "^9.5",
+                "symfony/process": "^5.2"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "0.4-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "PHPStan\\PhpDocParser\\": [
@@ -2200,9 +2197,9 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/master"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.6.4"
             },
-            "time": "2020-08-03T20:32:43+00:00"
+            "time": "2022-06-26T13:09:08+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -3902,37 +3899,37 @@
         },
         {
             "name": "slevomat/coding-standard",
-            "version": "6.4.1",
+            "version": "7.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/slevomat/coding-standard.git",
-                "reference": "696dcca217d0c9da2c40d02731526c1e25b65346"
+                "reference": "aff06ae7a84e4534bf6f821dc982a93a5d477c90"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/696dcca217d0c9da2c40d02731526c1e25b65346",
-                "reference": "696dcca217d0c9da2c40d02731526c1e25b65346",
+                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/aff06ae7a84e4534bf6f821dc982a93a5d477c90",
+                "reference": "aff06ae7a84e4534bf6f821dc982a93a5d477c90",
                 "shasum": ""
             },
             "require": {
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7",
-                "php": "^7.1 || ^8.0",
-                "phpstan/phpdoc-parser": "0.4.5 - 0.4.9",
-                "squizlabs/php_codesniffer": "^3.5.6"
+                "php": "^7.2 || ^8.0",
+                "phpstan/phpdoc-parser": "^1.5.1",
+                "squizlabs/php_codesniffer": "^3.6.2"
             },
             "require-dev": {
-                "phing/phing": "2.16.3",
-                "php-parallel-lint/php-parallel-lint": "1.2.0",
-                "phpstan/phpstan": "0.12.48",
-                "phpstan/phpstan-deprecation-rules": "0.12.5",
-                "phpstan/phpstan-phpunit": "0.12.16",
-                "phpstan/phpstan-strict-rules": "0.12.5",
-                "phpunit/phpunit": "7.5.20|8.5.5|9.4.0"
+                "phing/phing": "2.17.3",
+                "php-parallel-lint/php-parallel-lint": "1.3.2",
+                "phpstan/phpstan": "1.4.10|1.7.1",
+                "phpstan/phpstan-deprecation-rules": "1.0.0",
+                "phpstan/phpstan-phpunit": "1.0.0|1.1.1",
+                "phpstan/phpstan-strict-rules": "1.2.3",
+                "phpunit/phpunit": "7.5.20|8.5.21|9.5.20"
             },
             "type": "phpcodesniffer-standard",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "6.x-dev"
+                    "dev-master": "7.x-dev"
                 }
             },
             "autoload": {
@@ -3947,7 +3944,7 @@
             "description": "Slevomat Coding Standard for PHP_CodeSniffer complements Consistence Coding Standard by providing sniffs with additional checks.",
             "support": {
                 "issues": "https://github.com/slevomat/coding-standard/issues",
-                "source": "https://github.com/slevomat/coding-standard/tree/6.4.1"
+                "source": "https://github.com/slevomat/coding-standard/tree/7.2.1"
             },
             "funding": [
                 {
@@ -3959,20 +3956,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-10-05T12:39:37+00:00"
+            "time": "2022-05-25T10:58:12+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.6.0",
+            "version": "3.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "ffced0d2c8fa8e6cdc4d695a743271fab6c38625"
+                "reference": "1359e176e9307e906dc3d890bcc9603ff6d90619"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/ffced0d2c8fa8e6cdc4d695a743271fab6c38625",
-                "reference": "ffced0d2c8fa8e6cdc4d695a743271fab6c38625",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/1359e176e9307e906dc3d890bcc9603ff6d90619",
+                "reference": "1359e176e9307e906dc3d890bcc9603ff6d90619",
                 "shasum": ""
             },
             "require": {
@@ -4015,7 +4012,7 @@
                 "source": "https://github.com/squizlabs/PHP_CodeSniffer",
                 "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
             },
-            "time": "2021-04-09T00:54:41+00:00"
+            "time": "2022-06-18T07:21:10+00:00"
         },
         {
             "name": "symfony/console",
@@ -4988,24 +4985,24 @@
         },
         {
             "name": "webimpress/coding-standard",
-            "version": "1.2.2",
+            "version": "1.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webimpress/coding-standard.git",
-                "reference": "8f4a220de33f471a8101836f7ec72b852c3f9f03"
+                "reference": "cd0c4b0b97440c337c1f7da17b524674ca2f9ca9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webimpress/coding-standard/zipball/8f4a220de33f471a8101836f7ec72b852c3f9f03",
-                "reference": "8f4a220de33f471a8101836f7ec72b852c3f9f03",
+                "url": "https://api.github.com/repos/webimpress/coding-standard/zipball/cd0c4b0b97440c337c1f7da17b524674ca2f9ca9",
+                "reference": "cd0c4b0b97440c337c1f7da17b524674ca2f9ca9",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.3 || ^8.0",
-                "squizlabs/php_codesniffer": "^3.6"
+                "squizlabs/php_codesniffer": "^3.6.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.5.4"
+                "phpunit/phpunit": "^9.5.13"
             },
             "type": "phpcodesniffer-standard",
             "extra": {
@@ -5031,7 +5028,7 @@
             ],
             "support": {
                 "issues": "https://github.com/webimpress/coding-standard/issues",
-                "source": "https://github.com/webimpress/coding-standard/tree/1.2.2"
+                "source": "https://github.com/webimpress/coding-standard/tree/1.2.4"
             },
             "funding": [
                 {
@@ -5039,7 +5036,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-04-12T12:51:27+00:00"
+            "time": "2022-02-15T19:52:12+00:00"
         },
         {
             "name": "webmozart/assert",

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1850,9 +1850,6 @@
     <ImplementedReturnTypeMismatch occurrences="1">
       <code>Feed\FeedInterface</code>
     </ImplementedReturnTypeMismatch>
-    <InvalidNullableReturnType occurrences="1">
-      <code>ExtensionManagerInterface</code>
-    </InvalidNullableReturnType>
     <InvalidReturnStatement occurrences="1">
       <code>$reader</code>
     </InvalidReturnStatement>
@@ -1876,9 +1873,6 @@
       <code>$value</code>
       <code>$version</code>
     </MixedAssignment>
-    <NullableReturnStatement occurrences="1">
-      <code>static::$extensionManager</code>
-    </NullableReturnStatement>
     <RedundantCastGivenDocblockType occurrences="3">
       <code>(int) $response-&gt;getStatusCode()</code>
       <code>(int) $response-&gt;getStatusCode()</code>
@@ -2639,17 +2633,6 @@
     <MixedReturnStatement occurrences="1">
       <code>$this-&gt;pluginManager-&gt;get($extension)</code>
     </MixedReturnStatement>
-  </file>
-  <file src="src/Writer/ExtensionPluginManager.php">
-    <MixedArgument occurrences="1">
-      <code>$plugin</code>
-    </MixedArgument>
-    <RedundantCondition occurrences="1">
-      <code>is_object($instance)</code>
-    </RedundantCondition>
-    <TypeDoesNotContainType occurrences="1">
-      <code>gettype($instance)</code>
-    </TypeDoesNotContainType>
   </file>
   <file src="src/Writer/Feed.php">
     <InvalidStringClass occurrences="1">

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="4.10.0@916b098b008f6de4543892b1e0651c1c3b92cbfa">
+<files psalm-version="4.24.0@06dd975cb55d36af80f242561738f16c5f58264f">
   <file src="src/PubSubHubbub/AbstractCallback.php">
-    <DocblockTypeContradiction occurrences="4">
-      <code>! $httpResponse instanceof HttpResponse &amp;&amp; ! $httpResponse instanceof PhpResponse</code>
+    <DocblockTypeContradiction occurrences="3">
       <code>$this-&gt;httpResponse === null</code>
       <code>$this-&gt;storage === null</code>
       <code>is_array($options)</code>
@@ -215,9 +214,6 @@
     <InvalidPropertyAssignmentValue occurrences="1">
       <code>$bool</code>
     </InvalidPropertyAssignmentValue>
-    <InvalidScalarArgument occurrences="1">
-      <code>rand()</code>
-    </InvalidScalarArgument>
     <MissingReturnType occurrences="1">
       <code>setTestStaticToken</code>
     </MissingReturnType>
@@ -293,12 +289,7 @@
     <DocblockTypeContradiction occurrences="1">
       <code>$this-&gt;feedUpdate === null</code>
     </DocblockTypeContradiction>
-    <InvalidScalarArgument occurrences="6">
-      <code>$contentType</code>
-      <code>$contentType</code>
-      <code>$contentType</code>
-      <code>$contentType</code>
-      <code>$contentType</code>
+    <InvalidScalarArgument occurrences="1">
       <code>$this-&gt;getSubscriberCount()</code>
     </InvalidScalarArgument>
     <MixedArgument occurrences="9">
@@ -330,6 +321,13 @@
       <code>$this-&gt;_getRawBody()</code>
       <code>$verifyTokenKey</code>
     </PossiblyFalseArgument>
+    <PossiblyInvalidArgument occurrences="5">
+      <code>$contentType</code>
+      <code>$contentType</code>
+      <code>$contentType</code>
+      <code>$contentType</code>
+      <code>$contentType</code>
+    </PossiblyInvalidArgument>
     <PossiblyNullArgument occurrences="1">
       <code>$httpGetData['hub_verify_token']</code>
     </PossiblyNullArgument>
@@ -347,7 +345,8 @@
     </PropertyNotSetInConstructor>
   </file>
   <file src="src/Reader/AbstractEntry.php">
-    <DocblockTypeContradiction occurrences="1">
+    <DocblockTypeContradiction occurrences="2">
+      <code>! $this-&gt;xpath</code>
       <code>$this-&gt;xpath</code>
     </DocblockTypeContradiction>
     <InvalidArgument occurrences="1">
@@ -447,12 +446,10 @@
     </MixedAssignment>
   </file>
   <file src="src/Reader/Entry/AbstractEntry.php">
-    <DocblockTypeContradiction occurrences="1">
+    <DocblockTypeContradiction occurrences="2">
+      <code>! $this-&gt;xpath</code>
       <code>$this-&gt;xpath</code>
     </DocblockTypeContradiction>
-    <InvalidScalarArgument occurrences="1">
-      <code>$deep</code>
-    </InvalidScalarArgument>
     <MixedArgument occurrences="3">
       <code>$all['core']</code>
       <code>$extension</code>
@@ -486,8 +483,7 @@
     </PropertyNotSetInConstructor>
   </file>
   <file src="src/Reader/Entry/Atom.php">
-    <ImplementedReturnTypeMismatch occurrences="3">
-      <code>AuthorCollection</code>
+    <ImplementedReturnTypeMismatch occurrences="2">
       <code>null|string</code>
       <code>void</code>
     </ImplementedReturnTypeMismatch>
@@ -569,16 +565,14 @@
     <MixedArrayAccess occurrences="1">
       <code>$author['name']</code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="10">
+    <MixedAssignment occurrences="8">
       <code>$author</code>
       <code>$commentlink</code>
       <code>$dateModified</code>
       <code>$description</code>
-      <code>$description</code>
       <code>$extension</code>
       <code>$extension</code>
       <code>$id</code>
-      <code>$title</code>
       <code>$title</code>
     </MixedAssignment>
     <MixedInferredReturnType occurrences="13">
@@ -621,15 +615,15 @@
     <MixedReturnTypeCoercion occurrences="2">
       <code>null|array&lt;string, string&gt;</code>
     </MixedReturnTypeCoercion>
-    <NullableReturnStatement occurrences="6">
+    <NullableReturnStatement occurrences="5">
       <code>$this-&gt;data['commentfeedlink']</code>
       <code>$this-&gt;data['commentlink']</code>
       <code>$this-&gt;data['datemodified']</code>
-      <code>$this-&gt;data['description']</code>
       <code>$this-&gt;data['id']</code>
       <code>$this-&gt;getLink(0)</code>
     </NullableReturnStatement>
-    <PossiblyNullArgument occurrences="1">
+    <PossiblyNullArgument occurrences="2">
+      <code>$author-&gt;nodeValue</code>
       <code>$standard</code>
     </PossiblyNullArgument>
     <PropertyNotSetInConstructor occurrences="1">
@@ -638,13 +632,10 @@
     <UndefinedMethod occurrences="1">
       <code>getAttribute</code>
     </UndefinedMethod>
-    <UnusedVariable occurrences="2">
-      <code>$description</code>
-      <code>$title</code>
-    </UnusedVariable>
   </file>
   <file src="src/Reader/Extension/AbstractEntry.php">
-    <DocblockTypeContradiction occurrences="2">
+    <DocblockTypeContradiction occurrences="3">
+      <code>! $this-&gt;xpath</code>
       <code>$this-&gt;xpath</code>
       <code>null === $type</code>
     </DocblockTypeContradiction>
@@ -750,9 +741,6 @@
       <code>$author</code>
       <code>$element</code>
     </ArgumentTypeCoercion>
-    <InvalidScalarArgument occurrences="1">
-      <code>$deep</code>
-    </InvalidScalarArgument>
     <MixedArgument occurrences="6">
       <code>$content ?? ''</code>
       <code>$dateCreated</code>
@@ -847,15 +835,13 @@
       <code>$dateModified</code>
       <code>$link</code>
     </MixedArgument>
-    <MixedAssignment occurrences="16">
+    <MixedAssignment occurrences="14">
       <code>$baseUrl</code>
       <code>$copyright</code>
-      <code>$copyright</code>
       <code>$dateCreated</code>
       <code>$dateCreated</code>
       <code>$dateModified</code>
       <code>$dateModified</code>
-      <code>$description</code>
       <code>$description</code>
       <code>$generator</code>
       <code>$id</code>
@@ -882,16 +868,14 @@
       <code>null|string</code>
       <code>null|string</code>
     </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="22">
+    <MixedReturnStatement occurrences="20">
       <code>$this-&gt;data['authors']</code>
       <code>$this-&gt;data['baseUrl']</code>
       <code>$this-&gt;data['baseUrl']</code>
       <code>$this-&gt;data['categories']</code>
       <code>$this-&gt;data['copyright']</code>
-      <code>$this-&gt;data['copyright']</code>
       <code>$this-&gt;data['datecreated']</code>
       <code>$this-&gt;data['datemodified']</code>
-      <code>$this-&gt;data['description']</code>
       <code>$this-&gt;data['description']</code>
       <code>$this-&gt;data['feedlink']</code>
       <code>$this-&gt;data['generator']</code>
@@ -906,6 +890,9 @@
       <code>$this-&gt;data['title']</code>
       <code>$this-&gt;data['title']</code>
     </MixedReturnStatement>
+    <PossiblyNullArgument occurrences="1">
+      <code>$uri-&gt;nodeValue</code>
+    </PossiblyNullArgument>
     <PossiblyNullOperand occurrences="1">
       <code>$this-&gt;getBaseUrl()</code>
     </PossiblyNullOperand>
@@ -914,10 +901,6 @@
       <code>getAttribute</code>
       <code>getAttribute</code>
     </UndefinedMethod>
-    <UnusedVariable occurrences="2">
-      <code>$copyright</code>
-      <code>$description</code>
-    </UnusedVariable>
   </file>
   <file src="src/Reader/Extension/Content/Entry.php">
     <MixedInferredReturnType occurrences="1">
@@ -1124,10 +1107,6 @@
       <code>getAttribute</code>
       <code>getAttribute</code>
     </UndefinedMethod>
-    <UnusedVariable occurrences="2">
-      <code>$children</code>
-      <code>$children</code>
-    </UnusedVariable>
   </file>
   <file src="src/Reader/Extension/Podcast/Entry.php">
     <MixedAssignment occurrences="13">
@@ -1268,10 +1247,6 @@
       <code>getAttribute</code>
       <code>getAttribute</code>
     </UndefinedMethod>
-    <UnusedVariable occurrences="2">
-      <code>$children</code>
-      <code>$children</code>
-    </UnusedVariable>
   </file>
   <file src="src/Reader/Extension/PodcastIndex/Entry.php">
     <MismatchingDocblockReturnType occurrences="2">
@@ -1602,9 +1577,9 @@
     <ImplementedReturnTypeMismatch occurrences="1">
       <code>null|array&lt;string, string&gt;</code>
     </ImplementedReturnTypeMismatch>
-    <InvalidScalarArgument occurrences="1">
+    <InvalidArgument occurrences="1">
       <code>$lastBuildDateParsed</code>
-    </InvalidScalarArgument>
+    </InvalidArgument>
     <MixedArgument occurrences="6">
       <code>$authors</code>
       <code>$categoryCollection</code>
@@ -1737,7 +1712,8 @@
       <code>$this-&gt;data['datemodified']</code>
       <code>$this-&gt;data['lastBuildDate']</code>
     </NullableReturnStatement>
-    <PossiblyNullArgument occurrences="1">
+    <PossiblyNullArgument occurrences="2">
+      <code>$author-&gt;nodeValue</code>
       <code>$standard</code>
     </PossiblyNullArgument>
     <PossiblyNullReference occurrences="20">
@@ -1862,10 +1838,13 @@
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="src/Reader/Reader.php">
-    <DocblockTypeContradiction occurrences="4">
-      <code>! is_string($string)</code>
-      <code>$httpClient instanceof Http\ClientInterface</code>
-      <code>$response instanceof Http\ResponseInterface</code>
+    <ArgumentTypeCoercion occurrences="2">
+      <code>trim($responseHtml)</code>
+      <code>trim($string)</code>
+    </ArgumentTypeCoercion>
+    <DocblockTypeContradiction occurrences="3">
+      <code>! static::$httpClient</code>
+      <code>gettype($response)</code>
       <code>static::$httpClient</code>
     </DocblockTypeContradiction>
     <ImplementedReturnTypeMismatch occurrences="1">
@@ -1880,9 +1859,6 @@
     <InvalidReturnType occurrences="1">
       <code>Feed\FeedInterface</code>
     </InvalidReturnType>
-    <InvalidScalarArgument occurrences="1">
-      <code>1</code>
-    </InvalidScalarArgument>
     <MixedArgument occurrences="4">
       <code>$data</code>
       <code>$responseXml</code>
@@ -1908,13 +1884,19 @@
       <code>(int) $response-&gt;getStatusCode()</code>
       <code>(int) $response-&gt;getStatusCode()</code>
     </RedundantCastGivenDocblockType>
-    <RedundantConditionGivenDocblockType occurrences="2">
+    <RedundantConditionGivenDocblockType occurrences="5">
+      <code>$cache</code>
+      <code>$cache</code>
+      <code>is_object($response)</code>
       <code>is_string($feed)</code>
       <code>static::$httpConditionalGet &amp;&amp; $cache</code>
     </RedundantConditionGivenDocblockType>
     <TooManyArguments occurrences="1">
       <code>get</code>
     </TooManyArguments>
+    <TypeDoesNotContainType occurrences="1">
+      <code>! is_string($string)</code>
+    </TypeDoesNotContainType>
     <UndefinedInterfaceMethod occurrences="2">
       <code>setOriginalSourceUri</code>
       <code>setOriginalSourceUri</code>
@@ -2050,9 +2032,8 @@
     </PropertyNotSetInConstructor>
   </file>
   <file src="src/Writer/Deleted.php">
-    <DocblockTypeContradiction occurrences="2">
+    <DocblockTypeContradiction occurrences="1">
       <code>! is_string($reference)</code>
-      <code>$date instanceof DateTimeInterface</code>
     </DocblockTypeContradiction>
     <MissingConstructor occurrences="1">
       <code>$type</code>
@@ -2073,7 +2054,7 @@
     </MixedReturnStatement>
   </file>
   <file src="src/Writer/Entry.php">
-    <DocblockTypeContradiction occurrences="12">
+    <DocblockTypeContradiction occurrences="10">
       <code>! is_string($content)</code>
       <code>! is_string($copyright)</code>
       <code>! is_string($description)</code>
@@ -2082,8 +2063,6 @@
       <code>! is_string($link)</code>
       <code>! is_string($link)</code>
       <code>! is_string($title)</code>
-      <code>$date instanceof DateTimeInterface</code>
-      <code>$date instanceof DateTimeInterface</code>
       <code>empty($link) || ! is_string($link)</code>
       <code>empty($link) || ! is_string($link)</code>
     </DocblockTypeContradiction>
@@ -2217,10 +2196,9 @@
     </MissingConstructor>
   </file>
   <file src="src/Writer/Extension/Atom/Renderer/Feed.php">
-    <MixedArgument occurrences="4">
+    <MixedArgument occurrences="3">
       <code>$href</code>
       <code>$hubUrl</code>
-      <code>$type</code>
       <code>$type</code>
     </MixedArgument>
     <MixedAssignment occurrences="5">
@@ -2234,10 +2212,10 @@
       <code>getFeedLinks</code>
       <code>getHubs</code>
     </MixedMethodCall>
-    <ParadoxicalCondition occurrences="2">
+    <TypeDoesNotContainType occurrences="2">
       <code>empty($flinks)</code>
       <code>empty($hubs)</code>
-    </ParadoxicalCondition>
+    </TypeDoesNotContainType>
   </file>
   <file src="src/Writer/Extension/Content/Renderer/Entry.php">
     <MixedArgument occurrences="1">
@@ -2255,9 +2233,6 @@
       <code>$data</code>
       <code>$data['name']</code>
     </MixedArgument>
-    <MixedArrayAccess occurrences="1">
-      <code>$data['name']</code>
-    </MixedArrayAccess>
     <MixedAssignment occurrences="2">
       <code>$authors</code>
       <code>$data</code>
@@ -2265,18 +2240,15 @@
     <MixedMethodCall occurrences="1">
       <code>getAuthors</code>
     </MixedMethodCall>
-    <ParadoxicalCondition occurrences="1">
+    <TypeDoesNotContainType occurrences="1">
       <code>empty($authors)</code>
-    </ParadoxicalCondition>
+    </TypeDoesNotContainType>
   </file>
   <file src="src/Writer/Extension/DublinCore/Renderer/Feed.php">
     <MixedArgument occurrences="2">
       <code>$data</code>
       <code>$data['name']</code>
     </MixedArgument>
-    <MixedArrayAccess occurrences="1">
-      <code>$data['name']</code>
-    </MixedArrayAccess>
     <MixedAssignment occurrences="2">
       <code>$authors</code>
       <code>$data</code>
@@ -2284,12 +2256,13 @@
     <MixedMethodCall occurrences="1">
       <code>getAuthors</code>
     </MixedMethodCall>
-    <ParadoxicalCondition occurrences="1">
+    <TypeDoesNotContainType occurrences="1">
       <code>empty($authors)</code>
-    </ParadoxicalCondition>
+    </TypeDoesNotContainType>
   </file>
   <file src="src/Writer/Extension/GooglePlayPodcast/Entry.php">
-    <RedundantConditionGivenDocblockType occurrences="3">
+    <RedundantConditionGivenDocblockType occurrences="4">
+      <code>! in_array($value, ['yes', 'no', 'clean'], true)</code>
       <code>in_array($value, ['yes', 'no', 'clean'], true)</code>
       <code>in_array($value, ['yes', 'no', 'clean'], true)</code>
       <code>in_array($value, ['yes', 'no', 'clean'], true)</code>
@@ -2318,7 +2291,8 @@
       <code>$value</code>
       <code>$value</code>
     </MixedAssignment>
-    <RedundantConditionGivenDocblockType occurrences="3">
+    <RedundantConditionGivenDocblockType occurrences="4">
+      <code>! in_array($value, ['yes', 'no', 'clean'], true)</code>
       <code>in_array($value, ['yes', 'no', 'clean'], true)</code>
       <code>in_array($value, ['yes', 'no', 'clean'], true)</code>
       <code>in_array($value, ['yes', 'no', 'clean'], true)</code>
@@ -2372,10 +2346,10 @@
       <code>getPlayPodcastExplicit</code>
       <code>getPlayPodcastImage</code>
     </MixedMethodCall>
-    <ParadoxicalCondition occurrences="2">
+    <TypeDoesNotContainType occurrences="2">
       <code>empty($authors)</code>
       <code>empty($cats)</code>
-    </ParadoxicalCondition>
+    </TypeDoesNotContainType>
   </file>
   <file src="src/Writer/Extension/ITunes/Entry.php">
     <DocblockTypeContradiction occurrences="10">
@@ -2411,6 +2385,9 @@
       <code>gettype($number)</code>
       <code>var_export($type, true)</code>
     </RedundantConditionGivenDocblockType>
+    <TypeDoesNotContainType occurrences="1">
+      <code>'no'</code>
+    </TypeDoesNotContainType>
   </file>
   <file src="src/Writer/Extension/ITunes/Feed.php">
     <DocblockTypeContradiction occurrences="4">
@@ -2450,6 +2427,9 @@
     <RedundantConditionGivenDocblockType occurrences="1">
       <code>var_export($type, true)</code>
     </RedundantConditionGivenDocblockType>
+    <TypeDoesNotContainType occurrences="1">
+      <code>'no'</code>
+    </TypeDoesNotContainType>
   </file>
   <file src="src/Writer/Extension/ITunes/Renderer/Entry.php">
     <MixedArgument occurrences="12">
@@ -2497,10 +2477,10 @@
       <code>getItunesSummary</code>
       <code>getItunesTitle</code>
     </MixedMethodCall>
-    <ParadoxicalCondition occurrences="2">
+    <TypeDoesNotContainType occurrences="2">
       <code>empty($authors)</code>
       <code>empty($keywords)</code>
-    </ParadoxicalCondition>
+    </TypeDoesNotContainType>
   </file>
   <file src="src/Writer/Extension/ITunes/Renderer/Feed.php">
     <MixedArgument occurrences="15">
@@ -2559,12 +2539,12 @@
       <code>getItunesSummary</code>
       <code>getItunesType</code>
     </MixedMethodCall>
-    <ParadoxicalCondition occurrences="4">
+    <TypeDoesNotContainType occurrences="4">
       <code>empty($authors)</code>
       <code>empty($cats)</code>
       <code>empty($keywords)</code>
       <code>empty($owners)</code>
-    </ParadoxicalCondition>
+    </TypeDoesNotContainType>
   </file>
   <file src="src/Writer/Extension/PodcastIndex/Entry.php">
     <MixedArgument occurrences="1">
@@ -2594,9 +2574,8 @@
     </MixedMethodCall>
   </file>
   <file src="src/Writer/Extension/Slash/Renderer/Entry.php">
-    <MixedAssignment occurrences="2">
+    <MixedAssignment occurrences="1">
       <code>$count</code>
-      <code>$tcount-&gt;nodeValue</code>
     </MixedAssignment>
     <MixedMethodCall occurrences="1">
       <code>getCommentCount</code>
@@ -2613,14 +2592,12 @@
       <code>$link['type']</code>
       <code>$link['uri']</code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="7">
-      <code>$count</code>
+    <MixedAssignment occurrences="5">
       <code>$count</code>
       <code>$count</code>
       <code>$link</code>
       <code>$link</code>
       <code>$links</code>
-      <code>$tcount-&gt;nodeValue</code>
     </MixedAssignment>
     <MixedMethodCall occurrences="5">
       <code>getCommentCount</code>
@@ -2632,9 +2609,9 @@
     <MixedOperand occurrences="1">
       <code>$link['type']</code>
     </MixedOperand>
-    <ParadoxicalCondition occurrences="1">
+    <TypeDoesNotContainType occurrences="1">
       <code>empty($links)</code>
-    </ParadoxicalCondition>
+    </TypeDoesNotContainType>
   </file>
   <file src="src/Writer/Extension/WellFormedWeb/Renderer/Entry.php">
     <MixedArgument occurrences="1">
@@ -2651,9 +2628,9 @@
     <MixedMethodCall occurrences="1">
       <code>getCommentFeedLinks</code>
     </MixedMethodCall>
-    <ParadoxicalCondition occurrences="1">
+    <TypeDoesNotContainType occurrences="1">
       <code>empty($links)</code>
-    </ParadoxicalCondition>
+    </TypeDoesNotContainType>
   </file>
   <file src="src/Writer/ExtensionManager.php">
     <MixedInferredReturnType occurrences="1">
@@ -2664,15 +2641,15 @@
     </MixedReturnStatement>
   </file>
   <file src="src/Writer/ExtensionPluginManager.php">
-    <DocblockTypeContradiction occurrences="1">
-      <code>gettype($instance)</code>
-    </DocblockTypeContradiction>
     <MixedArgument occurrences="1">
       <code>$plugin</code>
     </MixedArgument>
-    <RedundantConditionGivenDocblockType occurrences="1">
+    <RedundantCondition occurrences="1">
       <code>is_object($instance)</code>
-    </RedundantConditionGivenDocblockType>
+    </RedundantCondition>
+    <TypeDoesNotContainType occurrences="1">
+      <code>gettype($instance)</code>
+    </TypeDoesNotContainType>
   </file>
   <file src="src/Writer/Feed.php">
     <InvalidStringClass occurrences="1">
@@ -2716,22 +2693,27 @@
   </file>
   <file src="src/Writer/FeedFactory.php">
     <DocblockTypeContradiction occurrences="2">
-      <code>! is_array($data) &amp;&amp; ! $data instanceof Traversable</code>
-      <code>! is_array($entries) &amp;&amp; ! $entries instanceof Traversable</code>
+      <code>gettype($data)</code>
+      <code>gettype($entries)</code>
     </DocblockTypeContradiction>
-    <MixedArgument occurrences="5">
-      <code>$key</code>
+    <MixedArgument occurrences="4">
       <code>$key</code>
       <code>$value</code>
       <code>$value['link']</code>
       <code>$value['type']</code>
     </MixedArgument>
-    <MixedAssignment occurrences="4">
+    <MixedArgumentTypeCoercion occurrences="1">
       <code>$key</code>
+    </MixedArgumentTypeCoercion>
+    <MixedAssignment occurrences="3">
       <code>$key</code>
       <code>$value</code>
       <code>$value</code>
     </MixedAssignment>
+    <RedundantConditionGivenDocblockType occurrences="2">
+      <code>is_object($data)</code>
+      <code>is_object($entries)</code>
+    </RedundantConditionGivenDocblockType>
   </file>
   <file src="src/Writer/Renderer/AbstractRenderer.php">
     <DocblockTypeContradiction occurrences="1">
@@ -2758,6 +2740,9 @@
     </PropertyNotSetInConstructor>
   </file>
   <file src="src/Writer/Renderer/Entry/Atom.php">
+    <DocblockTypeContradiction occurrences="1">
+      <code>empty($data)</code>
+    </DocblockTypeContradiction>
     <ImplementedReturnTypeMismatch occurrences="1">
       <code>$this</code>
     </ImplementedReturnTypeMismatch>
@@ -2774,16 +2759,12 @@
       <code>format</code>
       <code>format</code>
     </InvalidMethodCall>
-    <InvalidScalarArgument occurrences="1">
-      <code>$deep</code>
-    </InvalidScalarArgument>
-    <MixedArgument occurrences="16">
+    <MixedArgument occurrences="15">
       <code>$cat['label']</code>
       <code>$cat['scheme']</code>
       <code>$cat['term']</code>
       <code>$cat['term']</code>
       <code>$content</code>
-      <code>$data</code>
       <code>$data</code>
       <code>$data['email']</code>
       <code>$data['length']</code>
@@ -2795,16 +2776,14 @@
       <code>$this-&gt;getDataContainer()-&gt;getDateCreated()-&gt;format(DateTime::ATOM)</code>
       <code>$this-&gt;getDataContainer()-&gt;getDateModified()-&gt;format(DateTime::ATOM)</code>
     </MixedArgument>
-    <MixedArrayAccess occurrences="10">
+    <MixedArrayAccess occurrences="8">
       <code>$cat['label']</code>
       <code>$cat['scheme']</code>
       <code>$cat['term']</code>
       <code>$cat['term']</code>
-      <code>$data['email']</code>
       <code>$data['length']</code>
       <code>$data['name']</code>
       <code>$data['type']</code>
-      <code>$data['uri']</code>
       <code>$data['uri']</code>
     </MixedArrayAccess>
     <MixedAssignment occurrences="6">
@@ -2821,9 +2800,8 @@
       <code>setRootElement</code>
       <code>setType</code>
     </MixedMethodCall>
-    <ParadoxicalCondition occurrences="2">
+    <ParadoxicalCondition occurrences="1">
       <code>! $authors || empty($authors)</code>
-      <code>empty($data)</code>
     </ParadoxicalCondition>
     <PossiblyNullArgument occurrences="9">
       <code>$this-&gt;container-&gt;getEncoding()</code>
@@ -2846,14 +2824,16 @@
     </PropertyNotSetInConstructor>
   </file>
   <file src="src/Writer/Renderer/Entry/Atom/Deleted.php">
+    <DocblockTypeContradiction occurrences="1">
+      <code>empty($data)</code>
+    </DocblockTypeContradiction>
     <ImplementedReturnTypeMismatch occurrences="1">
       <code>$this</code>
     </ImplementedReturnTypeMismatch>
     <InvalidArgument occurrences="1">
       <code>$container</code>
     </InvalidArgument>
-    <MixedArgument occurrences="8">
-      <code>$data</code>
+    <MixedArgument occurrences="7">
       <code>$data</code>
       <code>$data['email']</code>
       <code>$data['name']</code>
@@ -2862,10 +2842,8 @@
       <code>$this-&gt;container-&gt;getWhen()-&gt;format(DateTime::ATOM)</code>
       <code>$this-&gt;getDataContainer()-&gt;getComment()</code>
     </MixedArgument>
-    <MixedArrayAccess occurrences="3">
-      <code>$data['email']</code>
+    <MixedArrayAccess occurrences="1">
       <code>$data['name']</code>
-      <code>$data['uri']</code>
     </MixedArrayAccess>
     <MixedAssignment occurrences="1">
       <code>$data</code>
@@ -2873,9 +2851,6 @@
     <MixedMethodCall occurrences="1">
       <code>format</code>
     </MixedMethodCall>
-    <ParadoxicalCondition occurrences="1">
-      <code>empty($data)</code>
-    </ParadoxicalCondition>
     <PossiblyNullArgument occurrences="1">
       <code>$this-&gt;container-&gt;getEncoding()</code>
     </PossiblyNullArgument>
@@ -2885,14 +2860,16 @@
     </PropertyNotSetInConstructor>
   </file>
   <file src="src/Writer/Renderer/Entry/AtomDeleted.php">
+    <DocblockTypeContradiction occurrences="1">
+      <code>empty($data)</code>
+    </DocblockTypeContradiction>
     <ImplementedReturnTypeMismatch occurrences="1">
       <code>$this</code>
     </ImplementedReturnTypeMismatch>
     <InvalidArgument occurrences="1">
       <code>$container</code>
     </InvalidArgument>
-    <MixedArgument occurrences="8">
-      <code>$data</code>
+    <MixedArgument occurrences="7">
       <code>$data</code>
       <code>$data['email']</code>
       <code>$data['name']</code>
@@ -2901,10 +2878,8 @@
       <code>$this-&gt;container-&gt;getWhen()-&gt;format(DateTime::ATOM)</code>
       <code>$this-&gt;getDataContainer()-&gt;getComment()</code>
     </MixedArgument>
-    <MixedArrayAccess occurrences="3">
-      <code>$data['email']</code>
+    <MixedArrayAccess occurrences="1">
       <code>$data['name']</code>
-      <code>$data['uri']</code>
     </MixedArrayAccess>
     <MixedAssignment occurrences="1">
       <code>$data</code>
@@ -2912,9 +2887,6 @@
     <MixedMethodCall occurrences="1">
       <code>format</code>
     </MixedMethodCall>
-    <ParadoxicalCondition occurrences="1">
-      <code>empty($data)</code>
-    </ParadoxicalCondition>
     <PossiblyNullArgument occurrences="1">
       <code>$this-&gt;container-&gt;getEncoding()</code>
     </PossiblyNullArgument>
@@ -2924,6 +2896,9 @@
     </PropertyNotSetInConstructor>
   </file>
   <file src="src/Writer/Renderer/Entry/Rss.php">
+    <DocblockTypeContradiction occurrences="1">
+      <code>empty($data)</code>
+    </DocblockTypeContradiction>
     <ImplementedReturnTypeMismatch occurrences="1">
       <code>$this</code>
     </ImplementedReturnTypeMismatch>
@@ -2936,25 +2911,22 @@
     <InvalidMethodCall occurrences="1">
       <code>format</code>
     </InvalidMethodCall>
-    <MixedArgument occurrences="9">
+    <MixedArgument occurrences="8">
       <code>$cat['scheme']</code>
       <code>$cat['term']</code>
       <code>$data</code>
-      <code>$data['length']</code>
       <code>$data['type']</code>
       <code>$data['uri']</code>
       <code>$link</code>
       <code>$name</code>
       <code>$this-&gt;getDataContainer()-&gt;getDateModified()-&gt;format(DateTime::RSS)</code>
     </MixedArgument>
-    <MixedArrayAccess occurrences="10">
+    <MixedArrayAccess occurrences="8">
       <code>$cat['scheme']</code>
       <code>$cat['term']</code>
-      <code>$data['email']</code>
       <code>$data['length']</code>
       <code>$data['length']</code>
       <code>$data['length']</code>
-      <code>$data['name']</code>
       <code>$data['name']</code>
       <code>$data['type']</code>
       <code>$data['uri']</code>
@@ -2977,9 +2949,8 @@
       <code>$data['email']</code>
       <code>$data['name']</code>
     </MixedOperand>
-    <ParadoxicalCondition occurrences="2">
+    <ParadoxicalCondition occurrences="1">
       <code>! $authors || empty($authors)</code>
-      <code>empty($data)</code>
     </ParadoxicalCondition>
     <PossiblyNullArgument occurrences="7">
       <code>$this-&gt;container-&gt;getEncoding()</code>
@@ -3015,12 +2986,11 @@
     <InvalidMethodCall occurrences="1">
       <code>format</code>
     </InvalidMethodCall>
-    <MixedArgument occurrences="15">
+    <MixedArgument occurrences="14">
       <code>$cat['label']</code>
       <code>$cat['scheme']</code>
       <code>$cat['term']</code>
       <code>$cat['term']</code>
-      <code>$data</code>
       <code>$data</code>
       <code>$data['email']</code>
       <code>$data['name']</code>
@@ -3032,14 +3002,12 @@
       <code>$this-&gt;getDataContainer()-&gt;getDateModified()-&gt;format(DateTime::ATOM)</code>
       <code>$type</code>
     </MixedArgument>
-    <MixedArrayAccess occurrences="7">
+    <MixedArrayAccess occurrences="5">
       <code>$cat['label']</code>
       <code>$cat['scheme']</code>
       <code>$cat['term']</code>
       <code>$cat['term']</code>
-      <code>$data['email']</code>
       <code>$data['name']</code>
-      <code>$data['uri']</code>
     </MixedArrayAccess>
     <MixedAssignment occurrences="5">
       <code>$cat</code>
@@ -3076,9 +3044,6 @@
     <ImplementedReturnTypeMismatch occurrences="1">
       <code>$this</code>
     </ImplementedReturnTypeMismatch>
-    <InvalidScalarArgument occurrences="1">
-      <code>$deep</code>
-    </InvalidScalarArgument>
     <MixedArgument occurrences="1">
       <code>$entry</code>
     </MixedArgument>
@@ -3121,12 +3086,11 @@
     <InvalidMethodCall occurrences="1">
       <code>format</code>
     </InvalidMethodCall>
-    <MixedArgument occurrences="15">
+    <MixedArgument occurrences="14">
       <code>$cat['label']</code>
       <code>$cat['scheme']</code>
       <code>$cat['term']</code>
       <code>$cat['term']</code>
-      <code>$data</code>
       <code>$data</code>
       <code>$data['email']</code>
       <code>$data['name']</code>
@@ -3138,14 +3102,12 @@
       <code>$this-&gt;getDataContainer()-&gt;getDateModified()-&gt;format(DateTime::ATOM)</code>
       <code>$type</code>
     </MixedArgument>
-    <MixedArrayAccess occurrences="7">
+    <MixedArrayAccess occurrences="5">
       <code>$cat['label']</code>
       <code>$cat['scheme']</code>
       <code>$cat['term']</code>
       <code>$cat['term']</code>
-      <code>$data['email']</code>
       <code>$data['name']</code>
-      <code>$data['uri']</code>
     </MixedArrayAccess>
     <MixedAssignment occurrences="5">
       <code>$cat</code>
@@ -3269,9 +3231,6 @@
       <code>format</code>
       <code>format</code>
     </InvalidMethodCall>
-    <InvalidScalarArgument occurrences="1">
-      <code>$deep</code>
-    </InvalidScalarArgument>
     <MixedArgument occurrences="10">
       <code>$cat['scheme']</code>
       <code>$cat['term']</code>
@@ -3284,11 +3243,9 @@
       <code>$this-&gt;getDataContainer()-&gt;getDateModified()-&gt;format(DateTime::RSS)</code>
       <code>$this-&gt;getDataContainer()-&gt;getLastBuildDate()-&gt;format(DateTime::RSS)</code>
     </MixedArgument>
-    <MixedArrayAccess occurrences="5">
+    <MixedArrayAccess occurrences="3">
       <code>$cat['scheme']</code>
       <code>$cat['term']</code>
-      <code>$data['email']</code>
-      <code>$data['name']</code>
       <code>$data['name']</code>
     </MixedArrayAccess>
     <MixedAssignment occurrences="6">
@@ -3449,6 +3406,9 @@
       <code>'Result'</code>
       <code>'Result'</code>
     </UndefinedClass>
+    <UnevaluatedCode occurrences="1">
+      <code>$this-&gt;assertFalse($this-&gt;callback-&gt;isValidHubVerification($this-&gt;get));</code>
+    </UnevaluatedCode>
   </file>
   <file src="test/PubSubHubbub/SubscriberHttpTest.php">
     <ArgumentTypeCoercion occurrences="2">
@@ -4536,10 +4496,6 @@
     <MismatchingDocblockReturnType occurrences="1">
       <code>MockObject&lt;Headers&gt;</code>
     </MismatchingDocblockReturnType>
-    <MissingClosureParamType occurrences="2">
-      <code>$argument</code>
-      <code>$parameter</code>
-    </MissingClosureParamType>
     <MixedArgument occurrences="3">
       <code>$this-&gt;client</code>
       <code>$this-&gt;client</code>
@@ -4581,10 +4537,6 @@
       <code>with</code>
       <code>with</code>
     </MixedMethodCall>
-    <MixedReturnTypeCoercion occurrences="2">
-      <code>$response</code>
-      <code>MockObject&lt;HttpResponse&gt;</code>
-    </MixedReturnTypeCoercion>
     <PossiblyUndefinedMethod occurrences="11">
       <code>expects</code>
       <code>expects</code>
@@ -4891,20 +4843,12 @@
     <InvalidArgument occurrences="2">
       <code>new stdClass()</code>
     </InvalidArgument>
-    <MissingClosureParamType occurrences="2">
+    <MixedArgument occurrences="1">
       <code>$message</code>
-      <code>$toReturn</code>
-    </MissingClosureParamType>
-    <MixedArgument occurrences="2">
-      <code>$message</code>
-      <code>$notices-&gt;messages</code>
     </MixedArgument>
     <MixedArrayAccess occurrences="1">
       <code>$link['feed']</code>
     </MixedArrayAccess>
-    <MixedArrayAssignment occurrences="1">
-      <code>$notices-&gt;messages[]</code>
-    </MixedArrayAssignment>
     <MixedAssignment occurrences="1">
       <code>$link</code>
     </MixedAssignment>
@@ -4946,8 +4890,7 @@
     <DocblockTypeContradiction occurrences="1">
       <code>assertNull</code>
     </DocblockTypeContradiction>
-    <InvalidArgument occurrences="6">
-      <code>Writer\Exception\ExceptionInterface::class</code>
+    <InvalidArgument occurrences="5">
       <code>Writer\Exception\ExceptionInterface::class</code>
       <code>Writer\Exception\ExceptionInterface::class</code>
       <code>Writer\Exception\ExceptionInterface::class</code>
@@ -4957,12 +4900,14 @@
     <InvalidScalarArgument occurrences="1">
       <code>'abc'</code>
     </InvalidScalarArgument>
+    <UnevaluatedCode occurrences="3">
+      <code>$entry = new Writer\Deleted();</code>
+      <code>$entry-&gt;setBy(['name' =&gt; 'Joe', 'uri' =&gt; 'notauri']);</code>
+      <code>$this-&gt;expectException(Writer\Exception\ExceptionInterface::class);</code>
+    </UnevaluatedCode>
   </file>
   <file src="test/Writer/EntryTest.php">
-    <InvalidArgument occurrences="20">
-      <code>ExceptionInterface::class</code>
-      <code>ExceptionInterface::class</code>
-      <code>ExceptionInterface::class</code>
+    <InvalidArgument occurrences="17">
       <code>ExceptionInterface::class</code>
       <code>Writer\Exception\ExceptionInterface::class</code>
       <code>Writer\Exception\ExceptionInterface::class</code>
@@ -4984,21 +4929,21 @@
       <code>'abc'</code>
       <code>'abc'</code>
     </InvalidScalarArgument>
-    <MissingClosureParamType occurrences="2">
-      <code>$message</code>
-      <code>$toReturn</code>
-    </MissingClosureParamType>
-    <MixedArgument occurrences="3">
+    <MixedArgument occurrences="2">
       <code>$count</code>
       <code>$message</code>
-      <code>$notices-&gt;messages</code>
     </MixedArgument>
-    <MixedArrayAssignment occurrences="1">
-      <code>$notices-&gt;messages[]</code>
-    </MixedArrayAssignment>
     <NullArgument occurrences="1">
       <code>null</code>
     </NullArgument>
+    <UnevaluatedCode occurrences="9">
+      <code>$entry = new Writer\Entry();</code>
+      <code>$entry = new Writer\Entry();</code>
+      <code>$entry = new Writer\Entry();</code>
+      <code>$this-&gt;expectException(ExceptionInterface::class);</code>
+      <code>$this-&gt;expectException(ExceptionInterface::class);</code>
+      <code>$this-&gt;expectException(ExceptionInterface::class);</code>
+    </UnevaluatedCode>
   </file>
   <file src="test/Writer/Extension/GooglePlayPodcast/EntryTest.php">
     <InvalidArgument occurrences="4">
@@ -5097,9 +5042,7 @@
     </PossiblyNullReference>
   </file>
   <file src="test/Writer/FeedTest.php">
-    <InvalidArgument occurrences="28">
-      <code>ExceptionInterface::class</code>
-      <code>ExceptionInterface::class</code>
+    <InvalidArgument occurrences="26">
       <code>ExceptionInterface::class</code>
       <code>ExceptionInterface::class</code>
       <code>ExceptionInterface::class</code>
@@ -5132,37 +5075,29 @@
       <code>getTimestamp</code>
       <code>getTimestamp</code>
     </InvalidMethodCall>
-    <MissingClosureParamType occurrences="2">
+    <MixedArgument occurrences="1">
       <code>$message</code>
-      <code>$toReturn</code>
-    </MissingClosureParamType>
-    <MixedArgument occurrences="2">
-      <code>$message</code>
-      <code>$notices-&gt;messages</code>
     </MixedArgument>
-    <MixedArrayAssignment occurrences="1">
-      <code>$notices-&gt;messages[]</code>
-    </MixedArrayAssignment>
+    <UnevaluatedCode occurrences="9">
+      <code>$this-&gt;expectException(ExceptionInterface::class);</code>
+      <code>$this-&gt;expectException(ExceptionInterface::class);</code>
+      <code>$this-&gt;expectException(Writer\Exception\InvalidArgumentException::class);</code>
+      <code>$writer = new Writer\Feed();</code>
+      <code>$writer = new Writer\Feed();</code>
+      <code>$writer = new Writer\Feed();</code>
+      <code>$writer-&gt;setGenerator('LaminasW', null, 'notauri');</code>
+    </UnevaluatedCode>
   </file>
   <file src="test/Writer/Renderer/Entry/AtomTest.php">
-    <InvalidArgument occurrences="6">
-      <code>ExceptionInterface::class</code>
+    <InvalidArgument occurrences="5">
       <code>ExceptionInterface::class</code>
       <code>ExceptionInterface::class</code>
       <code>ExceptionInterface::class</code>
       <code>ExceptionInterface::class</code>
     </InvalidArgument>
-    <MissingClosureParamType occurrences="2">
+    <MixedArgument occurrences="1">
       <code>$message</code>
-      <code>$toReturn</code>
-    </MissingClosureParamType>
-    <MixedArgument occurrences="2">
-      <code>$message</code>
-      <code>$notices-&gt;messages</code>
     </MixedArgument>
-    <MixedArrayAssignment occurrences="1">
-      <code>$notices-&gt;messages[]</code>
-    </MixedArrayAssignment>
     <MixedAssignment occurrences="19">
       <code>$enc</code>
       <code>$entry</code>
@@ -5212,6 +5147,14 @@
       <code>$enc-&gt;type</code>
       <code>$enc-&gt;url</code>
     </MixedPropertyFetch>
+    <UnevaluatedCode occurrences="6">
+      <code>$atomFeed = new Renderer\Feed\Atom($this-&gt;validWriter);</code>
+      <code>$atomFeed-&gt;render();</code>
+      <code>$this-&gt;expectException(ExceptionInterface::class);</code>
+      <code>$this-&gt;validEntry-&gt;remove('id');</code>
+      <code>$this-&gt;validEntry-&gt;remove('link');</code>
+      <code>$this-&gt;validEntry-&gt;setId('not-a-uri');</code>
+    </UnevaluatedCode>
   </file>
   <file src="test/Writer/Renderer/Entry/RssTest.php">
     <InvalidArgument occurrences="7">
@@ -5222,17 +5165,9 @@
       <code>ExceptionInterface::class</code>
       <code>ExceptionInterface::class</code>
     </InvalidArgument>
-    <MissingClosureParamType occurrences="2">
+    <MixedArgument occurrences="1">
       <code>$message</code>
-      <code>$toReturn</code>
-    </MissingClosureParamType>
-    <MixedArgument occurrences="2">
-      <code>$message</code>
-      <code>$notices-&gt;messages</code>
     </MixedArgument>
-    <MixedArrayAssignment occurrences="1">
-      <code>$notices-&gt;messages[]</code>
-    </MixedArrayAssignment>
     <MixedAssignment occurrences="22">
       <code>$enc</code>
       <code>$entry</code>
@@ -5296,17 +5231,9 @@
       <code>ExceptionInterface::class</code>
       <code>ExceptionInterface::class</code>
     </InvalidArgument>
-    <MissingClosureParamType occurrences="2">
+    <MixedArgument occurrences="1">
       <code>$message</code>
-      <code>$toReturn</code>
-    </MissingClosureParamType>
-    <MixedArgument occurrences="2">
-      <code>$message</code>
-      <code>$notices-&gt;messages</code>
     </MixedArgument>
-    <MixedArrayAssignment occurrences="1">
-      <code>$notices-&gt;messages[]</code>
-    </MixedArrayAssignment>
     <PossiblyNullReference occurrences="1">
       <code>getTimestamp</code>
     </PossiblyNullReference>
@@ -5335,18 +5262,10 @@
       <code>ExceptionInterface::class</code>
       <code>ExceptionInterface::class</code>
     </InvalidArgument>
-    <MissingClosureParamType occurrences="2">
-      <code>$message</code>
-      <code>$toReturn</code>
-    </MissingClosureParamType>
-    <MixedArgument occurrences="3">
+    <MixedArgument occurrences="2">
       <code>$feed-&gt;getDomDocument()</code>
       <code>$message</code>
-      <code>$notices-&gt;messages</code>
     </MixedArgument>
-    <MixedArrayAssignment occurrences="1">
-      <code>$notices-&gt;messages[]</code>
-    </MixedArrayAssignment>
     <MixedMethodCall occurrences="1">
       <code>getTimestamp</code>
     </MixedMethodCall>

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <psalm
     cacheDirectory="./.psalm-cache"
-    totallyTyped="true"
+    errorLevel="1"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"

--- a/src/Exception/BadMethodCallException.php
+++ b/src/Exception/BadMethodCallException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Exception;
 
 class BadMethodCallException extends \BadMethodCallException implements ExceptionInterface

--- a/src/Exception/ExceptionInterface.php
+++ b/src/Exception/ExceptionInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Exception;
 
 interface ExceptionInterface

--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Exception;
 
 class InvalidArgumentException extends \InvalidArgumentException implements ExceptionInterface

--- a/src/Exception/RuntimeException.php
+++ b/src/Exception/RuntimeException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Exception;
 
 class RuntimeException extends \RuntimeException implements ExceptionInterface

--- a/src/PubSubHubbub/AbstractCallback.php
+++ b/src/PubSubHubbub/AbstractCallback.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\PubSubHubbub;
 
 use Laminas\Http\PhpEnvironment\Response as PhpResponse;

--- a/src/PubSubHubbub/CallbackInterface.php
+++ b/src/PubSubHubbub/CallbackInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\PubSubHubbub;
 
 use Laminas\Http\PhpEnvironment\Response;

--- a/src/PubSubHubbub/Exception/ExceptionInterface.php
+++ b/src/PubSubHubbub/Exception/ExceptionInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\PubSubHubbub\Exception;
 
 use Laminas\Feed\Exception\ExceptionInterface as Exception;

--- a/src/PubSubHubbub/Exception/InvalidArgumentException.php
+++ b/src/PubSubHubbub/Exception/InvalidArgumentException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\PubSubHubbub\Exception;
 
 use Laminas\Feed\Exception;

--- a/src/PubSubHubbub/Exception/RuntimeException.php
+++ b/src/PubSubHubbub/Exception/RuntimeException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\PubSubHubbub\Exception;
 
 use Laminas\Feed\Exception;

--- a/src/PubSubHubbub/HttpResponse.php
+++ b/src/PubSubHubbub/HttpResponse.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\PubSubHubbub;
 
 use function header;

--- a/src/PubSubHubbub/Model/AbstractModel.php
+++ b/src/PubSubHubbub/Model/AbstractModel.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\PubSubHubbub\Model;
 
 use Laminas\Db\TableGateway\TableGateway;

--- a/src/PubSubHubbub/Model/Subscription.php
+++ b/src/PubSubHubbub/Model/Subscription.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\PubSubHubbub\Model;
 
 use DateInterval;

--- a/src/PubSubHubbub/Model/SubscriptionPersistenceInterface.php
+++ b/src/PubSubHubbub/Model/SubscriptionPersistenceInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\PubSubHubbub\Model;
 
 interface SubscriptionPersistenceInterface

--- a/src/PubSubHubbub/PubSubHubbub.php
+++ b/src/PubSubHubbub/PubSubHubbub.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\PubSubHubbub;
 
 use Laminas\Escaper\Escaper;

--- a/src/PubSubHubbub/Publisher.php
+++ b/src/PubSubHubbub/Publisher.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\PubSubHubbub;
 
 use Laminas\Feed\Uri;

--- a/src/PubSubHubbub/Subscriber.php
+++ b/src/PubSubHubbub/Subscriber.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\PubSubHubbub;
 
 use DateInterval;

--- a/src/PubSubHubbub/Subscriber.php
+++ b/src/PubSubHubbub/Subscriber.php
@@ -782,7 +782,7 @@ class Subscriber
         if (! empty($this->testStaticToken)) {
             return $this->testStaticToken;
         }
-        return uniqid(rand(), true) . time();
+        return uniqid((string) rand(), true) . time();
     }
 
     /**

--- a/src/PubSubHubbub/Subscriber/Callback.php
+++ b/src/PubSubHubbub/Subscriber/Callback.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\PubSubHubbub\Subscriber;
 
 use Laminas\Feed\PubSubHubbub;

--- a/src/PubSubHubbub/Version.php
+++ b/src/PubSubHubbub/Version.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\PubSubHubbub;
 
 // phpcs:ignore WebimpressCodingStandard.NamingConventions.AbstractClass.Prefix

--- a/src/Reader/AbstractEntry.php
+++ b/src/Reader/AbstractEntry.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Reader;
 
 use DOMDocument;

--- a/src/Reader/AbstractFeed.php
+++ b/src/Reader/AbstractFeed.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Reader;
 
 use DOMDocument;

--- a/src/Reader/Collection.php
+++ b/src/Reader/Collection.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Reader;
 
 use ArrayObject;

--- a/src/Reader/Collection/AbstractCollection.php
+++ b/src/Reader/Collection/AbstractCollection.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Reader\Collection;
 
 use ArrayObject;

--- a/src/Reader/Collection/Author.php
+++ b/src/Reader/Collection/Author.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Reader\Collection;
 
 use function array_unique;

--- a/src/Reader/Collection/Category.php
+++ b/src/Reader/Collection/Category.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Reader\Collection;
 
 use function array_unique;

--- a/src/Reader/Collection/Collection.php
+++ b/src/Reader/Collection/Collection.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Reader\Collection;
 
 use ArrayObject;

--- a/src/Reader/Entry/AbstractEntry.php
+++ b/src/Reader/Entry/AbstractEntry.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Reader\Entry;
 
 use DOMDocument;
@@ -12,9 +14,6 @@ use function call_user_func_array;
 use function in_array;
 use function method_exists;
 use function sprintf;
-use function version_compare;
-
-use const PHP_VERSION;
 
 abstract class AbstractEntry
 {
@@ -121,8 +120,7 @@ abstract class AbstractEntry
     public function saveXml()
     {
         $dom   = new DOMDocument('1.0', $this->getEncoding());
-        $deep  = version_compare(PHP_VERSION, '7', 'ge') ? 1 : true;
-        $entry = $dom->importNode($this->getElement(), $deep);
+        $entry = $dom->importNode($this->getElement(), true);
         $dom->appendChild($entry);
         return $dom->saveXML();
     }

--- a/src/Reader/Entry/Atom.php
+++ b/src/Reader/Entry/Atom.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Reader\Entry;
 
 use DateTime;

--- a/src/Reader/Entry/EntryInterface.php
+++ b/src/Reader/Entry/EntryInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Reader\Entry;
 
 use DateTime;

--- a/src/Reader/Entry/Rss.php
+++ b/src/Reader/Entry/Rss.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Reader\Entry;
 
 use DateTime;

--- a/src/Reader/Exception/BadMethodCallException.php
+++ b/src/Reader/Exception/BadMethodCallException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Reader\Exception;
 
 use Laminas\Feed\Exception;

--- a/src/Reader/Exception/ExceptionInterface.php
+++ b/src/Reader/Exception/ExceptionInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Reader\Exception;
 
 use Laminas\Feed\Exception\ExceptionInterface as Exception;

--- a/src/Reader/Exception/InvalidArgumentException.php
+++ b/src/Reader/Exception/InvalidArgumentException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Reader\Exception;
 
 use Laminas\Feed\Exception;

--- a/src/Reader/Exception/InvalidHttpClientException.php
+++ b/src/Reader/Exception/InvalidHttpClientException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Reader\Exception;
 
 use Laminas\Feed\Exception;

--- a/src/Reader/Exception/RuntimeException.php
+++ b/src/Reader/Exception/RuntimeException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Reader\Exception;
 
 use Laminas\Feed\Exception;

--- a/src/Reader/Extension/AbstractEntry.php
+++ b/src/Reader/Extension/AbstractEntry.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Reader\Extension;
 
 use DOMDocument;

--- a/src/Reader/Extension/AbstractFeed.php
+++ b/src/Reader/Extension/AbstractFeed.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Reader\Extension;
 
 use DOMDocument;

--- a/src/Reader/Extension/Atom/Entry.php
+++ b/src/Reader/Extension/Atom/Entry.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Reader\Extension\Atom;
 
 use DateTime;
@@ -18,9 +20,6 @@ use function is_string;
 use function preg_replace;
 use function strlen;
 use function trim;
-use function version_compare;
-
-use const PHP_VERSION;
 
 class Entry extends Extension\AbstractEntry
 {
@@ -112,8 +111,7 @@ class Entry extends Extension\AbstractEntry
                         ->query($this->getXpathPrefix() . '/atom:content/xhtml:div')
                         ->item(0);
                     $d      = new DOMDocument('1.0', $this->getEncoding());
-                    $deep   = version_compare(PHP_VERSION, '7', 'ge') ? 1 : true;
-                    $xhtmls = $d->importNode($xhtml, $deep);
+                    $xhtmls = $d->importNode($xhtml, true);
                     $d->appendChild($xhtmls);
                     $content = $this->collectXhtml(
                         $d->saveXML(),

--- a/src/Reader/Extension/Atom/Feed.php
+++ b/src/Reader/Extension/Atom/Feed.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Reader\Extension\Atom;
 
 use DateTime;

--- a/src/Reader/Extension/Content/Entry.php
+++ b/src/Reader/Extension/Content/Entry.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Reader\Extension\Content;
 
 use Laminas\Feed\Reader;

--- a/src/Reader/Extension/CreativeCommons/Entry.php
+++ b/src/Reader/Extension/CreativeCommons/Entry.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Reader\Extension\CreativeCommons;
 
 use DOMNodeList;

--- a/src/Reader/Extension/CreativeCommons/Feed.php
+++ b/src/Reader/Extension/CreativeCommons/Feed.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Reader\Extension\CreativeCommons;
 
 use Laminas\Feed\Reader\Exception\RuntimeException;

--- a/src/Reader/Extension/DublinCore/Entry.php
+++ b/src/Reader/Extension/DublinCore/Entry.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Reader\Extension\DublinCore;
 
 use DateTime;

--- a/src/Reader/Extension/DublinCore/Feed.php
+++ b/src/Reader/Extension/DublinCore/Feed.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Reader\Extension\DublinCore;
 
 use DateTime;

--- a/src/Reader/Extension/GooglePlayPodcast/Entry.php
+++ b/src/Reader/Extension/GooglePlayPodcast/Entry.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Reader\Extension\GooglePlayPodcast;
 
 use Laminas\Feed\Reader\Extension;

--- a/src/Reader/Extension/GooglePlayPodcast/Feed.php
+++ b/src/Reader/Extension/GooglePlayPodcast/Feed.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Reader\Extension\GooglePlayPodcast;
 
 use DOMText;

--- a/src/Reader/Extension/Podcast/Entry.php
+++ b/src/Reader/Extension/Podcast/Entry.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Reader\Extension\Podcast;
 
 use Laminas\Feed\Reader\Extension;

--- a/src/Reader/Extension/Podcast/Feed.php
+++ b/src/Reader/Extension/Podcast/Feed.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Reader\Extension\Podcast;
 
 use DOMText;

--- a/src/Reader/Extension/PodcastIndex/Entry.php
+++ b/src/Reader/Extension/PodcastIndex/Entry.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Reader\Extension\PodcastIndex;
 
 use DOMElement;

--- a/src/Reader/Extension/PodcastIndex/Feed.php
+++ b/src/Reader/Extension/PodcastIndex/Feed.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Reader\Extension\PodcastIndex;
 
 use Laminas\Feed\Reader\Extension;

--- a/src/Reader/Extension/Slash/Entry.php
+++ b/src/Reader/Extension/Slash/Entry.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Reader\Extension\Slash;
 
 use Laminas\Feed\Reader\Extension;

--- a/src/Reader/Extension/Syndication/Feed.php
+++ b/src/Reader/Extension/Syndication/Feed.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Reader\Extension\Syndication;
 
 use DateTime;

--- a/src/Reader/Extension/Thread/Entry.php
+++ b/src/Reader/Extension/Thread/Entry.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Reader\Extension\Thread;
 
 use Laminas\Feed\Reader\Extension;

--- a/src/Reader/Extension/WellFormedWeb/Entry.php
+++ b/src/Reader/Extension/WellFormedWeb/Entry.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Reader\Extension\WellFormedWeb;
 
 use Laminas\Feed\Reader\Extension;

--- a/src/Reader/ExtensionManager.php
+++ b/src/Reader/ExtensionManager.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Reader;
 
 use function call_user_func_array;

--- a/src/Reader/ExtensionManagerInterface.php
+++ b/src/Reader/ExtensionManagerInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Reader;
 
 interface ExtensionManagerInterface

--- a/src/Reader/ExtensionPluginManager.php
+++ b/src/Reader/ExtensionPluginManager.php
@@ -7,8 +7,6 @@ namespace Laminas\Feed\Reader;
 use Laminas\ServiceManager\AbstractPluginManager;
 use Laminas\ServiceManager\Exception\InvalidServiceException;
 use Laminas\ServiceManager\Factory\InvokableFactory;
-use Zend\Feed\Reader\Extension\Atom\Entry;
-use Zend\Feed\Reader\Extension\Atom\Feed;
 
 use function get_class;
 use function gettype;
@@ -100,21 +98,21 @@ class ExtensionPluginManager extends AbstractPluginManager implements ExtensionM
         'WellFormedWeb\Entry'     => Extension\WellFormedWeb\Entry::class,
 
         // Legacy Zend Framework aliases
-        Entry::class                                               => Extension\Atom\Entry::class,
-        Feed::class                                                => Extension\Atom\Feed::class,
-        \Zend\Feed\Reader\Extension\Content\Entry::class           => Extension\Content\Entry::class,
-        \Zend\Feed\Reader\Extension\CreativeCommons\Entry::class   => Extension\CreativeCommons\Entry::class,
-        \Zend\Feed\Reader\Extension\CreativeCommons\Feed::class    => Extension\CreativeCommons\Feed::class,
-        \Zend\Feed\Reader\Extension\DublinCore\Entry::class        => Extension\DublinCore\Entry::class,
-        \Zend\Feed\Reader\Extension\DublinCore\Feed::class         => Extension\DublinCore\Feed::class,
-        \Zend\Feed\Reader\Extension\GooglePlayPodcast\Entry::class => Extension\GooglePlayPodcast\Entry::class,
-        \Zend\Feed\Reader\Extension\GooglePlayPodcast\Feed::class  => Extension\GooglePlayPodcast\Feed::class,
-        \Zend\Feed\Reader\Extension\Podcast\Entry::class           => Extension\Podcast\Entry::class,
-        \Zend\Feed\Reader\Extension\Podcast\Feed::class            => Extension\Podcast\Feed::class,
-        \Zend\Feed\Reader\Extension\Slash\Entry::class             => Extension\Slash\Entry::class,
-        \Zend\Feed\Reader\Extension\Syndication\Feed::class        => Extension\Syndication\Feed::class,
-        \Zend\Feed\Reader\Extension\Thread\Entry::class            => Extension\Thread\Entry::class,
-        \Zend\Feed\Reader\Extension\WellFormedWeb\Entry::class     => Extension\WellFormedWeb\Entry::class,
+        'Zend\Feed\Reader\Extension\Atom\Entry'              => Extension\Atom\Entry::class,
+        'Zend\Feed\Reader\Extension\Atom\Feed'               => Extension\Atom\Feed::class,
+        'Zend\Feed\Reader\Extension\Content\Entry'           => Extension\Content\Entry::class,
+        'Zend\Feed\Reader\Extension\CreativeCommons\Entry'   => Extension\CreativeCommons\Entry::class,
+        'Zend\Feed\Reader\Extension\CreativeCommons\Feed'    => Extension\CreativeCommons\Feed::class,
+        'Zend\Feed\Reader\Extension\DublinCore\Entry'        => Extension\DublinCore\Entry::class,
+        'Zend\Feed\Reader\Extension\DublinCore\Feed'         => Extension\DublinCore\Feed::class,
+        'Zend\Feed\Reader\Extension\GooglePlayPodcast\Entry' => Extension\GooglePlayPodcast\Entry::class,
+        'Zend\Feed\Reader\Extension\GooglePlayPodcast\Feed'  => Extension\GooglePlayPodcast\Feed::class,
+        'Zend\Feed\Reader\Extension\Podcast\Entry'           => Extension\Podcast\Entry::class,
+        'Zend\Feed\Reader\Extension\Podcast\Feed'            => Extension\Podcast\Feed::class,
+        'Zend\Feed\Reader\Extension\Slash\Entry'             => Extension\Slash\Entry::class,
+        'Zend\Feed\Reader\Extension\Syndication\Feed'        => Extension\Syndication\Feed::class,
+        'Zend\Feed\Reader\Extension\Thread\Entry'            => Extension\Thread\Entry::class,
+        'Zend\Feed\Reader\Extension\WellFormedWeb\Entry'     => Extension\WellFormedWeb\Entry::class,
 
         // v2 normalized FQCNs
         'zendfeedreaderextensionatomentry'              => Extension\Atom\Entry::class,

--- a/src/Reader/ExtensionPluginManager.php
+++ b/src/Reader/ExtensionPluginManager.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace Laminas\Feed\Reader;
 
+use Laminas\Feed\Reader\Extension\AbstractEntry;
+use Laminas\Feed\Reader\Extension\AbstractFeed;
 use Laminas\ServiceManager\AbstractPluginManager;
+use Laminas\ServiceManager\ConfigInterface;
 use Laminas\ServiceManager\Exception\InvalidServiceException;
 use Laminas\ServiceManager\Factory\InvokableFactory;
 
@@ -19,6 +22,8 @@ use function sprintf;
  *
  * Validation checks that we have an Extension\AbstractEntry or
  * Extension\AbstractFeed.
+ *
+ * @psalm-import-type FactoriesConfigurationType from ConfigInterface
  */
 class ExtensionPluginManager extends AbstractPluginManager implements ExtensionManagerInterface
 {
@@ -136,6 +141,7 @@ class ExtensionPluginManager extends AbstractPluginManager implements ExtensionM
      * Factories for default set of extension classes
      *
      * @var array<array-key, callable|string>
+     * @psalm-var FactoriesConfigurationType
      */
     protected $factories = [
         Extension\Atom\Entry::class              => InvokableFactory::class,
@@ -180,6 +186,8 @@ class ExtensionPluginManager extends AbstractPluginManager implements ExtensionM
     /**
      * Do not share instances (v2)
      *
+     * @deprecated
+     *
      * @var bool
      */
     protected $shareByDefault = false;
@@ -203,24 +211,26 @@ class ExtensionPluginManager extends AbstractPluginManager implements ExtensionM
     public function validate($instance)
     {
         if (
-            $instance instanceof Extension\AbstractEntry
-            || $instance instanceof Extension\AbstractFeed
+            $instance instanceof AbstractEntry
+            || $instance instanceof AbstractFeed
         ) {
             // we're okay
             return;
         }
 
         throw new InvalidServiceException(sprintf(
-            'Plugin of type %s is invalid; must implement %s\Extension\AbstractFeed '
-            . 'or %s\Extension\AbstractEntry',
+            'Plugin of type %s is invalid; must implement %s or %s',
             is_object($instance) ? get_class($instance) : gettype($instance),
-            __NAMESPACE__,
-            __NAMESPACE__
+            AbstractEntry::class,
+            AbstractFeed::class
         ));
     }
 
     /**
      * Validate the plugin (v2)
+     *
+     * @deprecated Since 2.18.0 This component is no longer compatible with service manager v2 series.
+     *             This method will be removed in version 3.0 of this component
      *
      * @param  mixed $plugin
      * @return void
@@ -232,11 +242,10 @@ class ExtensionPluginManager extends AbstractPluginManager implements ExtensionM
             $this->validate($plugin);
         } catch (InvalidServiceException $e) {
             throw new Exception\InvalidArgumentException(sprintf(
-                'Plugin of type %s is invalid; must implement %s\Extension\AbstractFeed '
-                . 'or %s\Extension\AbstractEntry',
+                'Plugin of type %s is invalid; must implement %s or %s',
                 is_object($plugin) ? get_class($plugin) : gettype($plugin),
-                __NAMESPACE__,
-                __NAMESPACE__
+                AbstractEntry::class,
+                AbstractFeed::class
             ));
         }
     }

--- a/src/Reader/ExtensionPluginManager.php
+++ b/src/Reader/ExtensionPluginManager.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Reader;
 
 use Laminas\ServiceManager\AbstractPluginManager;

--- a/src/Reader/Feed/AbstractFeed.php
+++ b/src/Reader/Feed/AbstractFeed.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Reader\Feed;
 
 use DOMDocument;

--- a/src/Reader/Feed/Atom.php
+++ b/src/Reader/Feed/Atom.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Reader\Feed;
 
 use DateTime;

--- a/src/Reader/Feed/Atom/Source.php
+++ b/src/Reader/Feed/Atom/Source.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Reader\Feed\Atom;
 
 use DOMElement;

--- a/src/Reader/Feed/FeedInterface.php
+++ b/src/Reader/Feed/FeedInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Reader\Feed;
 
 use Countable;

--- a/src/Reader/Feed/Rss.php
+++ b/src/Reader/Feed/Rss.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Reader\Feed;
 
 use DateTime;

--- a/src/Reader/FeedSet.php
+++ b/src/Reader/FeedSet.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Reader;
 
 use ArrayObject;

--- a/src/Reader/Http/ClientInterface.php
+++ b/src/Reader/Http/ClientInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Reader\Http;
 
 interface ClientInterface

--- a/src/Reader/Http/HeaderAwareClientInterface.php
+++ b/src/Reader/Http/HeaderAwareClientInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Reader\Http;
 
 interface HeaderAwareClientInterface extends ClientInterface

--- a/src/Reader/Http/HeaderAwareResponseInterface.php
+++ b/src/Reader/Http/HeaderAwareResponseInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Reader\Http;
 
 interface HeaderAwareResponseInterface extends ResponseInterface

--- a/src/Reader/Http/LaminasHttpClientDecorator.php
+++ b/src/Reader/Http/LaminasHttpClientDecorator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Reader\Http;
 
 use Laminas\Feed\Reader\Exception;

--- a/src/Reader/Http/Psr7ResponseDecorator.php
+++ b/src/Reader/Http/Psr7ResponseDecorator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Reader\Http;
 
 use Psr\Http\Message\ResponseInterface as Psr7ResponseInterface;

--- a/src/Reader/Http/Response.php
+++ b/src/Reader/Http/Response.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Reader\Http;
 
 use Laminas\Feed\Reader\Exception;

--- a/src/Reader/Http/ResponseInterface.php
+++ b/src/Reader/Http/ResponseInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Reader\Http;
 
 interface ResponseInterface

--- a/src/Reader/Reader.php
+++ b/src/Reader/Reader.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Reader;
 
 use DOMDocument;
@@ -478,7 +480,7 @@ class Reader implements ReaderImportInterface
             $dom = $feed;
         } elseif (is_string($feed) && ! empty($feed)) {
             ErrorHandler::start(E_NOTICE | E_WARNING);
-            ini_set('track_errors', 1);
+            ini_set('track_errors', '1');
             $disableEntityLoaderFlag = self::disableEntityLoader();
             $dom                     = new DOMDocument();
             $status                  = $dom->loadXML($feed);

--- a/src/Reader/Reader.php
+++ b/src/Reader/Reader.php
@@ -605,10 +605,13 @@ class Reader implements ReaderImportInterface
      */
     public static function getExtensionManager()
     {
-        if (! isset(static::$extensionManager)) {
-            static::setExtensionManager(new StandaloneExtensionManager());
+        $manager = static::$extensionManager;
+        if (! $manager instanceof ExtensionManagerInterface) {
+            $manager = new StandaloneExtensionManager();
+            static::setExtensionManager($manager);
         }
-        return static::$extensionManager;
+
+        return $manager;
     }
 
     /**

--- a/src/Reader/ReaderImportInterface.php
+++ b/src/Reader/ReaderImportInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Reader;
 
 interface ReaderImportInterface

--- a/src/Reader/StandaloneExtensionManager.php
+++ b/src/Reader/StandaloneExtensionManager.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Reader;
 
 use Laminas\Feed\Reader\Exception\InvalidArgumentException;

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed;
 
 use function in_array;

--- a/src/Writer/AbstractFeed.php
+++ b/src/Writer/AbstractFeed.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Writer;
 
 use DateTime;

--- a/src/Writer/Deleted.php
+++ b/src/Writer/Deleted.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Writer;
 
 use DateTime;

--- a/src/Writer/Entry.php
+++ b/src/Writer/Entry.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Writer;
 
 use BadMethodCallException;

--- a/src/Writer/Exception/BadMethodCallException.php
+++ b/src/Writer/Exception/BadMethodCallException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Writer\Exception;
 
 use Laminas\Feed\Exception;

--- a/src/Writer/Exception/ExceptionInterface.php
+++ b/src/Writer/Exception/ExceptionInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Writer\Exception;
 
 /**

--- a/src/Writer/Exception/InvalidArgumentException.php
+++ b/src/Writer/Exception/InvalidArgumentException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Writer\Exception;
 
 use Laminas\Feed\Exception;

--- a/src/Writer/Exception/RuntimeException.php
+++ b/src/Writer/Exception/RuntimeException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Writer\Exception;
 
 use Laminas\Feed\Exception;

--- a/src/Writer/Extension/AbstractRenderer.php
+++ b/src/Writer/Extension/AbstractRenderer.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Writer\Extension;
 
 use DOMDocument;

--- a/src/Writer/Extension/Atom/Renderer/Feed.php
+++ b/src/Writer/Extension/Atom/Renderer/Feed.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Writer\Extension\Atom\Renderer;
 
 use DOMDocument;

--- a/src/Writer/Extension/Content/Renderer/Entry.php
+++ b/src/Writer/Extension/Content/Renderer/Entry.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Writer\Extension\Content\Renderer;
 
 use DOMDocument;

--- a/src/Writer/Extension/DublinCore/Renderer/Entry.php
+++ b/src/Writer/Extension/DublinCore/Renderer/Entry.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Writer\Extension\DublinCore\Renderer;
 
 use DOMDocument;

--- a/src/Writer/Extension/DublinCore/Renderer/Feed.php
+++ b/src/Writer/Extension/DublinCore/Renderer/Feed.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Writer\Extension\DublinCore\Renderer;
 
 use DOMDocument;

--- a/src/Writer/Extension/GooglePlayPodcast/Entry.php
+++ b/src/Writer/Extension/GooglePlayPodcast/Entry.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Writer\Extension\GooglePlayPodcast;
 
 use Laminas\Feed\Writer;

--- a/src/Writer/Extension/GooglePlayPodcast/Feed.php
+++ b/src/Writer/Extension/GooglePlayPodcast/Feed.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Writer\Extension\GooglePlayPodcast;
 
 use Laminas\Feed\Uri;

--- a/src/Writer/Extension/GooglePlayPodcast/Renderer/Entry.php
+++ b/src/Writer/Extension/GooglePlayPodcast/Renderer/Entry.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Writer\Extension\GooglePlayPodcast\Renderer;
 
 use DOMDocument;

--- a/src/Writer/Extension/GooglePlayPodcast/Renderer/Feed.php
+++ b/src/Writer/Extension/GooglePlayPodcast/Renderer/Feed.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Writer\Extension\GooglePlayPodcast\Renderer;
 
 use DOMDocument;

--- a/src/Writer/Extension/ITunes/Entry.php
+++ b/src/Writer/Extension/ITunes/Entry.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Writer\Extension\ITunes;
 
 use Laminas\Feed\Uri;

--- a/src/Writer/Extension/ITunes/Feed.php
+++ b/src/Writer/Extension/ITunes/Feed.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Writer\Extension\ITunes;
 
 use Laminas\Feed\Uri;

--- a/src/Writer/Extension/ITunes/Renderer/Entry.php
+++ b/src/Writer/Extension/ITunes/Renderer/Entry.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Writer\Extension\ITunes\Renderer;
 
 use DOMDocument;

--- a/src/Writer/Extension/ITunes/Renderer/Feed.php
+++ b/src/Writer/Extension/ITunes/Renderer/Feed.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Writer\Extension\ITunes\Renderer;
 
 use DOMDocument;

--- a/src/Writer/Extension/PodcastIndex/Entry.php
+++ b/src/Writer/Extension/PodcastIndex/Entry.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Writer\Extension\PodcastIndex;
 
 use Laminas\Feed\Writer;

--- a/src/Writer/Extension/PodcastIndex/Feed.php
+++ b/src/Writer/Extension/PodcastIndex/Feed.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Writer\Extension\PodcastIndex;
 
 use Laminas\Feed\Writer;

--- a/src/Writer/Extension/PodcastIndex/Renderer/Entry.php
+++ b/src/Writer/Extension/PodcastIndex/Renderer/Entry.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Writer\Extension\PodcastIndex\Renderer;
 
 use DOMDocument;

--- a/src/Writer/Extension/PodcastIndex/Renderer/Feed.php
+++ b/src/Writer/Extension/PodcastIndex/Renderer/Feed.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Writer\Extension\PodcastIndex\Renderer;
 
 use DOMDocument;

--- a/src/Writer/Extension/RendererInterface.php
+++ b/src/Writer/Extension/RendererInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Writer\Extension;
 
 use DOMDocument;

--- a/src/Writer/Extension/Slash/Renderer/Entry.php
+++ b/src/Writer/Extension/Slash/Renderer/Entry.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Writer\Extension\Slash\Renderer;
 
 use DOMDocument;

--- a/src/Writer/Extension/Slash/Renderer/Entry.php
+++ b/src/Writer/Extension/Slash/Renderer/Entry.php
@@ -8,6 +8,7 @@ use DOMDocument;
 use DOMElement;
 use Laminas\Feed\Writer\Extension;
 
+use function is_numeric;
 use function strtolower;
 
 class Entry extends Extension\AbstractRenderer
@@ -60,11 +61,11 @@ class Entry extends Extension\AbstractRenderer
     protected function _setCommentCount(DOMDocument $dom, DOMElement $root)
     {
         $count = $this->getDataContainer()->getCommentCount();
-        if (! $count) {
+        if (! $count || ! is_numeric($count)) {
             $count = 0;
         }
         $tcount            = $this->dom->createElement('slash:comments');
-        $tcount->nodeValue = $count;
+        $tcount->nodeValue = (string) $count;
         $root->appendChild($tcount);
         $this->called = true;
     }

--- a/src/Writer/Extension/Threading/Renderer/Entry.php
+++ b/src/Writer/Extension/Threading/Renderer/Entry.php
@@ -8,6 +8,7 @@ use DOMDocument;
 use DOMElement;
 use Laminas\Feed\Writer\Extension;
 
+use function is_numeric;
 use function strtolower;
 
 class Entry extends Extension\AbstractRenderer
@@ -110,11 +111,12 @@ class Entry extends Extension\AbstractRenderer
     protected function _setCommentCount(DOMDocument $dom, DOMElement $root)
     {
         $count = $this->getDataContainer()->getCommentCount();
-        if ($count === null) {
+        if ($count === null || ! is_numeric($count)) {
             return;
         }
+
         $tcount            = $this->dom->createElement('thr:total');
-        $tcount->nodeValue = $count;
+        $tcount->nodeValue = (string) $count;
         $root->appendChild($tcount);
         $this->called = true;
     }

--- a/src/Writer/Extension/Threading/Renderer/Entry.php
+++ b/src/Writer/Extension/Threading/Renderer/Entry.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Writer\Extension\Threading\Renderer;
 
 use DOMDocument;

--- a/src/Writer/Extension/WellFormedWeb/Renderer/Entry.php
+++ b/src/Writer/Extension/WellFormedWeb/Renderer/Entry.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Writer\Extension\WellFormedWeb\Renderer;
 
 use DOMDocument;

--- a/src/Writer/ExtensionManager.php
+++ b/src/Writer/ExtensionManager.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Writer;
 
 use function call_user_func_array;

--- a/src/Writer/ExtensionManagerInterface.php
+++ b/src/Writer/ExtensionManagerInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Writer;
 
 interface ExtensionManagerInterface

--- a/src/Writer/ExtensionPluginManager.php
+++ b/src/Writer/ExtensionPluginManager.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Writer;
 
 use Laminas\ServiceManager\AbstractPluginManager;

--- a/src/Writer/ExtensionPluginManager.php
+++ b/src/Writer/ExtensionPluginManager.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Laminas\Feed\Writer;
 
 use Laminas\ServiceManager\AbstractPluginManager;
+use Laminas\ServiceManager\ConfigInterface;
 use Laminas\ServiceManager\Exception\InvalidServiceException;
 use Laminas\ServiceManager\Factory\InvokableFactory;
 
@@ -18,6 +19,8 @@ use function substr;
  * Plugin manager implementation for feed writer extensions
  *
  * Validation checks that we have an Entry, Feed, or Extension\AbstractRenderer.
+ *
+ * @psalm-import-type FactoriesConfigurationType from ConfigInterface
  */
 class ExtensionPluginManager extends AbstractPluginManager implements ExtensionManagerInterface
 {
@@ -169,7 +172,7 @@ class ExtensionPluginManager extends AbstractPluginManager implements ExtensionM
     /**
      * Factories for default set of extension classes
      *
-     * @var array<array-key, callable|string>
+     * @var FactoriesConfigurationType
      */
     protected $factories = [
         Extension\Atom\Renderer\Feed::class               => InvokableFactory::class,
@@ -234,7 +237,7 @@ class ExtensionPluginManager extends AbstractPluginManager implements ExtensionM
      *
      * Checks that the extension loaded is of a valid type.
      *
-     * @param  object $instance
+     * @param  mixed $instance
      * @return void
      * @throws InvalidServiceException If invalid.
      */
@@ -245,12 +248,12 @@ class ExtensionPluginManager extends AbstractPluginManager implements ExtensionM
             return;
         }
 
-        if ('Feed' === substr(get_class($instance), -4)) {
+        if (is_object($instance) && 'Feed' === substr(get_class($instance), -4)) {
             // we're okay
             return;
         }
 
-        if ('Entry' === substr(get_class($instance), -5)) {
+        if (is_object($instance) && 'Entry' === substr(get_class($instance), -5)) {
             // we're okay
             return;
         }

--- a/src/Writer/ExtensionPluginManager.php
+++ b/src/Writer/ExtensionPluginManager.php
@@ -131,23 +131,21 @@ class ExtensionPluginManager extends AbstractPluginManager implements ExtensionM
         'WellFormedWeb\Renderer\Entry'     => Extension\WellFormedWeb\Renderer\Entry::class,
 
         // Legacy Zend Framework aliases
-        // phpcs:disable SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly.ReferenceViaFullyQualifiedName
-        \Zend\Feed\Writer\Extension\Atom\Renderer\Feed::class               => Extension\Atom\Renderer\Feed::class,
-        \Zend\Feed\Writer\Extension\Content\Renderer\Entry::class           => Extension\Content\Renderer\Entry::class,
-        \Zend\Feed\Writer\Extension\DublinCore\Renderer\Entry::class        => Extension\DublinCore\Renderer\Entry::class,
-        \Zend\Feed\Writer\Extension\DublinCore\Renderer\Feed::class         => Extension\DublinCore\Renderer\Feed::class,
-        \Zend\Feed\Writer\Extension\GooglePlayPodcast\Entry::class          => Extension\GooglePlayPodcast\Entry::class,
-        \Zend\Feed\Writer\Extension\GooglePlayPodcast\Feed::class           => Extension\GooglePlayPodcast\Feed::class,
-        \Zend\Feed\Writer\Extension\GooglePlayPodcast\Renderer\Entry::class => Extension\GooglePlayPodcast\Renderer\Entry::class,
-        \Zend\Feed\Writer\Extension\GooglePlayPodcast\Renderer\Feed::class  => Extension\GooglePlayPodcast\Renderer\Feed::class,
-        \Zend\Feed\Writer\Extension\ITunes\Entry::class                     => Extension\ITunes\Entry::class,
-        \Zend\Feed\Writer\Extension\ITunes\Feed::class                      => Extension\ITunes\Feed::class,
-        \Zend\Feed\Writer\Extension\ITunes\Renderer\Entry::class            => Extension\ITunes\Renderer\Entry::class,
-        \Zend\Feed\Writer\Extension\ITunes\Renderer\Feed::class             => Extension\ITunes\Renderer\Feed::class,
-        \Zend\Feed\Writer\Extension\Slash\Renderer\Entry::class             => Extension\Slash\Renderer\Entry::class,
-        \Zend\Feed\Writer\Extension\Threading\Renderer\Entry::class         => Extension\Threading\Renderer\Entry::class,
-        \Zend\Feed\Writer\Extension\WellFormedWeb\Renderer\Entry::class     => Extension\WellFormedWeb\Renderer\Entry::class,
-        // phpcs:enable SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly.ReferenceViaFullyQualifiedName
+        'Zend\Feed\Writer\Extension\Atom\Renderer\Feed'               => Extension\Atom\Renderer\Feed::class,
+        'Zend\Feed\Writer\Extension\Content\Renderer\Entry'           => Extension\Content\Renderer\Entry::class,
+        'Zend\Feed\Writer\Extension\DublinCore\Renderer\Entry'        => Extension\DublinCore\Renderer\Entry::class,
+        'Zend\Feed\Writer\Extension\DublinCore\Renderer\Feed'         => Extension\DublinCore\Renderer\Feed::class,
+        'Zend\Feed\Writer\Extension\GooglePlayPodcast\Entry'          => Extension\GooglePlayPodcast\Entry::class,
+        'Zend\Feed\Writer\Extension\GooglePlayPodcast\Feed'           => Extension\GooglePlayPodcast\Feed::class,
+        'Zend\Feed\Writer\Extension\GooglePlayPodcast\Renderer\Entry' => Extension\GooglePlayPodcast\Renderer\Entry::class,
+        'Zend\Feed\Writer\Extension\GooglePlayPodcast\Renderer\Feed'  => Extension\GooglePlayPodcast\Renderer\Feed::class,
+        'Zend\Feed\Writer\Extension\ITunes\Entry'                     => Extension\ITunes\Entry::class,
+        'Zend\Feed\Writer\Extension\ITunes\Feed'                      => Extension\ITunes\Feed::class,
+        'Zend\Feed\Writer\Extension\ITunes\Renderer\Entry'            => Extension\ITunes\Renderer\Entry::class,
+        'Zend\Feed\Writer\Extension\ITunes\Renderer\Feed'             => Extension\ITunes\Renderer\Feed::class,
+        'Zend\Feed\Writer\Extension\Slash\Renderer\Entry'             => Extension\Slash\Renderer\Entry::class,
+        'Zend\Feed\Writer\Extension\Threading\Renderer\Entry'         => Extension\Threading\Renderer\Entry::class,
+        'Zend\Feed\Writer\Extension\WellFormedWeb\Renderer\Entry'     => Extension\WellFormedWeb\Renderer\Entry::class,
 
         // v2 normalized FQCNs
         'zendfeedwriterextensionatomrendererfeed'               => Extension\Atom\Renderer\Feed::class,

--- a/src/Writer/Feed.php
+++ b/src/Writer/Feed.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Writer;
 
 use Countable;

--- a/src/Writer/FeedFactory.php
+++ b/src/Writer/FeedFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Writer;
 
 use Traversable;

--- a/src/Writer/Renderer/AbstractRenderer.php
+++ b/src/Writer/Renderer/AbstractRenderer.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Writer\Renderer;
 
 use DOMDocument;

--- a/src/Writer/Renderer/Entry/Atom.php
+++ b/src/Writer/Renderer/Entry/Atom.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Writer\Renderer\Entry;
 
 use DateTime;
@@ -19,9 +21,6 @@ use function preg_replace;
 use function str_replace;
 use function strlen;
 use function strtotime;
-use function version_compare;
-
-use const PHP_VERSION;
 
 class Atom extends Renderer\AbstractRenderer implements Renderer\RendererInterface
 {
@@ -342,8 +341,7 @@ class Atom extends Renderer\AbstractRenderer implements Renderer\RendererInterfa
         $element = $dom->createElement('content');
         $element->setAttribute('type', 'xhtml');
         $xhtmlElement = $this->_loadXhtml($content);
-        $deep         = version_compare(PHP_VERSION, '7', 'ge') ? 1 : true;
-        $xhtml        = $dom->importNode($xhtmlElement, $deep);
+        $xhtml        = $dom->importNode($xhtmlElement, true);
         $element->appendChild($xhtml);
         $root->appendChild($element);
     }

--- a/src/Writer/Renderer/Entry/Atom/Deleted.php
+++ b/src/Writer/Renderer/Entry/Atom/Deleted.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Writer\Renderer\Entry\Atom;
 
 use DateTime;

--- a/src/Writer/Renderer/Entry/AtomDeleted.php
+++ b/src/Writer/Renderer/Entry/AtomDeleted.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Writer\Renderer\Entry;
 
 use DateTime;

--- a/src/Writer/Renderer/Entry/Rss.php
+++ b/src/Writer/Renderer/Entry/Rss.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Writer\Renderer\Entry;
 
 use DateTime;
@@ -218,7 +220,7 @@ class Rss extends Renderer\AbstractRenderer implements Renderer\RendererInterfac
         }
         $enclosure = $this->dom->createElement('enclosure');
         $enclosure->setAttribute('type', $data['type']);
-        $enclosure->setAttribute('length', $data['length']);
+        $enclosure->setAttribute('length', (string) $data['length']);
         $enclosure->setAttribute('url', $data['uri']);
         $root->appendChild($enclosure);
     }

--- a/src/Writer/Renderer/Feed/AbstractAtom.php
+++ b/src/Writer/Renderer/Feed/AbstractAtom.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Writer\Renderer\Feed;
 
 use DateTime;

--- a/src/Writer/Renderer/Feed/Atom.php
+++ b/src/Writer/Renderer/Feed/Atom.php
@@ -1,14 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Writer\Renderer\Feed;
 
 use DOMDocument;
 use Laminas\Feed\Writer;
 use Laminas\Feed\Writer\Renderer;
-
-use function version_compare;
-
-use const PHP_VERSION;
 
 class Atom extends AbstractAtom implements Renderer\RendererInterface
 {
@@ -80,8 +78,7 @@ class Atom extends AbstractAtom implements Renderer\RendererInterface
             $renderer->setRootElement($this->dom->documentElement);
             $renderer->render();
             $element  = $renderer->getElement();
-            $deep     = version_compare(PHP_VERSION, '7', 'ge') ? 1 : true;
-            $imported = $this->dom->importNode($element, $deep);
+            $imported = $this->dom->importNode($element, true);
             $root->appendChild($imported);
         }
         return $this;

--- a/src/Writer/Renderer/Feed/Atom/AbstractAtom.php
+++ b/src/Writer/Renderer/Feed/Atom/AbstractAtom.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Writer\Renderer\Feed\Atom;
 
 use DateTime;

--- a/src/Writer/Renderer/Feed/Atom/Source.php
+++ b/src/Writer/Renderer/Feed/Atom/Source.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Writer\Renderer\Feed\Atom;
 
 use DOMDocument;

--- a/src/Writer/Renderer/Feed/AtomSource.php
+++ b/src/Writer/Renderer/Feed/AtomSource.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Writer\Renderer\Feed;
 
 use DOMDocument;

--- a/src/Writer/Renderer/Feed/Rss.php
+++ b/src/Writer/Renderer/Feed/Rss.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Writer\Renderer\Feed;
 
 use DateTime;
@@ -13,9 +15,6 @@ use Laminas\Feed\Writer\Version;
 use function array_key_exists;
 use function ctype_digit;
 use function is_string;
-use function version_compare;
-
-use const PHP_VERSION;
 
 class Rss extends Renderer\AbstractRenderer implements Renderer\RendererInterface
 {
@@ -78,8 +77,7 @@ class Rss extends Renderer\AbstractRenderer implements Renderer\RendererInterfac
             $renderer->setRootElement($this->dom->documentElement);
             $renderer->render();
             $element  = $renderer->getElement();
-            $deep     = version_compare(PHP_VERSION, '7', 'ge') ? 1 : true;
-            $imported = $this->dom->importNode($element, $deep);
+            $imported = $this->dom->importNode($element, true);
             $channel->appendChild($imported);
         }
         return $this;

--- a/src/Writer/Renderer/RendererInterface.php
+++ b/src/Writer/Renderer/RendererInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Writer\Renderer;
 
 use DOMDocument;

--- a/src/Writer/Source.php
+++ b/src/Writer/Source.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Writer;
 
 class Source extends AbstractFeed

--- a/src/Writer/StandaloneExtensionManager.php
+++ b/src/Writer/StandaloneExtensionManager.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Writer;
 
 use Laminas\Feed\Writer\Exception\InvalidArgumentException;

--- a/src/Writer/Version.php
+++ b/src/Writer/Version.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Writer;
 
 // phpcs:ignore WebimpressCodingStandard.NamingConventions.AbstractClass.Prefix

--- a/src/Writer/Writer.php
+++ b/src/Writer/Writer.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laminas\Feed\Writer;
 
 use function in_array;

--- a/test/PubSubHubbub/AbstractCallbackTest.php
+++ b/test/PubSubHubbub/AbstractCallbackTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaminasTest\Feed\PubSubHubbub;
 
 use PHPUnit\Framework\TestCase;

--- a/test/PubSubHubbub/ClientNotReset.php
+++ b/test/PubSubHubbub/ClientNotReset.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaminasTest\Feed\PubSubHubbub;
 
 use Laminas\Http\Client as HttpClient;

--- a/test/PubSubHubbub/Model/SubscriptionTest.php
+++ b/test/PubSubHubbub/Model/SubscriptionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaminasTest\Feed\PubSubHubbub\Model;
 
 use DateTime;

--- a/test/PubSubHubbub/PubSubHubbubTest.php
+++ b/test/PubSubHubbub/PubSubHubbubTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaminasTest\Feed\PubSubHubbub;
 
 use Laminas\Feed\PubSubHubbub\PubSubHubbub;

--- a/test/PubSubHubbub/PublisherTest.php
+++ b/test/PubSubHubbub/PublisherTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaminasTest\Feed\PubSubHubbub;
 
 use Laminas\Feed\PubSubHubbub\Exception\ExceptionInterface;

--- a/test/PubSubHubbub/Subscriber/CallbackTest.php
+++ b/test/PubSubHubbub/Subscriber/CallbackTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaminasTest\Feed\PubSubHubbub\Subscriber;
 
 use ArrayObject;

--- a/test/PubSubHubbub/SubscriberHttpTest.php
+++ b/test/PubSubHubbub/SubscriberHttpTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaminasTest\Feed\PubSubHubbub;
 
 use Laminas\Feed\PubSubHubbub\Model\Subscription;

--- a/test/PubSubHubbub/SubscriberTest.php
+++ b/test/PubSubHubbub/SubscriberTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaminasTest\Feed\PubSubHubbub;
 
 use Laminas\Db\Adapter\Adapter;

--- a/test/PubSubHubbub/TestAsset/Callback.php
+++ b/test/PubSubHubbub/TestAsset/Callback.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaminasTest\Feed\PubSubHubbub\TestAsset;
 
 use Laminas\Feed\PubSubHubbub\AbstractCallback;

--- a/test/PubSubHubbub/_files/testRawPostData.php
+++ b/test/PubSubHubbub/_files/testRawPostData.php
@@ -1,3 +1,5 @@
 <?php
 
+declare(strict_types=1);
+
 readfile('php://input');

--- a/test/Reader/Entry/AtomStandaloneEntryTest.php
+++ b/test/Reader/Entry/AtomStandaloneEntryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaminasTest\Feed\Reader\Entry;
 
 use DateTime;

--- a/test/Reader/Entry/AtomTest.php
+++ b/test/Reader/Entry/AtomTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaminasTest\Feed\Reader\Entry;
 
 use DateTime;

--- a/test/Reader/Entry/CommonTest.php
+++ b/test/Reader/Entry/CommonTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaminasTest\Feed\Reader\Entry;
 
 use DOMDocument;

--- a/test/Reader/ExtensionPluginManagerCompatibilityTest.php
+++ b/test/Reader/ExtensionPluginManagerCompatibilityTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaminasTest\Feed\Reader;
 
 use Laminas\Feed\Reader\Exception\InvalidArgumentException;

--- a/test/Reader/Feed/AtomSourceTest.php
+++ b/test/Reader/Feed/AtomSourceTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaminasTest\Feed\Reader\Feed;
 
 use DateTime;

--- a/test/Reader/Feed/AtomTest.php
+++ b/test/Reader/Feed/AtomTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaminasTest\Feed\Reader\Feed;
 
 use DateTime;

--- a/test/Reader/Feed/CommonTest.php
+++ b/test/Reader/Feed/CommonTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaminasTest\Feed\Reader\Feed;
 
 use DOMDocument;

--- a/test/Reader/FeedSetTest.php
+++ b/test/Reader/FeedSetTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaminasTest\Feed\Reader;
 
 use Laminas\Feed\Reader\FeedSet;

--- a/test/Reader/Http/LaminasHttpClientDecoratorTest.php
+++ b/test/Reader/Http/LaminasHttpClientDecoratorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaminasTest\Feed\Reader\Http;
 
 use Laminas\Feed\Reader\Exception\InvalidArgumentException;

--- a/test/Reader/Http/Psr7ResponseDecoratorTest.php
+++ b/test/Reader/Http/Psr7ResponseDecoratorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaminasTest\Feed\Reader\Http;
 
 use Laminas\Feed\Reader\Http\HeaderAwareResponseInterface;

--- a/test/Reader/Http/ResponseTest.php
+++ b/test/Reader/Http/ResponseTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaminasTest\Feed\Reader\Http;
 
 use Laminas\Feed\Reader\Exception\InvalidArgumentException;

--- a/test/Reader/Integration/GooglePlayPodcastRss2Test.php
+++ b/test/Reader/Integration/GooglePlayPodcastRss2Test.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaminasTest\Feed\Reader\Integration;
 
 use Laminas\Feed\Reader;

--- a/test/Reader/Integration/HOnlineComAtom10Test.php
+++ b/test/Reader/Integration/HOnlineComAtom10Test.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaminasTest\Feed\Reader\Integration;
 
 use Laminas\Feed\Reader;

--- a/test/Reader/Integration/LautDeRdfTest.php
+++ b/test/Reader/Integration/LautDeRdfTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaminasTest\Feed\Reader\Integration;
 
 use Laminas\Feed\Reader;

--- a/test/Reader/Integration/PodcastIndexRss2Test.php
+++ b/test/Reader/Integration/PodcastIndexRss2Test.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaminasTest\Feed\Reader\Integration;
 
 use Laminas\Feed\Reader;

--- a/test/Reader/Integration/PodcastRss2Test.php
+++ b/test/Reader/Integration/PodcastRss2Test.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaminasTest\Feed\Reader\Integration;
 
 use Laminas\Feed\Reader;

--- a/test/Reader/Integration/WordpressAtom10Test.php
+++ b/test/Reader/Integration/WordpressAtom10Test.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaminasTest\Feed\Reader\Integration;
 
 use Laminas\Feed\Reader;

--- a/test/Reader/Integration/WordpressRss2DcAtomTest.php
+++ b/test/Reader/Integration/WordpressRss2DcAtomTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaminasTest\Feed\Reader\Integration;
 
 use Laminas\Feed\Reader;

--- a/test/Reader/ReaderTest.php
+++ b/test/Reader/ReaderTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace LaminasTest\Feed\Reader;
 
-use Interop\Container\ContainerInterface;
 use Laminas\Feed\Reader;
 use Laminas\Feed\Reader\Exception\InvalidArgumentException;
 use Laminas\Feed\Reader\Feed\FeedInterface;
@@ -17,6 +16,7 @@ use Laminas\Http\Response as HttpResponse;
 use My\Extension\JungleBooks\Entry;
 use My\Extension\JungleBooks\Feed;
 use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
 use stdClass;
 
 use function array_reduce;

--- a/test/Reader/ReaderTest.php
+++ b/test/Reader/ReaderTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaminasTest\Feed\Reader;
 
 use Interop\Container\ContainerInterface;

--- a/test/Reader/StandaloneExtensionManagerTest.php
+++ b/test/Reader/StandaloneExtensionManagerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaminasTest\Feed\Reader;
 
 use Laminas\Feed\Reader\Exception\InvalidArgumentException;

--- a/test/Reader/TestAsset/CustomExtensionManager.php
+++ b/test/Reader/TestAsset/CustomExtensionManager.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaminasTest\Feed\Reader\TestAsset;
 
 use Laminas\Feed\Reader\Extension;

--- a/test/Reader/TestAsset/Psr7Stream.php
+++ b/test/Reader/TestAsset/Psr7Stream.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaminasTest\Feed\Reader\TestAsset;
 
 /**

--- a/test/Reader/_files/My/Extension/JungleBooks/Entry.php
+++ b/test/Reader/_files/My/Extension/JungleBooks/Entry.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace My\Extension\JungleBooks;
 
 use Laminas\Feed\Reader\Extension;

--- a/test/Reader/_files/My/Extension/JungleBooks/Feed.php
+++ b/test/Reader/_files/My/Extension/JungleBooks/Feed.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace My\Extension\JungleBooks;
 
 use Laminas\Feed\Reader\Extension;

--- a/test/Writer/DeletedTest.php
+++ b/test/Writer/DeletedTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaminasTest\Feed\Writer;
 
 use DateTime;

--- a/test/Writer/EntryTest.php
+++ b/test/Writer/EntryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaminasTest\Feed\Writer;
 
 use DateTime;

--- a/test/Writer/Extension/GooglePlayPodcast/EntryTest.php
+++ b/test/Writer/Extension/GooglePlayPodcast/EntryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaminasTest\Feed\Writer\Extension\GooglePlayPodcast;
 
 use Laminas\Feed\Writer;

--- a/test/Writer/Extension/GooglePlayPodcast/FeedTest.php
+++ b/test/Writer/Extension/GooglePlayPodcast/FeedTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaminasTest\Feed\Writer\Extension\GooglePlayPodcast;
 
 use Laminas\Feed\Writer;

--- a/test/Writer/Extension/ITunes/EntryTest.php
+++ b/test/Writer/Extension/ITunes/EntryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaminasTest\Feed\Writer\Extension\ITunes;
 
 use Laminas\Feed\Writer;

--- a/test/Writer/Extension/ITunes/FeedTest.php
+++ b/test/Writer/Extension/ITunes/FeedTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaminasTest\Feed\Writer\Extension\ITunes;
 
 use Laminas\Feed\Writer;

--- a/test/Writer/Extension/PodcastIndex/EntryTest.php
+++ b/test/Writer/Extension/PodcastIndex/EntryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaminasTest\Feed\Writer\Extension\PodcastIndex;
 
 use Laminas\Feed\Writer;

--- a/test/Writer/Extension/PodcastIndex/FeedTest.php
+++ b/test/Writer/Extension/PodcastIndex/FeedTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaminasTest\Feed\Writer\Extension\PodcastIndex;
 
 use Laminas\Feed\Writer;

--- a/test/Writer/ExtensionPluginManagerCompatibilityTest.php
+++ b/test/Writer/ExtensionPluginManagerCompatibilityTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaminasTest\Feed\Writer;
 
 use Laminas\Feed\Writer\Exception\InvalidArgumentException;

--- a/test/Writer/FeedFactoryTest.php
+++ b/test/Writer/FeedFactoryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaminasTest\Feed\Writer;
 
 use DateTime;

--- a/test/Writer/FeedTest.php
+++ b/test/Writer/FeedTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaminasTest\Feed\Writer;
 
 use DateTime;

--- a/test/Writer/Renderer/Entry/AtomTest.php
+++ b/test/Writer/Renderer/Entry/AtomTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaminasTest\Feed\Writer\Renderer\Entry;
 
 use Laminas\Feed\Reader;

--- a/test/Writer/Renderer/Entry/RssTest.php
+++ b/test/Writer/Renderer/Entry/RssTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaminasTest\Feed\Writer\Renderer\Entry;
 
 use Laminas\Feed\Reader;

--- a/test/Writer/Renderer/Feed/AtomTest.php
+++ b/test/Writer/Renderer/Feed/AtomTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaminasTest\Feed\Writer\Renderer\Feed;
 
 use DateTime;

--- a/test/Writer/Renderer/Feed/RssTest.php
+++ b/test/Writer/Renderer/Feed/RssTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaminasTest\Feed\Writer\Renderer\Feed;
 
 use DateTime;

--- a/test/Writer/StandaloneExtensionManagerTest.php
+++ b/test/Writer/StandaloneExtensionManagerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaminasTest\Feed\Writer;
 
 use Laminas\Feed\Writer\Exception\InvalidArgumentException;

--- a/test/Writer/TestAsset/CustomExtensionManager.php
+++ b/test/Writer/TestAsset/CustomExtensionManager.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LaminasTest\Feed\Writer\TestAsset;
 
 use Laminas\Feed\Writer\Exception\InvalidArgumentException;


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| QA            | yes

### Description

- Adds strict types
- Fixes calls to DomDocument#importNode to use `bool` for deep parameter
- Drops support for PHP 7.3
- Moves `laminas-servicemanager` into `require` at 3.14 minimum, making it a hard dependency and allowing the removal of `Interop\Container` and the ZF Bridge