### PR TITLE
Adjusted built-in plugin managers for `psr/container:^2` compatibility

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1359,12 +1359,20 @@
     </MixedReturnStatement>
   </file>
   <file src="src/Reader/ExtensionManager.php">
+    <DeprecatedInterface occurrences="1">
+      <code>ExtensionManager</code>
+    </DeprecatedInterface>
     <MixedInferredReturnType occurrences="1">
       <code>Extension\AbstractEntry|Extension\AbstractFeed</code>
     </MixedInferredReturnType>
     <MixedReturnStatement occurrences="1">
       <code>$this-&gt;pluginManager-&gt;get($extension)</code>
     </MixedReturnStatement>
+  </file>
+  <file src="src/Reader/ExtensionPluginManager.php">
+    <DeprecatedInterface occurrences="1">
+      <code>ExtensionPluginManager</code>
+    </DeprecatedInterface>
   </file>
   <file src="src/Reader/Feed/AbstractFeed.php">
     <InvalidScalarArgument occurrences="1">
@@ -1842,6 +1850,11 @@
       <code>trim($responseHtml)</code>
       <code>trim($string)</code>
     </ArgumentTypeCoercion>
+    <DeprecatedClass occurrences="3">
+      <code>ExtensionManagerInterface</code>
+      <code>ExtensionManagerInterface</code>
+      <code>null|ExtensionManagerInterface</code>
+    </DeprecatedClass>
     <DocblockTypeContradiction occurrences="3">
       <code>! static::$httpClient</code>
       <code>gettype($response)</code>
@@ -1900,6 +1913,9 @@
     </UndefinedVariable>
   </file>
   <file src="src/Reader/StandaloneExtensionManager.php">
+    <DeprecatedInterface occurrences="1">
+      <code>StandaloneExtensionManager</code>
+    </DeprecatedInterface>
     <LessSpecificReturnStatement occurrences="1">
       <code>new $class()</code>
     </LessSpecificReturnStatement>
@@ -2627,12 +2643,24 @@
     </TypeDoesNotContainType>
   </file>
   <file src="src/Writer/ExtensionManager.php">
+    <DeprecatedClass occurrences="2">
+      <code>?ExtensionManagerInterface</code>
+      <code>ExtensionManagerInterface</code>
+    </DeprecatedClass>
+    <DeprecatedInterface occurrences="1">
+      <code>ExtensionManager</code>
+    </DeprecatedInterface>
     <MixedInferredReturnType occurrences="1">
       <code>Extension\AbstractRenderer</code>
     </MixedInferredReturnType>
     <MixedReturnStatement occurrences="1">
       <code>$this-&gt;pluginManager-&gt;get($extension)</code>
     </MixedReturnStatement>
+  </file>
+  <file src="src/Writer/ExtensionPluginManager.php">
+    <DeprecatedInterface occurrences="1">
+      <code>ExtensionPluginManager</code>
+    </DeprecatedInterface>
   </file>
   <file src="src/Writer/Feed.php">
     <InvalidStringClass occurrences="1">
@@ -2769,15 +2797,18 @@
       <code>$data['type']</code>
       <code>$data['uri']</code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="6">
+    <MixedAssignment occurrences="7">
       <code>$cat</code>
       <code>$content</code>
       <code>$data</code>
       <code>$data</code>
       <code>$ext</code>
       <code>$source</code>
+      <code>$tidy</code>
     </MixedAssignment>
-    <MixedMethodCall occurrences="4">
+    <MixedMethodCall occurrences="6">
+      <code>cleanRepair</code>
+      <code>parseString</code>
       <code>render</code>
       <code>setDomDocument</code>
       <code>setRootElement</code>
@@ -3292,6 +3323,9 @@
     </PropertyNotSetInConstructor>
   </file>
   <file src="src/Writer/StandaloneExtensionManager.php">
+    <DeprecatedInterface occurrences="1">
+      <code>StandaloneExtensionManager</code>
+    </DeprecatedInterface>
     <MixedMethodCall occurrences="1">
       <code>new $class()</code>
     </MixedMethodCall>
@@ -3300,6 +3334,11 @@
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="src/Writer/Writer.php">
+    <DeprecatedClass occurrences="3">
+      <code>ExtensionManagerInterface</code>
+      <code>ExtensionManagerInterface</code>
+      <code>ExtensionManagerInterface</code>
+    </DeprecatedClass>
     <MixedArgument occurrences="4">
       <code>static::$extensions['entry']</code>
       <code>static::$extensions['entryRenderer']</code>
@@ -4843,6 +4882,9 @@
     </UndefinedInterfaceMethod>
   </file>
   <file src="test/Reader/TestAsset/CustomExtensionManager.php">
+    <DeprecatedInterface occurrences="1">
+      <code>CustomExtensionManager</code>
+    </DeprecatedInterface>
     <LessSpecificReturnStatement occurrences="1">
       <code>new $class()</code>
     </LessSpecificReturnStatement>
@@ -5277,6 +5319,9 @@
     </MixedAssignment>
   </file>
   <file src="test/Writer/TestAsset/CustomExtensionManager.php">
+    <DeprecatedInterface occurrences="1">
+      <code>CustomExtensionManager</code>
+    </DeprecatedInterface>
     <MixedMethodCall occurrences="1">
       <code>new $class()</code>
     </MixedMethodCall>

--- a/src/Reader/ExtensionManager.php
+++ b/src/Reader/ExtensionManager.php
@@ -12,6 +12,9 @@ use function sprintf;
  * Default implementation of ExtensionManagerInterface
  *
  * Decorator of ExtensionPluginManager.
+ *
+ * @final this class wasn't designed to be inherited from, but we can't assume that consumers haven't already
+ *        extended it, therefore we cannot add the final marker without a new major release.
  */
 class ExtensionManager implements ExtensionManagerInterface
 {
@@ -67,9 +70,8 @@ class ExtensionManager implements ExtensionManagerInterface
      * Do we have the named extension?
      *
      * @param  string $extension
-     * @return bool
      */
-    public function has($extension)
+    public function has($extension): bool
     {
         return $this->pluginManager->has($extension);
     }

--- a/src/Reader/ExtensionManagerInterface.php
+++ b/src/Reader/ExtensionManagerInterface.php
@@ -4,21 +4,17 @@ declare(strict_types=1);
 
 namespace Laminas\Feed\Reader;
 
+/**
+ * This interface exists to provide type inference for container implementations that retrieve extensions.
+ * Methods have been migrated from declared in PHP to being part of the docblock signature,
+ * in order to avoid conflicting with `psr/container` signatures, which are way stricter, and
+ * therefore incompatible with this one.
+ *
+ * @deprecated this interface is no longer needed, and shouldn't be relied upon
+ *
+ * @method has(string $extension): bool
+ * @method get(string $extension): mixed
+ */
 interface ExtensionManagerInterface
 {
-    /**
-     * Do we have the extension?
-     *
-     * @param  string $extension
-     * @return bool
-     */
-    public function has($extension);
-
-    /**
-     * Retrieve the extension
-     *
-     * @param  string $extension
-     * @return mixed
-     */
-    public function get($extension);
 }

--- a/src/Reader/ExtensionPluginManager.php
+++ b/src/Reader/ExtensionPluginManager.php
@@ -24,6 +24,8 @@ use function sprintf;
  * Extension\AbstractFeed.
  *
  * @psalm-import-type FactoriesConfigurationType from ConfigInterface
+ * @final this class wasn't designed to be inherited from, but we can't assume that consumers haven't already
+ *        extended it, therefore we cannot add the final marker without a new major release.
  */
 class ExtensionPluginManager extends AbstractPluginManager implements ExtensionManagerInterface
 {

--- a/src/Reader/StandaloneExtensionManager.php
+++ b/src/Reader/StandaloneExtensionManager.php
@@ -11,6 +11,10 @@ use function is_a;
 use function is_string;
 use function sprintf;
 
+/**
+ * @final this class wasn't designed to be inherited from, but we can't assume that consumers haven't already
+ *        extended it, therefore we cannot add the final marker without a new major release.
+ */
 class StandaloneExtensionManager implements ExtensionManagerInterface
 {
     /** @var array<string, class-string> */
@@ -38,9 +42,8 @@ class StandaloneExtensionManager implements ExtensionManagerInterface
      * Do we have the extension?
      *
      * @param  string $extension
-     * @return bool
      */
-    public function has($extension)
+    public function has($extension): bool
     {
         return array_key_exists($extension, $this->extensions);
     }

--- a/src/Writer/ExtensionManagerInterface.php
+++ b/src/Writer/ExtensionManagerInterface.php
@@ -4,21 +4,17 @@ declare(strict_types=1);
 
 namespace Laminas\Feed\Writer;
 
+/**
+ * This interface exists to provide type inference for container implementations that retrieve extensions.
+ * Methods have been migrated from declared in PHP to being part of the docblock signature,
+ * in order to avoid conflicting with `psr/container` signatures, which are way stricter, and
+ * therefore incompatible with this one.
+ *
+ * @deprecated this interface is no longer needed, and shouldn't be relied upon
+ *
+ * @method has(string $extension): bool
+ * @method get(string $extension): mixed
+ */
 interface ExtensionManagerInterface
 {
-    /**
-     * Do we have the extension?
-     *
-     * @param  string $extension
-     * @return bool
-     */
-    public function has($extension);
-
-    /**
-     * Retrieve the extension
-     *
-     * @param  string $extension
-     * @return mixed
-     */
-    public function get($extension);
 }

--- a/test/Reader/TestAsset/CustomExtensionManager.php
+++ b/test/Reader/TestAsset/CustomExtensionManager.php
@@ -12,7 +12,7 @@ use function array_key_exists;
 /**
  * Standalone extension manager that omits any extensions added after the 2.9 series.
  */
-class CustomExtensionManager implements ExtensionManagerInterface
+final class CustomExtensionManager implements ExtensionManagerInterface
 {
     /** @var array<string, class-string> */
     private $extensions = [
@@ -35,9 +35,8 @@ class CustomExtensionManager implements ExtensionManagerInterface
      * Do we have the extension?
      *
      * @param  string $extension
-     * @return bool
      */
-    public function has($extension)
+    public function has($extension): bool
     {
         return array_key_exists($extension, $this->extensions);
     }


### PR DESCRIPTION
This counts as a minor BC break (which is already inherent of switching to `psr/container:^2`),
since the return type of `ExtensionManagerInterface#has()` now requires a `bool` return type,
and so will further child classes.

To mitigate this BC break, the methods for the two `ExtensionManagerInterface` types have been
moved to the docblock definitions, reducing the chance of inheritance-based BC breaks.

The two `ExtensionManagerInterface` have also been deprecated, since they came from a time where
`Zend_Loader` (in `zendframework/zendframework1`) was still a thing, whereas `laminas/laminas-servicemanager`
currently provides healthy abstractions for building objects of a specific category, by using
cleaner dependency injection patterns.


|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | yes (-ish - better to break inheritance, than break the library completely)
| New Feature   | no
| RFC           | no
| QA            | no
