### PR TITLE
Fix strict_types errors in DOMDocument::createTextNode()

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -2223,9 +2223,8 @@
     </MixedMethodCall>
   </file>
   <file src="src/Writer/Extension/DublinCore/Renderer/Entry.php">
-    <MixedArgument occurrences="2">
+    <MixedArgument occurrences="1">
       <code>$data</code>
-      <code>$data['name']</code>
     </MixedArgument>
     <MixedAssignment occurrences="2">
       <code>$authors</code>
@@ -2239,9 +2238,8 @@
     </TypeDoesNotContainType>
   </file>
   <file src="src/Writer/Extension/DublinCore/Renderer/Feed.php">
-    <MixedArgument occurrences="2">
+    <MixedArgument occurrences="1">
       <code>$data</code>
-      <code>$data['name']</code>
     </MixedArgument>
     <MixedAssignment occurrences="2">
       <code>$authors</code>
@@ -2293,11 +2291,6 @@
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="src/Writer/Extension/GooglePlayPodcast/Renderer/Entry.php">
-    <MixedArgument occurrences="3">
-      <code>$block</code>
-      <code>$description</code>
-      <code>$explicit</code>
-    </MixedArgument>
     <MixedAssignment occurrences="3">
       <code>$block</code>
       <code>$description</code>
@@ -2310,12 +2303,8 @@
     </MixedMethodCall>
   </file>
   <file src="src/Writer/Extension/GooglePlayPodcast/Renderer/Feed.php">
-    <MixedArgument occurrences="8">
-      <code>$author</code>
-      <code>$block</code>
+    <MixedArgument occurrences="4">
       <code>$cat</code>
-      <code>$description</code>
-      <code>$explicit</code>
       <code>$image</code>
       <code>$key</code>
       <code>$subcat</code>
@@ -2426,19 +2415,9 @@
     </TypeDoesNotContainType>
   </file>
   <file src="src/Writer/Extension/ITunes/Renderer/Entry.php">
-    <MixedArgument occurrences="12">
-      <code>$author</code>
-      <code>$block</code>
-      <code>$duration</code>
-      <code>$episode</code>
-      <code>$explicit</code>
+    <MixedArgument occurrences="2">
       <code>$image</code>
       <code>$keywords</code>
-      <code>$season</code>
-      <code>$subtitle</code>
-      <code>$summary</code>
-      <code>$title</code>
-      <code>$type</code>
     </MixedArgument>
     <MixedAssignment occurrences="14">
       <code>$author</code>
@@ -2477,22 +2456,12 @@
     </TypeDoesNotContainType>
   </file>
   <file src="src/Writer/Extension/ITunes/Renderer/Feed.php">
-    <MixedArgument occurrences="15">
-      <code>$author</code>
-      <code>$block</code>
+    <MixedArgument occurrences="5">
       <code>$cat</code>
-      <code>$duration</code>
-      <code>$explicit</code>
       <code>$image</code>
       <code>$key</code>
       <code>$keywords</code>
-      <code>$owner['email']</code>
-      <code>$owner['name']</code>
       <code>$subcat</code>
-      <code>$subtitle</code>
-      <code>$summary</code>
-      <code>$type</code>
-      <code>$url</code>
     </MixedArgument>
     <MixedArrayAccess occurrences="2">
       <code>$owner['email']</code>
@@ -2560,12 +2529,19 @@
       <code>getPodcastIndexSoundbites</code>
       <code>getPodcastIndexTranscript</code>
     </MixedMethodCall>
+    <RedundantCastGivenDocblockType occurrences="1">
+      <code>(string) $soundbite['title']</code>
+    </RedundantCastGivenDocblockType>
   </file>
   <file src="src/Writer/Extension/PodcastIndex/Renderer/Feed.php">
     <MixedMethodCall occurrences="2">
       <code>getPodcastIndexFunding</code>
       <code>getPodcastIndexLocked</code>
     </MixedMethodCall>
+    <RedundantCastGivenDocblockType occurrences="2">
+      <code>(string) $funding['title']</code>
+      <code>(string) $locked['value']</code>
+    </RedundantCastGivenDocblockType>
   </file>
   <file src="src/Writer/Extension/Slash/Renderer/Entry.php">
     <MixedAssignment occurrences="1">
@@ -2608,9 +2584,6 @@
     </TypeDoesNotContainType>
   </file>
   <file src="src/Writer/Extension/WellFormedWeb/Renderer/Entry.php">
-    <MixedArgument occurrences="1">
-      <code>$link['uri']</code>
-    </MixedArgument>
     <MixedArrayAccess occurrences="2">
       <code>$link['type']</code>
       <code>$link['uri']</code>
@@ -2742,18 +2715,15 @@
       <code>format</code>
       <code>format</code>
     </InvalidMethodCall>
-    <MixedArgument occurrences="15">
+    <MixedArgument occurrences="12">
       <code>$cat['label']</code>
       <code>$cat['scheme']</code>
       <code>$cat['term']</code>
       <code>$cat['term']</code>
       <code>$content</code>
       <code>$data</code>
-      <code>$data['email']</code>
       <code>$data['length']</code>
-      <code>$data['name']</code>
       <code>$data['type']</code>
-      <code>$data['uri']</code>
       <code>$data['uri']</code>
       <code>$source</code>
       <code>$this-&gt;getDataContainer()-&gt;getDateCreated()-&gt;format(DateTime::ATOM)</code>
@@ -2786,10 +2756,9 @@
     <ParadoxicalCondition occurrences="1">
       <code>! $authors || empty($authors)</code>
     </ParadoxicalCondition>
-    <PossiblyNullArgument occurrences="9">
+    <PossiblyNullArgument occurrences="8">
       <code>$this-&gt;container-&gt;getEncoding()</code>
       <code>$this-&gt;getDataContainer()-&gt;getDescription()</code>
-      <code>$this-&gt;getDataContainer()-&gt;getId()</code>
       <code>$this-&gt;getDataContainer()-&gt;getId()</code>
       <code>$this-&gt;getDataContainer()-&gt;getId()</code>
       <code>$this-&gt;getDataContainer()-&gt;getId()</code>
@@ -2816,11 +2785,8 @@
     <InvalidArgument occurrences="1">
       <code>$container</code>
     </InvalidArgument>
-    <MixedArgument occurrences="7">
+    <MixedArgument occurrences="4">
       <code>$data</code>
-      <code>$data['email']</code>
-      <code>$data['name']</code>
-      <code>$data['uri']</code>
       <code>$this-&gt;container-&gt;getReference()</code>
       <code>$this-&gt;container-&gt;getWhen()-&gt;format(DateTime::ATOM)</code>
       <code>$this-&gt;getDataContainer()-&gt;getComment()</code>
@@ -2852,11 +2818,8 @@
     <InvalidArgument occurrences="1">
       <code>$container</code>
     </InvalidArgument>
-    <MixedArgument occurrences="7">
+    <MixedArgument occurrences="4">
       <code>$data</code>
-      <code>$data['email']</code>
-      <code>$data['name']</code>
-      <code>$data['uri']</code>
       <code>$this-&gt;container-&gt;getReference()</code>
       <code>$this-&gt;container-&gt;getWhen()-&gt;format(DateTime::ATOM)</code>
       <code>$this-&gt;getDataContainer()-&gt;getComment()</code>
@@ -2894,14 +2857,12 @@
     <InvalidMethodCall occurrences="1">
       <code>format</code>
     </InvalidMethodCall>
-    <MixedArgument occurrences="8">
+    <MixedArgument occurrences="6">
       <code>$cat['scheme']</code>
       <code>$cat['term']</code>
       <code>$data</code>
       <code>$data['type']</code>
       <code>$data['uri']</code>
-      <code>$link</code>
-      <code>$name</code>
       <code>$this-&gt;getDataContainer()-&gt;getDateModified()-&gt;format(DateTime::RSS)</code>
     </MixedArgument>
     <MixedArrayAccess occurrences="8">
@@ -2935,14 +2896,11 @@
     <ParadoxicalCondition occurrences="1">
       <code>! $authors || empty($authors)</code>
     </ParadoxicalCondition>
-    <PossiblyNullArgument occurrences="7">
+    <PossiblyNullArgument occurrences="4">
       <code>$this-&gt;container-&gt;getEncoding()</code>
       <code>$this-&gt;getDataContainer()-&gt;getDescription()</code>
       <code>$this-&gt;getDataContainer()-&gt;getId()</code>
-      <code>$this-&gt;getDataContainer()-&gt;getId()</code>
       <code>$this-&gt;getDataContainer()-&gt;getLink()</code>
-      <code>$this-&gt;getDataContainer()-&gt;getLink()</code>
-      <code>$this-&gt;getDataContainer()-&gt;getTitle()</code>
     </PossiblyNullArgument>
     <PossiblyNullReference occurrences="1">
       <code>format</code>
@@ -2969,19 +2927,14 @@
     <InvalidMethodCall occurrences="1">
       <code>format</code>
     </InvalidMethodCall>
-    <MixedArgument occurrences="14">
+    <MixedArgument occurrences="9">
       <code>$cat['label']</code>
       <code>$cat['scheme']</code>
       <code>$cat['term']</code>
       <code>$cat['term']</code>
       <code>$data</code>
-      <code>$data['email']</code>
-      <code>$data['name']</code>
-      <code>$data['uri']</code>
-      <code>$gdata['name']</code>
       <code>$href</code>
       <code>$hubUrl</code>
-      <code>$image['uri']</code>
       <code>$this-&gt;getDataContainer()-&gt;getDateModified()-&gt;format(DateTime::ATOM)</code>
       <code>$type</code>
     </MixedArgument>
@@ -3002,15 +2955,12 @@
     <ParadoxicalCondition occurrences="1">
       <code>! $authors || empty($authors)</code>
     </ParadoxicalCondition>
-    <PossiblyNullArgument occurrences="8">
+    <PossiblyNullArgument occurrences="5">
       <code>$gdata['uri']</code>
       <code>$gdata['version']</code>
-      <code>$this-&gt;getDataContainer()-&gt;getDescription()</code>
-      <code>$this-&gt;getDataContainer()-&gt;getId()</code>
       <code>$this-&gt;getDataContainer()-&gt;getLanguage()</code>
       <code>$this-&gt;getDataContainer()-&gt;getLink()</code>
       <code>$this-&gt;getDataContainer()-&gt;getLink()</code>
-      <code>$this-&gt;getDataContainer()-&gt;getTitle()</code>
     </PossiblyNullArgument>
     <PossiblyNullArrayAccess occurrences="1">
       <code>$gdata['name']</code>
@@ -3069,19 +3019,14 @@
     <InvalidMethodCall occurrences="1">
       <code>format</code>
     </InvalidMethodCall>
-    <MixedArgument occurrences="14">
+    <MixedArgument occurrences="9">
       <code>$cat['label']</code>
       <code>$cat['scheme']</code>
       <code>$cat['term']</code>
       <code>$cat['term']</code>
       <code>$data</code>
-      <code>$data['email']</code>
-      <code>$data['name']</code>
-      <code>$data['uri']</code>
-      <code>$gdata['name']</code>
       <code>$href</code>
       <code>$hubUrl</code>
-      <code>$image['uri']</code>
       <code>$this-&gt;getDataContainer()-&gt;getDateModified()-&gt;format(DateTime::ATOM)</code>
       <code>$type</code>
     </MixedArgument>
@@ -3102,15 +3047,12 @@
     <ParadoxicalCondition occurrences="1">
       <code>! $authors || empty($authors)</code>
     </ParadoxicalCondition>
-    <PossiblyNullArgument occurrences="8">
+    <PossiblyNullArgument occurrences="5">
       <code>$gdata['uri']</code>
       <code>$gdata['version']</code>
-      <code>$this-&gt;getDataContainer()-&gt;getDescription()</code>
-      <code>$this-&gt;getDataContainer()-&gt;getId()</code>
       <code>$this-&gt;getDataContainer()-&gt;getLanguage()</code>
       <code>$this-&gt;getDataContainer()-&gt;getLink()</code>
       <code>$this-&gt;getDataContainer()-&gt;getLink()</code>
-      <code>$this-&gt;getDataContainer()-&gt;getTitle()</code>
     </PossiblyNullArgument>
     <PossiblyNullArrayAccess occurrences="1">
       <code>$gdata['name']</code>
@@ -3135,9 +3077,6 @@
     <InvalidArrayOffset occurrences="1">
       <code>$gdata['name']</code>
     </InvalidArrayOffset>
-    <MixedArgument occurrences="1">
-      <code>$gdata['name']</code>
-    </MixedArgument>
     <MixedAssignment occurrences="1">
       <code>$ext</code>
     </MixedAssignment>
@@ -3171,9 +3110,6 @@
     <InvalidArrayOffset occurrences="1">
       <code>$gdata['name']</code>
     </InvalidArrayOffset>
-    <MixedArgument occurrences="1">
-      <code>$gdata['name']</code>
-    </MixedArgument>
     <MixedAssignment occurrences="1">
       <code>$ext</code>
     </MixedAssignment>
@@ -3214,15 +3150,9 @@
       <code>format</code>
       <code>format</code>
     </InvalidMethodCall>
-    <MixedArgument occurrences="10">
+    <MixedArgument occurrences="4">
       <code>$cat['scheme']</code>
-      <code>$cat['term']</code>
       <code>$data</code>
-      <code>$image['height']</code>
-      <code>$image['uri']</code>
-      <code>$image['width']</code>
-      <code>$name</code>
-      <code>$name</code>
       <code>$this-&gt;getDataContainer()-&gt;getDateModified()-&gt;format(DateTime::RSS)</code>
       <code>$this-&gt;getDataContainer()-&gt;getLastBuildDate()-&gt;format(DateTime::RSS)</code>
     </MixedArgument>
@@ -3255,10 +3185,8 @@
     <ParadoxicalCondition occurrences="1">
       <code>! $authors || empty($authors)</code>
     </ParadoxicalCondition>
-    <PossiblyNullArgument occurrences="3">
+    <PossiblyNullArgument occurrences="1">
       <code>$this-&gt;container-&gt;getEncoding()</code>
-      <code>$this-&gt;getDataContainer()-&gt;getDescription()</code>
-      <code>$this-&gt;getDataContainer()-&gt;getTitle()</code>
     </PossiblyNullArgument>
     <PossiblyNullArrayAccess occurrences="1">
       <code>$gdata['name']</code>

--- a/src/Writer/Extension/DublinCore/Renderer/Entry.php
+++ b/src/Writer/Extension/DublinCore/Renderer/Entry.php
@@ -67,7 +67,7 @@ class Entry extends Extension\AbstractRenderer
         foreach ($authors as $data) {
             $author = $this->dom->createElement('dc:creator');
             if (array_key_exists('name', $data)) {
-                $text = $dom->createTextNode($data['name']);
+                $text = $dom->createTextNode((string) $data['name']);
                 $author->appendChild($text);
                 $root->appendChild($author);
             }

--- a/src/Writer/Extension/DublinCore/Renderer/Feed.php
+++ b/src/Writer/Extension/DublinCore/Renderer/Feed.php
@@ -67,7 +67,7 @@ class Feed extends Extension\AbstractRenderer
         foreach ($authors as $data) {
             $author = $this->dom->createElement('dc:creator');
             if (array_key_exists('name', $data)) {
-                $text = $dom->createTextNode($data['name']);
+                $text = $dom->createTextNode((string) $data['name']);
                 $author->appendChild($text);
                 $root->appendChild($author);
             }

--- a/src/Writer/Extension/GooglePlayPodcast/Renderer/Entry.php
+++ b/src/Writer/Extension/GooglePlayPodcast/Renderer/Entry.php
@@ -61,7 +61,7 @@ class Entry extends Extension\AbstractRenderer
             return;
         }
         $el   = $dom->createElement('googleplay:block');
-        $text = $dom->createTextNode($block);
+        $text = $dom->createTextNode((string) $block);
         $el->appendChild($text);
         $root->appendChild($el);
         $this->called = true;
@@ -79,7 +79,7 @@ class Entry extends Extension\AbstractRenderer
             return;
         }
         $el   = $dom->createElement('googleplay:explicit');
-        $text = $dom->createTextNode($explicit);
+        $text = $dom->createTextNode((string) $explicit);
         $el->appendChild($text);
         $root->appendChild($el);
         $this->called = true;
@@ -97,7 +97,7 @@ class Entry extends Extension\AbstractRenderer
             return;
         }
         $el   = $dom->createElement('googleplay:description');
-        $text = $dom->createTextNode($description);
+        $text = $dom->createTextNode((string) $description);
         $el->appendChild($text);
         $root->appendChild($el);
         $this->called = true;

--- a/src/Writer/Extension/GooglePlayPodcast/Renderer/Feed.php
+++ b/src/Writer/Extension/GooglePlayPodcast/Renderer/Feed.php
@@ -67,7 +67,7 @@ class Feed extends Extension\AbstractRenderer
         }
         foreach ($authors as $author) {
             $el   = $dom->createElement('googleplay:author');
-            $text = $dom->createTextNode($author);
+            $text = $dom->createTextNode((string) $author);
             $el->appendChild($text);
             $root->appendChild($el);
         }
@@ -86,7 +86,7 @@ class Feed extends Extension\AbstractRenderer
             return;
         }
         $el   = $dom->createElement('googleplay:block');
-        $text = $dom->createTextNode($block);
+        $text = $dom->createTextNode((string) $block);
         $el->appendChild($text);
         $root->appendChild($el);
         $this->called = true;
@@ -151,7 +151,7 @@ class Feed extends Extension\AbstractRenderer
             return;
         }
         $el   = $dom->createElement('googleplay:explicit');
-        $text = $dom->createTextNode($explicit);
+        $text = $dom->createTextNode((string) $explicit);
         $el->appendChild($text);
         $root->appendChild($el);
         $this->called = true;
@@ -169,7 +169,7 @@ class Feed extends Extension\AbstractRenderer
             return;
         }
         $el   = $dom->createElement('googleplay:description');
-        $text = $dom->createTextNode($description);
+        $text = $dom->createTextNode((string) $description);
         $el->appendChild($text);
         $root->appendChild($el);
         $this->called = true;

--- a/src/Writer/Extension/ITunes/Renderer/Entry.php
+++ b/src/Writer/Extension/ITunes/Renderer/Entry.php
@@ -74,7 +74,7 @@ class Entry extends Extension\AbstractRenderer
         }
         foreach ($authors as $author) {
             $el   = $dom->createElement('itunes:author');
-            $text = $dom->createTextNode($author);
+            $text = $dom->createTextNode((string) $author);
             $el->appendChild($text);
             $root->appendChild($el);
             $this->called = true;
@@ -93,7 +93,7 @@ class Entry extends Extension\AbstractRenderer
             return;
         }
         $el   = $dom->createElement('itunes:block');
-        $text = $dom->createTextNode($block);
+        $text = $dom->createTextNode((string) $block);
         $el->appendChild($text);
         $root->appendChild($el);
         $this->called = true;
@@ -111,7 +111,7 @@ class Entry extends Extension\AbstractRenderer
             return;
         }
         $el   = $dom->createElement('itunes:duration');
-        $text = $dom->createTextNode($duration);
+        $text = $dom->createTextNode((string) $duration);
         $el->appendChild($text);
         $root->appendChild($el);
         $this->called = true;
@@ -146,7 +146,7 @@ class Entry extends Extension\AbstractRenderer
             return;
         }
         $el   = $dom->createElement('itunes:explicit');
-        $text = $dom->createTextNode($explicit);
+        $text = $dom->createTextNode((string) $explicit);
         $el->appendChild($text);
         $root->appendChild($el);
         $this->called = true;
@@ -182,7 +182,7 @@ class Entry extends Extension\AbstractRenderer
             return;
         }
         $el   = $dom->createElement('itunes:title');
-        $text = $dom->createTextNode($title);
+        $text = $dom->createTextNode((string) $title);
         $el->appendChild($text);
         $root->appendChild($el);
         $this->called = true;
@@ -200,7 +200,7 @@ class Entry extends Extension\AbstractRenderer
             return;
         }
         $el   = $dom->createElement('itunes:subtitle');
-        $text = $dom->createTextNode($subtitle);
+        $text = $dom->createTextNode((string) $subtitle);
         $el->appendChild($text);
         $root->appendChild($el);
         $this->called = true;
@@ -218,7 +218,7 @@ class Entry extends Extension\AbstractRenderer
             return;
         }
         $el   = $dom->createElement('itunes:summary');
-        $text = $dom->createTextNode($summary);
+        $text = $dom->createTextNode((string) $summary);
         $el->appendChild($text);
         $root->appendChild($el);
         $this->called = true;
@@ -236,7 +236,7 @@ class Entry extends Extension\AbstractRenderer
             return;
         }
         $el   = $dom->createElement('itunes:episode');
-        $text = $dom->createTextNode($episode);
+        $text = $dom->createTextNode((string) $episode);
         $el->appendChild($text);
         $root->appendChild($el);
         $this->called = true;
@@ -254,7 +254,7 @@ class Entry extends Extension\AbstractRenderer
             return;
         }
         $el   = $dom->createElement('itunes:episodeType');
-        $text = $dom->createTextNode($type);
+        $text = $dom->createTextNode((string) $type);
         $el->appendChild($text);
         $root->appendChild($el);
         $this->called = true;
@@ -290,7 +290,7 @@ class Entry extends Extension\AbstractRenderer
             return;
         }
         $el   = $dom->createElement('itunes:season');
-        $text = $dom->createTextNode($season);
+        $text = $dom->createTextNode((string) $season);
         $el->appendChild($text);
         $root->appendChild($el);
         $this->called = true;

--- a/src/Writer/Extension/ITunes/Renderer/Feed.php
+++ b/src/Writer/Extension/ITunes/Renderer/Feed.php
@@ -75,7 +75,7 @@ class Feed extends Extension\AbstractRenderer
         }
         foreach ($authors as $author) {
             $el   = $dom->createElement('itunes:author');
-            $text = $dom->createTextNode($author);
+            $text = $dom->createTextNode((string) $author);
             $el->appendChild($text);
             $root->appendChild($el);
         }
@@ -94,7 +94,7 @@ class Feed extends Extension\AbstractRenderer
             return;
         }
         $el   = $dom->createElement('itunes:block');
-        $text = $dom->createTextNode($block);
+        $text = $dom->createTextNode((string) $block);
         $el->appendChild($text);
         $root->appendChild($el);
         $this->called = true;
@@ -159,7 +159,7 @@ class Feed extends Extension\AbstractRenderer
             return;
         }
         $el   = $dom->createElement('itunes:duration');
-        $text = $dom->createTextNode($duration);
+        $text = $dom->createTextNode((string) $duration);
         $el->appendChild($text);
         $root->appendChild($el);
         $this->called = true;
@@ -177,7 +177,7 @@ class Feed extends Extension\AbstractRenderer
             return;
         }
         $el   = $dom->createElement('itunes:explicit');
-        $text = $dom->createTextNode($explicit);
+        $text = $dom->createTextNode((string) $explicit);
         $el->appendChild($text);
         $root->appendChild($el);
         $this->called = true;
@@ -213,7 +213,7 @@ class Feed extends Extension\AbstractRenderer
             return;
         }
         $el   = $dom->createElement('itunes:new-feed-url');
-        $text = $dom->createTextNode($url);
+        $text = $dom->createTextNode((string) $url);
         $el->appendChild($text);
         $root->appendChild($el);
         $this->called = true;
@@ -233,10 +233,10 @@ class Feed extends Extension\AbstractRenderer
         foreach ($owners as $owner) {
             $el   = $dom->createElement('itunes:owner');
             $name = $dom->createElement('itunes:name');
-            $text = $dom->createTextNode($owner['name']);
+            $text = $dom->createTextNode((string) $owner['name']);
             $name->appendChild($text);
             $email = $dom->createElement('itunes:email');
-            $text  = $dom->createTextNode($owner['email']);
+            $text  = $dom->createTextNode((string) $owner['email']);
             $email->appendChild($text);
             $root->appendChild($el);
             $el->appendChild($name);
@@ -257,7 +257,7 @@ class Feed extends Extension\AbstractRenderer
             return;
         }
         $el   = $dom->createElement('itunes:subtitle');
-        $text = $dom->createTextNode($subtitle);
+        $text = $dom->createTextNode((string) $subtitle);
         $el->appendChild($text);
         $root->appendChild($el);
         $this->called = true;
@@ -275,7 +275,7 @@ class Feed extends Extension\AbstractRenderer
             return;
         }
         $el   = $dom->createElement('itunes:summary');
-        $text = $dom->createTextNode($summary);
+        $text = $dom->createTextNode((string) $summary);
         $el->appendChild($text);
         $root->appendChild($el);
         $this->called = true;
@@ -293,7 +293,7 @@ class Feed extends Extension\AbstractRenderer
             return;
         }
         $el   = $dom->createElement('itunes:type');
-        $text = $dom->createTextNode($type);
+        $text = $dom->createTextNode((string) $type);
         $el->appendChild($text);
         $root->appendChild($el);
         $this->called = true;

--- a/src/Writer/Extension/PodcastIndex/Renderer/Entry.php
+++ b/src/Writer/Extension/PodcastIndex/Renderer/Entry.php
@@ -103,7 +103,7 @@ class Entry extends Extension\AbstractRenderer
             /** @psalm-var array<string, string> $soundbite */
             $el = $dom->createElement('podcast:soundbite');
             if (array_key_exists('title', $soundbite)) {
-                $text = $dom->createTextNode($soundbite['title']);
+                $text = $dom->createTextNode((string) $soundbite['title']);
                 $el->appendChild($text);
             }
             $el->setAttribute('startTime', $soundbite['startTime']);

--- a/src/Writer/Extension/PodcastIndex/Renderer/Feed.php
+++ b/src/Writer/Extension/PodcastIndex/Renderer/Feed.php
@@ -57,7 +57,7 @@ class Feed extends Extension\AbstractRenderer
             return;
         }
         $el   = $dom->createElement('podcast:locked');
-        $text = $dom->createTextNode($locked['value']);
+        $text = $dom->createTextNode((string) $locked['value']);
         $el->appendChild($text);
         $el->setAttribute('owner', $locked['owner']);
         $root->appendChild($el);
@@ -75,7 +75,7 @@ class Feed extends Extension\AbstractRenderer
             return;
         }
         $el   = $dom->createElement('podcast:locked');
-        $text = $dom->createTextNode($funding['title']);
+        $text = $dom->createTextNode((string) $funding['title']);
         $el->appendChild($text);
         $el->setAttribute('url', $funding['url']);
         $root->appendChild($el);

--- a/src/Writer/Extension/WellFormedWeb/Renderer/Entry.php
+++ b/src/Writer/Extension/WellFormedWeb/Renderer/Entry.php
@@ -66,7 +66,7 @@ class Entry extends Extension\AbstractRenderer
         foreach ($links as $link) {
             if ($link['type'] === 'rss') {
                 $flink = $this->dom->createElement('wfw:commentRss');
-                $text  = $dom->createTextNode($link['uri']);
+                $text  = $dom->createTextNode((string) $link['uri']);
                 $flink->appendChild($text);
                 $root->appendChild($flink);
             }

--- a/src/Writer/Renderer/Entry/Atom.php
+++ b/src/Writer/Renderer/Entry/Atom.php
@@ -176,18 +176,18 @@ class Atom extends Renderer\AbstractRenderer implements Renderer\RendererInterfa
             $name   = $this->dom->createElement('name');
             $author->appendChild($name);
             $root->appendChild($author);
-            $text = $dom->createTextNode($data['name']);
+            $text = $dom->createTextNode((string) $data['name']);
             $name->appendChild($text);
             if (array_key_exists('email', $data)) {
                 $email = $this->dom->createElement('email');
                 $author->appendChild($email);
-                $text = $dom->createTextNode($data['email']);
+                $text = $dom->createTextNode((string) $data['email']);
                 $email->appendChild($text);
             }
             if (array_key_exists('uri', $data)) {
                 $uri = $this->dom->createElement('uri');
                 $author->appendChild($uri);
-                $text = $dom->createTextNode($data['uri']);
+                $text = $dom->createTextNode((string) $data['uri']);
                 $uri->appendChild($text);
             }
         }
@@ -273,7 +273,7 @@ class Atom extends Renderer\AbstractRenderer implements Renderer\RendererInterfa
         }
         $id = $dom->createElement('id');
         $root->appendChild($id);
-        $text = $dom->createTextNode($this->getDataContainer()->getId());
+        $text = $dom->createTextNode((string) $this->getDataContainer()->getId());
         $id->appendChild($text);
     }
 

--- a/src/Writer/Renderer/Entry/Atom/Deleted.php
+++ b/src/Writer/Renderer/Entry/Atom/Deleted.php
@@ -74,18 +74,18 @@ class Deleted extends Renderer\AbstractRenderer implements Renderer\RendererInte
         $name   = $this->dom->createElement('name');
         $author->appendChild($name);
         $root->appendChild($author);
-        $text = $dom->createTextNode($data['name']);
+        $text = $dom->createTextNode((string) $data['name']);
         $name->appendChild($text);
         if (array_key_exists('email', $data)) {
             $email = $this->dom->createElement('email');
             $author->appendChild($email);
-            $text = $dom->createTextNode($data['email']);
+            $text = $dom->createTextNode((string) $data['email']);
             $email->appendChild($text);
         }
         if (array_key_exists('uri', $data)) {
             $uri = $this->dom->createElement('uri');
             $author->appendChild($uri);
-            $text = $dom->createTextNode($data['uri']);
+            $text = $dom->createTextNode((string) $data['uri']);
             $uri->appendChild($text);
         }
     }

--- a/src/Writer/Renderer/Entry/AtomDeleted.php
+++ b/src/Writer/Renderer/Entry/AtomDeleted.php
@@ -74,18 +74,18 @@ class AtomDeleted extends Renderer\AbstractRenderer implements Renderer\Renderer
         $name   = $this->dom->createElement('name');
         $author->appendChild($name);
         $root->appendChild($author);
-        $text = $dom->createTextNode($data['name']);
+        $text = $dom->createTextNode((string) $data['name']);
         $name->appendChild($text);
         if (array_key_exists('email', $data)) {
             $email = $this->dom->createElement('email');
             $author->appendChild($email);
-            $text = $dom->createTextNode($data['email']);
+            $text = $dom->createTextNode((string) $data['email']);
             $email->appendChild($text);
         }
         if (array_key_exists('uri', $data)) {
             $uri = $this->dom->createElement('uri');
             $author->appendChild($uri);
-            $text = $dom->createTextNode($data['uri']);
+            $text = $dom->createTextNode((string) $data['uri']);
             $uri->appendChild($text);
         }
     }

--- a/src/Writer/Renderer/Entry/Rss.php
+++ b/src/Writer/Renderer/Entry/Rss.php
@@ -81,7 +81,7 @@ class Rss extends Renderer\AbstractRenderer implements Renderer\RendererInterfac
         }
         $title = $dom->createElement('title');
         $root->appendChild($title);
-        $text = $dom->createTextNode($this->getDataContainer()->getTitle());
+        $text = $dom->createTextNode((string) $this->getDataContainer()->getTitle());
         $title->appendChild($text);
     }
 
@@ -171,7 +171,7 @@ class Rss extends Renderer\AbstractRenderer implements Renderer\RendererInterfac
             if (array_key_exists('email', $data)) {
                 $name = $data['email'] . ' (' . $data['name'] . ')';
             }
-            $text = $dom->createTextNode($name);
+            $text = $dom->createTextNode((string) $name);
             $author->appendChild($text);
             $root->appendChild($author);
         }
@@ -237,7 +237,7 @@ class Rss extends Renderer\AbstractRenderer implements Renderer\RendererInterfac
         }
         $link = $dom->createElement('link');
         $root->appendChild($link);
-        $text = $dom->createTextNode($this->getDataContainer()->getLink());
+        $text = $dom->createTextNode((string) $this->getDataContainer()->getLink());
         $link->appendChild($text);
     }
 
@@ -262,7 +262,7 @@ class Rss extends Renderer\AbstractRenderer implements Renderer\RendererInterfac
                 $this->getDataContainer()->getLink()
             );
         }
-        $text = $dom->createTextNode($this->getDataContainer()->getId());
+        $text = $dom->createTextNode((string) $this->getDataContainer()->getId());
         $id->appendChild($text);
 
         $uri = Uri::factory($this->getDataContainer()->getId());
@@ -284,7 +284,7 @@ class Rss extends Renderer\AbstractRenderer implements Renderer\RendererInterfac
             return;
         }
         $clink = $this->dom->createElement('comments');
-        $text  = $dom->createTextNode($link);
+        $text  = $dom->createTextNode((string) $link);
         $clink->appendChild($text);
         $root->appendChild($clink);
     }

--- a/src/Writer/Renderer/Feed/AbstractAtom.php
+++ b/src/Writer/Renderer/Feed/AbstractAtom.php
@@ -61,7 +61,7 @@ class AbstractAtom extends Renderer\AbstractRenderer
         $title = $dom->createElement('title');
         $root->appendChild($title);
         $title->setAttribute('type', 'text');
-        $text = $dom->createTextNode($this->getDataContainer()->getTitle());
+        $text = $dom->createTextNode((string) $this->getDataContainer()->getTitle());
         $title->appendChild($text);
     }
 
@@ -78,7 +78,7 @@ class AbstractAtom extends Renderer\AbstractRenderer
         $subtitle = $dom->createElement('subtitle');
         $root->appendChild($subtitle);
         $subtitle->setAttribute('type', 'text');
-        $text = $dom->createTextNode($this->getDataContainer()->getDescription());
+        $text = $dom->createTextNode((string) $this->getDataContainer()->getDescription());
         $subtitle->appendChild($text);
     }
 
@@ -128,7 +128,7 @@ class AbstractAtom extends Renderer\AbstractRenderer
         $gdata     = $this->getDataContainer()->getGenerator();
         $generator = $dom->createElement('generator');
         $root->appendChild($generator);
-        $text = $dom->createTextNode($gdata['name']);
+        $text = $dom->createTextNode((string) $gdata['name']);
         $generator->appendChild($text);
         if (array_key_exists('uri', $gdata)) {
             $generator->setAttribute('uri', $gdata['uri']);
@@ -209,18 +209,18 @@ class AbstractAtom extends Renderer\AbstractRenderer
             $name   = $this->dom->createElement('name');
             $author->appendChild($name);
             $root->appendChild($author);
-            $text = $dom->createTextNode($data['name']);
+            $text = $dom->createTextNode((string) $data['name']);
             $name->appendChild($text);
             if (array_key_exists('email', $data)) {
                 $email = $this->dom->createElement('email');
                 $author->appendChild($email);
-                $text = $dom->createTextNode($data['email']);
+                $text = $dom->createTextNode((string) $data['email']);
                 $email->appendChild($text);
             }
             if (array_key_exists('uri', $data)) {
                 $uri = $this->dom->createElement('uri');
                 $author->appendChild($uri);
-                $text = $dom->createTextNode($data['uri']);
+                $text = $dom->createTextNode((string) $data['uri']);
                 $uri->appendChild($text);
             }
         }
@@ -258,7 +258,7 @@ class AbstractAtom extends Renderer\AbstractRenderer
         }
         $id = $dom->createElement('id');
         $root->appendChild($id);
-        $text = $dom->createTextNode($this->getDataContainer()->getId());
+        $text = $dom->createTextNode((string) $this->getDataContainer()->getId());
         $id->appendChild($text);
     }
 
@@ -292,7 +292,7 @@ class AbstractAtom extends Renderer\AbstractRenderer
         }
         $img = $dom->createElement('logo');
         $root->appendChild($img);
-        $text = $dom->createTextNode($image['uri']);
+        $text = $dom->createTextNode((string) $image['uri']);
         $img->appendChild($text);
     }
 

--- a/src/Writer/Renderer/Feed/Atom/AbstractAtom.php
+++ b/src/Writer/Renderer/Feed/Atom/AbstractAtom.php
@@ -60,7 +60,7 @@ class AbstractAtom extends Feed\Writer\Renderer\AbstractRenderer
         $title = $dom->createElement('title');
         $root->appendChild($title);
         $title->setAttribute('type', 'text');
-        $text = $dom->createTextNode($this->getDataContainer()->getTitle());
+        $text = $dom->createTextNode((string) $this->getDataContainer()->getTitle());
         $title->appendChild($text);
     }
 
@@ -77,7 +77,7 @@ class AbstractAtom extends Feed\Writer\Renderer\AbstractRenderer
         $subtitle = $dom->createElement('subtitle');
         $root->appendChild($subtitle);
         $subtitle->setAttribute('type', 'text');
-        $text = $dom->createTextNode($this->getDataContainer()->getDescription());
+        $text = $dom->createTextNode((string) $this->getDataContainer()->getDescription());
         $subtitle->appendChild($text);
     }
 
@@ -127,7 +127,7 @@ class AbstractAtom extends Feed\Writer\Renderer\AbstractRenderer
         $gdata     = $this->getDataContainer()->getGenerator();
         $generator = $dom->createElement('generator');
         $root->appendChild($generator);
-        $text = $dom->createTextNode($gdata['name']);
+        $text = $dom->createTextNode((string) $gdata['name']);
         $generator->appendChild($text);
         if (array_key_exists('uri', $gdata)) {
             $generator->setAttribute('uri', $gdata['uri']);
@@ -208,18 +208,18 @@ class AbstractAtom extends Feed\Writer\Renderer\AbstractRenderer
             $name   = $this->dom->createElement('name');
             $author->appendChild($name);
             $root->appendChild($author);
-            $text = $dom->createTextNode($data['name']);
+            $text = $dom->createTextNode((string) $data['name']);
             $name->appendChild($text);
             if (array_key_exists('email', $data)) {
                 $email = $this->dom->createElement('email');
                 $author->appendChild($email);
-                $text = $dom->createTextNode($data['email']);
+                $text = $dom->createTextNode((string) $data['email']);
                 $email->appendChild($text);
             }
             if (array_key_exists('uri', $data)) {
                 $uri = $this->dom->createElement('uri');
                 $author->appendChild($uri);
-                $text = $dom->createTextNode($data['uri']);
+                $text = $dom->createTextNode((string) $data['uri']);
                 $uri->appendChild($text);
             }
         }
@@ -257,7 +257,7 @@ class AbstractAtom extends Feed\Writer\Renderer\AbstractRenderer
         }
         $id = $dom->createElement('id');
         $root->appendChild($id);
-        $text = $dom->createTextNode($this->getDataContainer()->getId());
+        $text = $dom->createTextNode((string) $this->getDataContainer()->getId());
         $id->appendChild($text);
     }
 
@@ -291,7 +291,7 @@ class AbstractAtom extends Feed\Writer\Renderer\AbstractRenderer
         }
         $img = $dom->createElement('logo');
         $root->appendChild($img);
-        $text = $dom->createTextNode($image['uri']);
+        $text = $dom->createTextNode((string) $image['uri']);
         $img->appendChild($text);
     }
 

--- a/src/Writer/Renderer/Feed/Atom/Source.php
+++ b/src/Writer/Renderer/Feed/Atom/Source.php
@@ -71,7 +71,7 @@ class Source extends AbstractAtom implements Renderer\RendererInterface
         $gdata     = $this->getDataContainer()->getGenerator();
         $generator = $dom->createElement('generator');
         $root->appendChild($generator);
-        $text = $dom->createTextNode($gdata['name']);
+        $text = $dom->createTextNode((string) $gdata['name']);
         $generator->appendChild($text);
         if (array_key_exists('uri', $gdata)) {
             $generator->setAttribute('uri', $gdata['uri']);

--- a/src/Writer/Renderer/Feed/AtomSource.php
+++ b/src/Writer/Renderer/Feed/AtomSource.php
@@ -71,7 +71,7 @@ class AtomSource extends AbstractAtom implements Renderer\RendererInterface
         $gdata     = $this->getDataContainer()->getGenerator();
         $generator = $dom->createElement('generator');
         $root->appendChild($generator);
-        $text = $dom->createTextNode($gdata['name']);
+        $text = $dom->createTextNode((string) $gdata['name']);
         $generator->appendChild($text);
         if (array_key_exists('uri', $gdata)) {
             $generator->setAttribute('uri', $gdata['uri']);

--- a/src/Writer/Renderer/Feed/Rss.php
+++ b/src/Writer/Renderer/Feed/Rss.php
@@ -222,7 +222,7 @@ class Rss extends Renderer\AbstractRenderer implements Renderer\RendererInterfac
         }
         $link = $dom->createElement('link');
         $root->appendChild($link);
-        $text = $dom->createTextNode((string) $value);
+        $text = $dom->createTextNode($value);
         $link->appendChild($text);
         if (! Uri::factory($value)->isValid()) {
             $link->setAttribute('isPermaLink', 'false');

--- a/src/Writer/Renderer/Feed/Rss.php
+++ b/src/Writer/Renderer/Feed/Rss.php
@@ -123,7 +123,7 @@ class Rss extends Renderer\AbstractRenderer implements Renderer\RendererInterfac
 
         $title = $dom->createElement('title');
         $root->appendChild($title);
-        $text = $dom->createTextNode($this->getDataContainer()->getTitle());
+        $text = $dom->createTextNode((string) $this->getDataContainer()->getTitle());
         $title->appendChild($text);
     }
 
@@ -148,7 +148,7 @@ class Rss extends Renderer\AbstractRenderer implements Renderer\RendererInterfac
         }
         $subtitle = $dom->createElement('description');
         $root->appendChild($subtitle);
-        $text = $dom->createTextNode($this->getDataContainer()->getDescription());
+        $text = $dom->createTextNode((string) $this->getDataContainer()->getDescription());
         $subtitle->appendChild($text);
     }
 
@@ -196,7 +196,7 @@ class Rss extends Renderer\AbstractRenderer implements Renderer\RendererInterfac
         if (array_key_exists('uri', $gdata)) {
             $name .= ' (' . $gdata['uri'] . ')';
         }
-        $text = $dom->createTextNode($name);
+        $text = $dom->createTextNode((string) $name);
         $generator->appendChild($text);
     }
 
@@ -222,7 +222,7 @@ class Rss extends Renderer\AbstractRenderer implements Renderer\RendererInterfac
         }
         $link = $dom->createElement('link');
         $root->appendChild($link);
-        $text = $dom->createTextNode($value);
+        $text = $dom->createTextNode((string) $value);
         $link->appendChild($text);
         if (! Uri::factory($value)->isValid()) {
             $link->setAttribute('isPermaLink', 'false');
@@ -246,7 +246,7 @@ class Rss extends Renderer\AbstractRenderer implements Renderer\RendererInterfac
             if (array_key_exists('email', $data)) {
                 $name = $data['email'] . ' (' . $data['name'] . ')';
             }
-            $text = $dom->createTextNode($name);
+            $text = $dom->createTextNode((string) $name);
             $author->appendChild($text);
             $root->appendChild($author);
         }
@@ -315,7 +315,7 @@ class Rss extends Renderer\AbstractRenderer implements Renderer\RendererInterfac
         $root->appendChild($img);
 
         $url  = $dom->createElement('url');
-        $text = $dom->createTextNode($image['uri']);
+        $text = $dom->createTextNode((string) $image['uri']);
         $url->appendChild($text);
 
         $title = $dom->createElement('title');
@@ -343,7 +343,7 @@ class Rss extends Renderer\AbstractRenderer implements Renderer\RendererInterfac
                 }
             }
             $height = $dom->createElement('height');
-            $text   = $dom->createTextNode($image['height']);
+            $text   = $dom->createTextNode((string) $image['height']);
             $height->appendChild($text);
             $img->appendChild($height);
         }
@@ -360,7 +360,7 @@ class Rss extends Renderer\AbstractRenderer implements Renderer\RendererInterfac
                 }
             }
             $width = $dom->createElement('width');
-            $text  = $dom->createTextNode($image['width']);
+            $text  = $dom->createTextNode((string) $image['width']);
             $width->appendChild($text);
             $img->appendChild($width);
         }
@@ -449,7 +449,7 @@ class Rss extends Renderer\AbstractRenderer implements Renderer\RendererInterfac
             if (isset($cat['scheme'])) {
                 $category->setAttribute('domain', $cat['scheme']);
             }
-            $text = $dom->createTextNode($cat['term']);
+            $text = $dom->createTextNode((string) $cat['term']);
             $category->appendChild($text);
             $root->appendChild($category);
         }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Bugfix        | yes

### Description

Modifies all calls to `DOMDocument::createTextNode()` to ensure parameters are cast to a string where the type is currently ambiguous.

Should close #61 



