### PR TITLE
Remove support for PHP 8.0, Remove hard dependency on service manager

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,20 +33,20 @@
         "ext-dom": "*",
         "ext-libxml": "*",
         "laminas/laminas-escaper": "^2.9",
-        "laminas/laminas-servicemanager": "^3.14.0",
         "laminas/laminas-stdlib": "^3.6"
     },
     "require-dev": {
-        "laminas/laminas-cache": "^2.13.2 || ^3.6",
-        "laminas/laminas-cache-storage-adapter-memory": "^1.1.0 || ^2.1",
+        "laminas/laminas-cache": "^2.13.2 || ^3.10.1",
+        "laminas/laminas-cache-storage-adapter-memory": "^1.1.0 || ^2.2",
         "laminas/laminas-coding-standard": "~2.5.0",
-        "laminas/laminas-db": "^2.15",
-        "laminas/laminas-http": "^2.17.0",
-        "laminas/laminas-validator": "^2.26",
-        "phpunit/phpunit": "^9.5.25",
-        "psalm/plugin-phpunit": "^0.18.0",
-        "psr/http-message": "^1.0.1",
-        "vimeo/psalm": "^5.1.0"
+        "laminas/laminas-db": "^2.18",
+        "laminas/laminas-http": "^2.18",
+        "laminas/laminas-servicemanager": "^3.20.0",
+        "laminas/laminas-validator": "^2.30.1",
+        "phpunit/phpunit": "^9.6.10",
+        "psalm/plugin-phpunit": "^0.18.4",
+        "psr/http-message": "^1.1",
+        "vimeo/psalm": "^5.13.1"
     },
     "conflict": {
         "laminas/laminas-servicemanager": "<3.3",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "config": {
         "sort-packages": true,
         "platform": {
-            "php": "8.0.99"
+            "php": "8.1.99"
         },
         "allow-plugins": {
             "dealerdirect/phpcodesniffer-composer-installer": true
@@ -29,7 +29,7 @@
     "extra": {
     },
     "require": {
-        "php": "~8.0.0 || ~8.1.0 || ~8.2.0",
+        "php": "~8.1.0 || ~8.2.0",
         "ext-dom": "*",
         "ext-libxml": "*",
         "laminas/laminas-escaper": "^2.9",
@@ -41,7 +41,7 @@
         "laminas/laminas-coding-standard": "~2.5.0",
         "laminas/laminas-db": "^2.18",
         "laminas/laminas-http": "^2.18",
-        "laminas/laminas-servicemanager": "^3.20.0",
+        "laminas/laminas-servicemanager": "^3.21.0",
         "laminas/laminas-validator": "^2.30.1",
         "phpunit/phpunit": "^9.6.10",
         "psalm/plugin-phpunit": "^0.18.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "44d667b694636d6ed21118b3e119b6db",
+    "content-hash": "e7f19906bbe1d991058f563fbf02e258",
     "packages": [
         {
             "name": "laminas/laminas-escaper",
@@ -70,30 +70,30 @@
         },
         {
             "name": "laminas/laminas-stdlib",
-            "version": "3.16.1",
+            "version": "3.17.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-stdlib.git",
-                "reference": "f4f773641807c7ccee59b758bfe4ac4ba33ecb17"
+                "reference": "dd35c868075bad80b6718959740913e178eb4274"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-stdlib/zipball/f4f773641807c7ccee59b758bfe4ac4ba33ecb17",
-                "reference": "f4f773641807c7ccee59b758bfe4ac4ba33ecb17",
+                "url": "https://api.github.com/repos/laminas/laminas-stdlib/zipball/dd35c868075bad80b6718959740913e178eb4274",
+                "reference": "dd35c868075bad80b6718959740913e178eb4274",
                 "shasum": ""
             },
             "require": {
-                "php": "~8.0.0 || ~8.1.0 || ~8.2.0"
+                "php": "~8.1.0 || ~8.2.0"
             },
             "conflict": {
                 "zendframework/zend-stdlib": "*"
             },
             "require-dev": {
-                "laminas/laminas-coding-standard": "^2.4.0",
-                "phpbench/phpbench": "^1.2.7",
-                "phpunit/phpunit": "^9.5.26",
-                "psalm/plugin-phpunit": "^0.18.0",
-                "vimeo/psalm": "^5.0.0"
+                "laminas/laminas-coding-standard": "^2.5",
+                "phpbench/phpbench": "^1.2.9",
+                "phpunit/phpunit": "^10.0.16",
+                "psalm/plugin-phpunit": "^0.18.4",
+                "vimeo/psalm": "^5.8"
             },
             "type": "library",
             "autoload": {
@@ -125,7 +125,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-12-03T18:48:01+00:00"
+            "time": "2023-03-20T13:51:37+00:00"
         }
     ],
     "packages-dev": [
@@ -700,30 +700,30 @@
         },
         {
             "name": "doctrine/instantiator",
-            "version": "1.5.0",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "0a0fa9780f5d4e507415a065172d26a98d02047b"
+                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/0a0fa9780f5d4e507415a065172d26a98d02047b",
-                "reference": "0a0fa9780f5d4e507415a065172d26a98d02047b",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
+                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1 || ^8.0"
+                "php": "^8.1"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^9 || ^11",
+                "doctrine/coding-standard": "^11",
                 "ext-pdo": "*",
                 "ext-phar": "*",
-                "phpbench/phpbench": "^0.16 || ^1",
-                "phpstan/phpstan": "^1.4",
-                "phpstan/phpstan-phpunit": "^1",
-                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
-                "vimeo/psalm": "^4.30 || ^5.4"
+                "phpbench/phpbench": "^1.2",
+                "phpstan/phpstan": "^1.9.4",
+                "phpstan/phpstan-phpunit": "^1.3",
+                "phpunit/phpunit": "^9.5.27",
+                "vimeo/psalm": "^5.4"
             },
             "type": "library",
             "autoload": {
@@ -750,7 +750,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/instantiator/issues",
-                "source": "https://github.com/doctrine/instantiator/tree/1.5.0"
+                "source": "https://github.com/doctrine/instantiator/tree/2.0.0"
             },
             "funding": [
                 {
@@ -766,7 +766,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-12-30T00:15:36+00:00"
+            "time": "2022-12-30T00:23:10+00:00"
         },
         {
             "name": "felixfbecker/advanced-json-rpc",
@@ -1415,26 +1415,26 @@
         },
         {
             "name": "laminas/laminas-servicemanager",
-            "version": "3.20.0",
+            "version": "3.21.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-servicemanager.git",
-                "reference": "bc2c2cbe2dd90db8b9d16b0618f542692b76ab59"
+                "reference": "625f2aa3bc6dd02688b2da5155b3a69870812bda"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-servicemanager/zipball/bc2c2cbe2dd90db8b9d16b0618f542692b76ab59",
-                "reference": "bc2c2cbe2dd90db8b9d16b0618f542692b76ab59",
+                "url": "https://api.github.com/repos/laminas/laminas-servicemanager/zipball/625f2aa3bc6dd02688b2da5155b3a69870812bda",
+                "reference": "625f2aa3bc6dd02688b2da5155b3a69870812bda",
                 "shasum": ""
             },
             "require": {
-                "laminas/laminas-stdlib": "^3.2.1",
-                "php": "~8.0.0 || ~8.1.0 || ~8.2.0",
+                "laminas/laminas-stdlib": "^3.17",
+                "php": "~8.1.0 || ~8.2.0",
                 "psr/container": "^1.0"
             },
             "conflict": {
                 "ext-psr": "*",
-                "laminas/laminas-code": "<3.3.1",
+                "laminas/laminas-code": "<4.10.0",
                 "zendframework/zend-code": "<3.3.1",
                 "zendframework/zend-servicemanager": "*"
             },
@@ -1446,18 +1446,19 @@
             },
             "require-dev": {
                 "composer/package-versions-deprecated": "^1.11.99.5",
-                "laminas/laminas-coding-standard": "~2.4.0",
+                "friendsofphp/proxy-manager-lts": "^1.0.14",
+                "laminas/laminas-code": "^4.10.0",
+                "laminas/laminas-coding-standard": "~2.5.0",
                 "laminas/laminas-container-config-test": "^0.8",
                 "laminas/laminas-dependency-plugin": "^2.2",
-                "mikey179/vfsstream": "^1.6.11@alpha",
-                "ocramius/proxy-manager": "^2.14.1",
-                "phpbench/phpbench": "^1.2.7",
-                "phpunit/phpunit": "^9.5.26",
-                "psalm/plugin-phpunit": "^0.18.0",
-                "vimeo/psalm": "^5.0.0"
+                "mikey179/vfsstream": "^1.6.11",
+                "phpbench/phpbench": "^1.2.9",
+                "phpunit/phpunit": "^10.0.17",
+                "psalm/plugin-phpunit": "^0.18.4",
+                "vimeo/psalm": "^5.8.0"
             },
             "suggest": {
-                "ocramius/proxy-manager": "ProxyManager ^2.1.1 to handle lazy initialization of services"
+                "friendsofphp/proxy-manager-lts": "ProxyManager ^2.1.1 to handle lazy initialization of services"
             },
             "bin": [
                 "bin/generate-deps-for-config-factory",
@@ -1501,7 +1502,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-12-01T17:03:38+00:00"
+            "time": "2023-05-14T12:24:54+00:00"
         },
         {
             "name": "laminas/laminas-uri",
@@ -1563,40 +1564,39 @@
         },
         {
             "name": "laminas/laminas-validator",
-            "version": "2.30.1",
+            "version": "2.35.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-validator.git",
-                "reference": "b7d217b5e4951955fda9a3a5ada91b717b5c8d5c"
+                "reference": "7a4a30f6c526a518ba9af50e037c2f97cb595958"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-validator/zipball/b7d217b5e4951955fda9a3a5ada91b717b5c8d5c",
-                "reference": "b7d217b5e4951955fda9a3a5ada91b717b5c8d5c",
+                "url": "https://api.github.com/repos/laminas/laminas-validator/zipball/7a4a30f6c526a518ba9af50e037c2f97cb595958",
+                "reference": "7a4a30f6c526a518ba9af50e037c2f97cb595958",
                 "shasum": ""
             },
             "require": {
-                "laminas/laminas-servicemanager": "^3.12.0",
+                "laminas/laminas-servicemanager": "^3.21.0",
                 "laminas/laminas-stdlib": "^3.13",
-                "php": "~8.0.0 || ~8.1.0 || ~8.2.0",
-                "psr/http-message": "^1.0.1"
+                "php": "~8.1.0 || ~8.2.0",
+                "psr/http-message": "^1.0.1 || ^2.0.0"
             },
             "conflict": {
                 "zendframework/zend-validator": "*"
             },
             "require-dev": {
-                "laminas/laminas-coding-standard": "^2.4.0",
-                "laminas/laminas-db": "^2.16",
-                "laminas/laminas-filter": "^2.28.1",
-                "laminas/laminas-http": "^2.18",
-                "laminas/laminas-i18n": "^2.19",
-                "laminas/laminas-session": "^2.15",
+                "laminas/laminas-coding-standard": "^2.5",
+                "laminas/laminas-db": "^2.18",
+                "laminas/laminas-filter": "^2.32",
+                "laminas/laminas-i18n": "^2.23",
+                "laminas/laminas-session": "^2.16",
                 "laminas/laminas-uri": "^2.10.0",
-                "phpunit/phpunit": "^9.5.26",
-                "psalm/plugin-phpunit": "^0.18.3",
-                "psr/http-client": "^1.0.1",
-                "psr/http-factory": "^1.0.1",
-                "vimeo/psalm": "^5.0"
+                "phpunit/phpunit": "^10.1.3",
+                "psalm/plugin-phpunit": "^0.18.4",
+                "psr/http-client": "^1.0.2",
+                "psr/http-factory": "^1.0.2",
+                "vimeo/psalm": "^5.12"
             },
             "suggest": {
                 "laminas/laminas-db": "Laminas\\Db component, required by the (No)RecordExists validator",
@@ -1644,7 +1644,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2023-01-30T22:41:19+00:00"
+            "time": "2023-07-10T07:32:01+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -4106,22 +4106,23 @@
         },
         {
             "name": "symfony/console",
-            "version": "v6.0.19",
+            "version": "v6.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "c3ebc83d031b71c39da318ca8b7a07ecc67507ed"
+                "reference": "8788808b07cf0bdd6e4b7fdd23d8ddb1470c83b7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/c3ebc83d031b71c39da318ca8b7a07ecc67507ed",
-                "reference": "c3ebc83d031b71c39da318ca8b7a07ecc67507ed",
+                "url": "https://api.github.com/repos/symfony/console/zipball/8788808b07cf0bdd6e4b7fdd23d8ddb1470c83b7",
+                "reference": "8788808b07cf0bdd6e4b7fdd23d8ddb1470c83b7",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.2",
+                "php": ">=8.1",
+                "symfony/deprecation-contracts": "^2.5|^3",
                 "symfony/polyfill-mbstring": "~1.0",
-                "symfony/service-contracts": "^1.1|^2|^3",
+                "symfony/service-contracts": "^2.5|^3",
                 "symfony/string": "^5.4|^6.0"
             },
             "conflict": {
@@ -4142,12 +4143,6 @@
                 "symfony/lock": "^5.4|^6.0",
                 "symfony/process": "^5.4|^6.0",
                 "symfony/var-dumper": "^5.4|^6.0"
-            },
-            "suggest": {
-                "psr/log": "For using the console logger",
-                "symfony/event-dispatcher": "",
-                "symfony/lock": "",
-                "symfony/process": ""
             },
             "type": "library",
             "autoload": {
@@ -4176,12 +4171,12 @@
             "homepage": "https://symfony.com",
             "keywords": [
                 "cli",
-                "command line",
+                "command-line",
                 "console",
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v6.0.19"
+                "source": "https://github.com/symfony/console/tree/v6.3.0"
             },
             "funding": [
                 {
@@ -4197,29 +4192,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-01T08:36:10+00:00"
+            "time": "2023-05-29T12:49:39+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v3.0.2",
+            "version": "v3.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "26954b3d62a6c5fd0ea8a2a00c0353a14978d05c"
+                "reference": "7c3aff79d10325257a001fcf92d991f24fc967cf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/26954b3d62a6c5fd0ea8a2a00c0353a14978d05c",
-                "reference": "26954b3d62a6c5fd0ea8a2a00c0353a14978d05c",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/7c3aff79d10325257a001fcf92d991f24fc967cf",
+                "reference": "7c3aff79d10325257a001fcf92d991f24fc967cf",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.2"
+                "php": ">=8.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.0-dev"
+                    "dev-main": "3.4-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -4248,7 +4243,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.0.2"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.3.0"
             },
             "funding": [
                 {
@@ -4264,24 +4259,24 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-01-02T09:55:41+00:00"
+            "time": "2023-05-23T14:45:45+00:00"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v6.0.19",
+            "version": "v6.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "3d49eec03fda1f0fc19b7349fbbe55ebc1004214"
+                "reference": "edd36776956f2a6fcf577edb5b05eb0e3bdc52ae"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/3d49eec03fda1f0fc19b7349fbbe55ebc1004214",
-                "reference": "3d49eec03fda1f0fc19b7349fbbe55ebc1004214",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/edd36776956f2a6fcf577edb5b05eb0e3bdc52ae",
+                "reference": "edd36776956f2a6fcf577edb5b05eb0e3bdc52ae",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.2",
+                "php": ">=8.1",
                 "symfony/polyfill-ctype": "~1.8",
                 "symfony/polyfill-mbstring": "~1.8"
             },
@@ -4311,7 +4306,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v6.0.19"
+                "source": "https://github.com/symfony/filesystem/tree/v6.3.1"
             },
             "funding": [
                 {
@@ -4327,7 +4322,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-20T17:44:14+00:00"
+            "time": "2023-06-01T08:30:39+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -4744,32 +4739,33 @@
         },
         {
             "name": "symfony/string",
-            "version": "v6.0.19",
+            "version": "v6.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "d9e72497367c23e08bf94176d2be45b00a9d232a"
+                "reference": "f2e190ee75ff0f5eced645ec0be5c66fac81f51f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/d9e72497367c23e08bf94176d2be45b00a9d232a",
-                "reference": "d9e72497367c23e08bf94176d2be45b00a9d232a",
+                "url": "https://api.github.com/repos/symfony/string/zipball/f2e190ee75ff0f5eced645ec0be5c66fac81f51f",
+                "reference": "f2e190ee75ff0f5eced645ec0be5c66fac81f51f",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.2",
+                "php": ">=8.1",
                 "symfony/polyfill-ctype": "~1.8",
                 "symfony/polyfill-intl-grapheme": "~1.0",
                 "symfony/polyfill-intl-normalizer": "~1.0",
                 "symfony/polyfill-mbstring": "~1.0"
             },
             "conflict": {
-                "symfony/translation-contracts": "<2.0"
+                "symfony/translation-contracts": "<2.5"
             },
             "require-dev": {
                 "symfony/error-handler": "^5.4|^6.0",
                 "symfony/http-client": "^5.4|^6.0",
-                "symfony/translation-contracts": "^2.0|^3.0",
+                "symfony/intl": "^6.2",
+                "symfony/translation-contracts": "^2.5|^3.0",
                 "symfony/var-exporter": "^5.4|^6.0"
             },
             "type": "library",
@@ -4809,7 +4805,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v6.0.19"
+                "source": "https://github.com/symfony/string/tree/v6.3.0"
             },
             "funding": [
                 {
@@ -4825,7 +4821,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-01T08:36:10+00:00"
+            "time": "2023-03-21T21:06:29+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -5103,13 +5099,13 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "~8.0.0 || ~8.1.0 || ~8.2.0",
+        "php": "~8.1.0 || ~8.2.0",
         "ext-dom": "*",
         "ext-libxml": "*"
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "8.0.99"
+        "php": "8.1.99"
     },
     "plugin-api-version": "2.3.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ac2c4348a6b17437e583475d8e7651d3",
+    "content-hash": "44d667b694636d6ed21118b3e119b6db",
     "packages": [
         {
             "name": "laminas/laminas-escaper",
@@ -69,96 +69,6 @@
             "time": "2022-10-10T10:11:09+00:00"
         },
         {
-            "name": "laminas/laminas-servicemanager",
-            "version": "3.20.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laminas/laminas-servicemanager.git",
-                "reference": "bc2c2cbe2dd90db8b9d16b0618f542692b76ab59"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-servicemanager/zipball/bc2c2cbe2dd90db8b9d16b0618f542692b76ab59",
-                "reference": "bc2c2cbe2dd90db8b9d16b0618f542692b76ab59",
-                "shasum": ""
-            },
-            "require": {
-                "laminas/laminas-stdlib": "^3.2.1",
-                "php": "~8.0.0 || ~8.1.0 || ~8.2.0",
-                "psr/container": "^1.0"
-            },
-            "conflict": {
-                "ext-psr": "*",
-                "laminas/laminas-code": "<3.3.1",
-                "zendframework/zend-code": "<3.3.1",
-                "zendframework/zend-servicemanager": "*"
-            },
-            "provide": {
-                "psr/container-implementation": "^1.0"
-            },
-            "replace": {
-                "container-interop/container-interop": "^1.2.0"
-            },
-            "require-dev": {
-                "composer/package-versions-deprecated": "^1.11.99.5",
-                "laminas/laminas-coding-standard": "~2.4.0",
-                "laminas/laminas-container-config-test": "^0.8",
-                "laminas/laminas-dependency-plugin": "^2.2",
-                "mikey179/vfsstream": "^1.6.11@alpha",
-                "ocramius/proxy-manager": "^2.14.1",
-                "phpbench/phpbench": "^1.2.7",
-                "phpunit/phpunit": "^9.5.26",
-                "psalm/plugin-phpunit": "^0.18.0",
-                "vimeo/psalm": "^5.0.0"
-            },
-            "suggest": {
-                "ocramius/proxy-manager": "ProxyManager ^2.1.1 to handle lazy initialization of services"
-            },
-            "bin": [
-                "bin/generate-deps-for-config-factory",
-                "bin/generate-factory-for-class"
-            ],
-            "type": "library",
-            "autoload": {
-                "files": [
-                    "src/autoload.php"
-                ],
-                "psr-4": {
-                    "Laminas\\ServiceManager\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "Factory-Driven Dependency Injection Container",
-            "homepage": "https://laminas.dev",
-            "keywords": [
-                "PSR-11",
-                "dependency-injection",
-                "di",
-                "dic",
-                "laminas",
-                "service-manager",
-                "servicemanager"
-            ],
-            "support": {
-                "chat": "https://laminas.dev/chat",
-                "docs": "https://docs.laminas.dev/laminas-servicemanager/",
-                "forum": "https://discourse.laminas.dev",
-                "issues": "https://github.com/laminas/laminas-servicemanager/issues",
-                "rss": "https://github.com/laminas/laminas-servicemanager/releases.atom",
-                "source": "https://github.com/laminas/laminas-servicemanager"
-            },
-            "funding": [
-                {
-                    "url": "https://funding.communitybridge.org/projects/laminas-project",
-                    "type": "community_bridge"
-                }
-            ],
-            "time": "2022-12-01T17:03:38+00:00"
-        },
-        {
             "name": "laminas/laminas-stdlib",
             "version": "3.16.1",
             "source": {
@@ -216,54 +126,6 @@
                 }
             ],
             "time": "2022-12-03T18:48:01+00:00"
-        },
-        {
-            "name": "psr/container",
-            "version": "1.1.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/container.git",
-                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/container/zipball/513e0666f7216c7459170d56df27dfcefe1689ea",
-                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.4.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Container\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "https://www.php-fig.org/"
-                }
-            ],
-            "description": "Common Container Interface (PHP FIG PSR-11)",
-            "homepage": "https://github.com/php-fig/container",
-            "keywords": [
-                "PSR-11",
-                "container",
-                "container-interface",
-                "container-interop",
-                "psr"
-            ],
-            "support": {
-                "issues": "https://github.com/php-fig/container/issues",
-                "source": "https://github.com/php-fig/container/tree/1.1.2"
-            },
-            "time": "2021-11-05T16:50:12+00:00"
         }
     ],
     "packages-dev": [
@@ -1009,16 +871,16 @@
         },
         {
             "name": "fidry/cpu-core-counter",
-            "version": "0.4.1",
+            "version": "0.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/theofidry/cpu-core-counter.git",
-                "reference": "79261cc280aded96d098e1b0e0ba0c4881b432c2"
+                "reference": "b58e5a3933e541dc286cc91fc4f3898bbc6f1623"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theofidry/cpu-core-counter/zipball/79261cc280aded96d098e1b0e0ba0c4881b432c2",
-                "reference": "79261cc280aded96d098e1b0e0ba0c4881b432c2",
+                "url": "https://api.github.com/repos/theofidry/cpu-core-counter/zipball/b58e5a3933e541dc286cc91fc4f3898bbc6f1623",
+                "reference": "b58e5a3933e541dc286cc91fc4f3898bbc6f1623",
                 "shasum": ""
             },
             "require": {
@@ -1058,7 +920,7 @@
             ],
             "support": {
                 "issues": "https://github.com/theofidry/cpu-core-counter/issues",
-                "source": "https://github.com/theofidry/cpu-core-counter/tree/0.4.1"
+                "source": "https://github.com/theofidry/cpu-core-counter/tree/0.5.1"
             },
             "funding": [
                 {
@@ -1066,20 +928,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-12-16T22:01:02+00:00"
+            "time": "2022-12-24T12:35:10+00:00"
         },
         {
             "name": "laminas/laminas-cache",
-            "version": "3.10.0",
+            "version": "3.10.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-cache.git",
-                "reference": "5807c51b92fd256bbf58eda6df4c1d27148bbfb8"
+                "reference": "7bda6c5b500b916cbb03d0504069865d31b3efa5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-cache/zipball/5807c51b92fd256bbf58eda6df4c1d27148bbfb8",
-                "reference": "5807c51b92fd256bbf58eda6df4c1d27148bbfb8",
+                "url": "https://api.github.com/repos/laminas/laminas-cache/zipball/7bda6c5b500b916cbb03d0504069865d31b3efa5",
+                "reference": "7bda6c5b500b916cbb03d0504069865d31b3efa5",
                 "shasum": ""
             },
             "require": {
@@ -1166,7 +1028,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2023-01-10T14:17:43+00:00"
+            "time": "2023-03-31T18:59:17+00:00"
         },
         {
             "name": "laminas/laminas-cache-storage-adapter-memory",
@@ -1293,16 +1155,16 @@
         },
         {
             "name": "laminas/laminas-db",
-            "version": "2.16.3",
+            "version": "2.18.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-db.git",
-                "reference": "dadd9a19d2f9e89aa59205572b928892b91ff1da"
+                "reference": "4df7a3f7ffe268e8683306fcec125c269408b295"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-db/zipball/dadd9a19d2f9e89aa59205572b928892b91ff1da",
-                "reference": "dadd9a19d2f9e89aa59205572b928892b91ff1da",
+                "url": "https://api.github.com/repos/laminas/laminas-db/zipball/4df7a3f7ffe268e8683306fcec125c269408b295",
+                "reference": "4df7a3f7ffe268e8683306fcec125c269408b295",
                 "shasum": ""
             },
             "require": {
@@ -1360,7 +1222,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-12-17T16:31:58+00:00"
+            "time": "2023-05-05T16:22:28+00:00"
         },
         {
             "name": "laminas/laminas-eventmanager",
@@ -1552,6 +1414,96 @@
             "time": "2022-10-16T12:50:49+00:00"
         },
         {
+            "name": "laminas/laminas-servicemanager",
+            "version": "3.20.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-servicemanager.git",
+                "reference": "bc2c2cbe2dd90db8b9d16b0618f542692b76ab59"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-servicemanager/zipball/bc2c2cbe2dd90db8b9d16b0618f542692b76ab59",
+                "reference": "bc2c2cbe2dd90db8b9d16b0618f542692b76ab59",
+                "shasum": ""
+            },
+            "require": {
+                "laminas/laminas-stdlib": "^3.2.1",
+                "php": "~8.0.0 || ~8.1.0 || ~8.2.0",
+                "psr/container": "^1.0"
+            },
+            "conflict": {
+                "ext-psr": "*",
+                "laminas/laminas-code": "<3.3.1",
+                "zendframework/zend-code": "<3.3.1",
+                "zendframework/zend-servicemanager": "*"
+            },
+            "provide": {
+                "psr/container-implementation": "^1.0"
+            },
+            "replace": {
+                "container-interop/container-interop": "^1.2.0"
+            },
+            "require-dev": {
+                "composer/package-versions-deprecated": "^1.11.99.5",
+                "laminas/laminas-coding-standard": "~2.4.0",
+                "laminas/laminas-container-config-test": "^0.8",
+                "laminas/laminas-dependency-plugin": "^2.2",
+                "mikey179/vfsstream": "^1.6.11@alpha",
+                "ocramius/proxy-manager": "^2.14.1",
+                "phpbench/phpbench": "^1.2.7",
+                "phpunit/phpunit": "^9.5.26",
+                "psalm/plugin-phpunit": "^0.18.0",
+                "vimeo/psalm": "^5.0.0"
+            },
+            "suggest": {
+                "ocramius/proxy-manager": "ProxyManager ^2.1.1 to handle lazy initialization of services"
+            },
+            "bin": [
+                "bin/generate-deps-for-config-factory",
+                "bin/generate-factory-for-class"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/autoload.php"
+                ],
+                "psr-4": {
+                    "Laminas\\ServiceManager\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Factory-Driven Dependency Injection Container",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "PSR-11",
+                "dependency-injection",
+                "di",
+                "dic",
+                "laminas",
+                "service-manager",
+                "servicemanager"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-servicemanager/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-servicemanager/issues",
+                "rss": "https://github.com/laminas/laminas-servicemanager/releases.atom",
+                "source": "https://github.com/laminas/laminas-servicemanager"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2022-12-01T17:03:38+00:00"
+        },
+        {
             "name": "laminas/laminas-uri",
             "version": "2.10.0",
             "source": {
@@ -1611,16 +1563,16 @@
         },
         {
             "name": "laminas/laminas-validator",
-            "version": "2.29.0",
+            "version": "2.30.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-validator.git",
-                "reference": "e40ee8d86cc1907083e273bfd6ed8b6dde2d9850"
+                "reference": "b7d217b5e4951955fda9a3a5ada91b717b5c8d5c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-validator/zipball/e40ee8d86cc1907083e273bfd6ed8b6dde2d9850",
-                "reference": "e40ee8d86cc1907083e273bfd6ed8b6dde2d9850",
+                "url": "https://api.github.com/repos/laminas/laminas-validator/zipball/b7d217b5e4951955fda9a3a5ada91b717b5c8d5c",
+                "reference": "b7d217b5e4951955fda9a3a5ada91b717b5c8d5c",
                 "shasum": ""
             },
             "require": {
@@ -1692,20 +1644,20 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-12-13T22:53:38+00:00"
+            "time": "2023-01-30T22:41:19+00:00"
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.11.0",
+            "version": "1.11.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "14daed4296fae74d9e3201d2c4925d1acb7aa614"
+                "reference": "7284c22080590fb39f2ffa3e9057f10a4ddd0e0c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/14daed4296fae74d9e3201d2c4925d1acb7aa614",
-                "reference": "14daed4296fae74d9e3201d2c4925d1acb7aa614",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/7284c22080590fb39f2ffa3e9057f10a4ddd0e0c",
+                "reference": "7284c22080590fb39f2ffa3e9057f10a4ddd0e0c",
                 "shasum": ""
             },
             "require": {
@@ -1743,7 +1695,7 @@
             ],
             "support": {
                 "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.11.0"
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.11.1"
             },
             "funding": [
                 {
@@ -1751,20 +1703,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-03-03T13:19:32+00:00"
+            "time": "2023-03-08T13:26:56+00:00"
         },
         {
             "name": "netresearch/jsonmapper",
-            "version": "v4.1.0",
+            "version": "v4.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cweiske/jsonmapper.git",
-                "reference": "cfa81ea1d35294d64adb9c68aa4cb9e92400e53f"
+                "reference": "f60565f8c0566a31acf06884cdaa591867ecc956"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cweiske/jsonmapper/zipball/cfa81ea1d35294d64adb9c68aa4cb9e92400e53f",
-                "reference": "cfa81ea1d35294d64adb9c68aa4cb9e92400e53f",
+                "url": "https://api.github.com/repos/cweiske/jsonmapper/zipball/f60565f8c0566a31acf06884cdaa591867ecc956",
+                "reference": "f60565f8c0566a31acf06884cdaa591867ecc956",
                 "shasum": ""
             },
             "require": {
@@ -1800,22 +1752,22 @@
             "support": {
                 "email": "cweiske@cweiske.de",
                 "issues": "https://github.com/cweiske/jsonmapper/issues",
-                "source": "https://github.com/cweiske/jsonmapper/tree/v4.1.0"
+                "source": "https://github.com/cweiske/jsonmapper/tree/v4.2.0"
             },
-            "time": "2022-12-08T20:46:14+00:00"
+            "time": "2023-04-09T17:37:40+00:00"
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.15.3",
+            "version": "v4.16.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "570e980a201d8ed0236b0a62ddf2c9cbb2034039"
+                "reference": "19526a33fb561ef417e822e85f08a00db4059c17"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/570e980a201d8ed0236b0a62ddf2c9cbb2034039",
-                "reference": "570e980a201d8ed0236b0a62ddf2c9cbb2034039",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/19526a33fb561ef417e822e85f08a00db4059c17",
+                "reference": "19526a33fb561ef417e822e85f08a00db4059c17",
                 "shasum": ""
             },
             "require": {
@@ -1856,9 +1808,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.15.3"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.16.0"
             },
-            "time": "2023-01-16T22:05:37+00:00"
+            "time": "2023-06-25T14:52:30+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -2182,23 +2134,23 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.23",
+            "version": "9.2.26",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "9f1f0f9a2fbb680b26d1cf9b61b6eac43a6e4e9c"
+                "reference": "443bc6912c9bd5b409254a40f4b0f4ced7c80ea1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/9f1f0f9a2fbb680b26d1cf9b61b6eac43a6e4e9c",
-                "reference": "9f1f0f9a2fbb680b26d1cf9b61b6eac43a6e4e9c",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/443bc6912c9bd5b409254a40f4b0f4ced7c80ea1",
+                "reference": "443bc6912c9bd5b409254a40f4b0f4ced7c80ea1",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-libxml": "*",
                 "ext-xmlwriter": "*",
-                "nikic/php-parser": "^4.14",
+                "nikic/php-parser": "^4.15",
                 "php": ">=7.3",
                 "phpunit/php-file-iterator": "^3.0.3",
                 "phpunit/php-text-template": "^2.0.2",
@@ -2213,8 +2165,8 @@
                 "phpunit/phpunit": "^9.3"
             },
             "suggest": {
-                "ext-pcov": "*",
-                "ext-xdebug": "*"
+                "ext-pcov": "PHP extension that provides line coverage",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
             },
             "type": "library",
             "extra": {
@@ -2247,7 +2199,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.23"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.26"
             },
             "funding": [
                 {
@@ -2255,7 +2207,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-12-28T12:41:10+00:00"
+            "time": "2023-03-06T12:58:08+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -2500,16 +2452,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.5.28",
+            "version": "9.6.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "954ca3113a03bf780d22f07bf055d883ee04b65e"
+                "reference": "a6d351645c3fe5a30f5e86be6577d946af65a328"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/954ca3113a03bf780d22f07bf055d883ee04b65e",
-                "reference": "954ca3113a03bf780d22f07bf055d883ee04b65e",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/a6d351645c3fe5a30f5e86be6577d946af65a328",
+                "reference": "a6d351645c3fe5a30f5e86be6577d946af65a328",
                 "shasum": ""
             },
             "require": {
@@ -2542,8 +2494,8 @@
                 "sebastian/version": "^3.0.2"
             },
             "suggest": {
-                "ext-soap": "*",
-                "ext-xdebug": "*"
+                "ext-soap": "To be able to generate mocks based on WSDL files",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
             },
             "bin": [
                 "phpunit"
@@ -2551,7 +2503,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "9.5-dev"
+                    "dev-master": "9.6-dev"
                 }
             },
             "autoload": {
@@ -2582,7 +2534,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.28"
+                "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.10"
             },
             "funding": [
                 {
@@ -2598,7 +2551,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-14T12:32:24+00:00"
+            "time": "2023-07-10T04:04:23+00:00"
         },
         {
             "name": "psalm/plugin-phpunit",
@@ -2758,26 +2711,74 @@
             "time": "2022-11-25T14:36:26+00:00"
         },
         {
-            "name": "psr/http-message",
-            "version": "1.0.1",
+            "name": "psr/container",
+            "version": "1.1.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/php-fig/http-message.git",
-                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363"
+                "url": "https://github.com/php-fig/container.git",
+                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/http-message/zipball/f6561bf28d520154e4b0ec72be95418abe6d9363",
-                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/513e0666f7216c7459170d56df27dfcefe1689ea",
+                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0"
+                "php": ">=7.4.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Container\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common Container Interface (PHP FIG PSR-11)",
+            "homepage": "https://github.com/php-fig/container",
+            "keywords": [
+                "PSR-11",
+                "container",
+                "container-interface",
+                "container-interop",
+                "psr"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/container/issues",
+                "source": "https://github.com/php-fig/container/tree/1.1.2"
+            },
+            "time": "2021-11-05T16:50:12+00:00"
+        },
+        {
+            "name": "psr/http-message",
+            "version": "1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-message.git",
+                "reference": "cb6ce4845ce34a8ad9e68117c10ee90a29919eba"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/cb6ce4845ce34a8ad9e68117c10ee90a29919eba",
+                "reference": "cb6ce4845ce34a8ad9e68117c10ee90a29919eba",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.1.x-dev"
                 }
             },
             "autoload": {
@@ -2806,9 +2807,9 @@
                 "response"
             ],
             "support": {
-                "source": "https://github.com/php-fig/http-message/tree/master"
+                "source": "https://github.com/php-fig/http-message/tree/1.1"
             },
-            "time": "2016-08-06T14:39:51+00:00"
+            "time": "2023-04-04T09:50:52+00:00"
         },
         {
             "name": "psr/log",
@@ -3211,16 +3212,16 @@
         },
         {
             "name": "sebastian/diff",
-            "version": "4.0.4",
+            "version": "4.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "3461e3fccc7cfdfc2720be910d3bd73c69be590d"
+                "reference": "74be17022044ebaaecfdf0c5cd504fc9cd5a7131"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/3461e3fccc7cfdfc2720be910d3bd73c69be590d",
-                "reference": "3461e3fccc7cfdfc2720be910d3bd73c69be590d",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/74be17022044ebaaecfdf0c5cd504fc9cd5a7131",
+                "reference": "74be17022044ebaaecfdf0c5cd504fc9cd5a7131",
                 "shasum": ""
             },
             "require": {
@@ -3265,7 +3266,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/diff/issues",
-                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.4"
+                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.5"
             },
             "funding": [
                 {
@@ -3273,20 +3274,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:10:38+00:00"
+            "time": "2023-05-07T05:35:17+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "5.1.4",
+            "version": "5.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "1b5dff7bb151a4db11d49d90e5408e4e938270f7"
+                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/1b5dff7bb151a4db11d49d90e5408e4e938270f7",
-                "reference": "1b5dff7bb151a4db11d49d90e5408e4e938270f7",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
+                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
                 "shasum": ""
             },
             "require": {
@@ -3328,7 +3329,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/environment/issues",
-                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.4"
+                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.5"
             },
             "funding": [
                 {
@@ -3336,7 +3337,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-04-03T09:37:03+00:00"
+            "time": "2023-02-03T06:03:51+00:00"
         },
         {
             "name": "sebastian/exporter",
@@ -3650,16 +3651,16 @@
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "4.0.4",
+            "version": "4.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "cd9d8cf3c5804de4341c283ed787f099f5506172"
+                "reference": "e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/cd9d8cf3c5804de4341c283ed787f099f5506172",
-                "reference": "cd9d8cf3c5804de4341c283ed787f099f5506172",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1",
+                "reference": "e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1",
                 "shasum": ""
             },
             "require": {
@@ -3698,10 +3699,10 @@
                 }
             ],
             "description": "Provides functionality to recursively process PHP variables",
-            "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
+            "homepage": "https://github.com/sebastianbergmann/recursion-context",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
-                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.4"
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.5"
             },
             "funding": [
                 {
@@ -3709,7 +3710,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:17:30+00:00"
+            "time": "2023-02-03T06:07:39+00:00"
         },
         {
             "name": "sebastian/resource-operations",
@@ -3768,16 +3769,16 @@
         },
         {
             "name": "sebastian/type",
-            "version": "3.2.0",
+            "version": "3.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "fb3fe09c5f0bae6bc27ef3ce933a1e0ed9464b6e"
+                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/fb3fe09c5f0bae6bc27ef3ce933a1e0ed9464b6e",
-                "reference": "fb3fe09c5f0bae6bc27ef3ce933a1e0ed9464b6e",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
+                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
                 "shasum": ""
             },
             "require": {
@@ -3812,7 +3813,7 @@
             "homepage": "https://github.com/sebastianbergmann/type",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/type/issues",
-                "source": "https://github.com/sebastianbergmann/type/tree/3.2.0"
+                "source": "https://github.com/sebastianbergmann/type/tree/3.2.1"
             },
             "funding": [
                 {
@@ -3820,7 +3821,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-09-12T14:47:03+00:00"
+            "time": "2023-02-03T06:13:03+00:00"
         },
         {
             "name": "sebastian/version",
@@ -3938,26 +3939,25 @@
         },
         {
             "name": "spatie/array-to-xml",
-            "version": "2.17.1",
+            "version": "3.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spatie/array-to-xml.git",
-                "reference": "5cbec9c6ab17e320c58a259f0cebe88bde4a7c46"
+                "reference": "f9ab39c808500c347d5a8b6b13310bd5221e39e7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spatie/array-to-xml/zipball/5cbec9c6ab17e320c58a259f0cebe88bde4a7c46",
-                "reference": "5cbec9c6ab17e320c58a259f0cebe88bde4a7c46",
+                "url": "https://api.github.com/repos/spatie/array-to-xml/zipball/f9ab39c808500c347d5a8b6b13310bd5221e39e7",
+                "reference": "f9ab39c808500c347d5a8b6b13310bd5221e39e7",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
-                "php": "^7.4|^8.0"
+                "php": "^8.0"
             },
             "require-dev": {
                 "mockery/mockery": "^1.2",
                 "pestphp/pest": "^1.21",
-                "phpunit/phpunit": "^9.0",
                 "spatie/pest-plugin-snapshots": "^1.1"
             },
             "type": "library",
@@ -3986,7 +3986,7 @@
                 "xml"
             ],
             "support": {
-                "source": "https://github.com/spatie/array-to-xml/tree/2.17.1"
+                "source": "https://github.com/spatie/array-to-xml/tree/3.2.0"
             },
             "funding": [
                 {
@@ -3998,20 +3998,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-12-26T08:22:07+00:00"
+            "time": "2023-07-19T18:30:26+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.7.1",
+            "version": "3.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "1359e176e9307e906dc3d890bcc9603ff6d90619"
+                "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/1359e176e9307e906dc3d890bcc9603ff6d90619",
-                "reference": "1359e176e9307e906dc3d890bcc9603ff6d90619",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/ed8e00df0a83aa96acf703f8c2979ff33341f879",
+                "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879",
                 "shasum": ""
             },
             "require": {
@@ -4047,14 +4047,15 @@
             "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
             "keywords": [
                 "phpcs",
-                "standards"
+                "standards",
+                "static analysis"
             ],
             "support": {
                 "issues": "https://github.com/squizlabs/PHP_CodeSniffer/issues",
                 "source": "https://github.com/squizlabs/PHP_CodeSniffer",
                 "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
             },
-            "time": "2022-06-18T07:21:10+00:00"
+            "time": "2023-02-22T23:07:41+00:00"
         },
         {
             "name": "stella-maris/clock",
@@ -4105,16 +4106,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v6.0.17",
+            "version": "v6.0.19",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "2ab307342a7233b9a260edd5ef94087aaca57d18"
+                "reference": "c3ebc83d031b71c39da318ca8b7a07ecc67507ed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/2ab307342a7233b9a260edd5ef94087aaca57d18",
-                "reference": "2ab307342a7233b9a260edd5ef94087aaca57d18",
+                "url": "https://api.github.com/repos/symfony/console/zipball/c3ebc83d031b71c39da318ca8b7a07ecc67507ed",
+                "reference": "c3ebc83d031b71c39da318ca8b7a07ecc67507ed",
                 "shasum": ""
             },
             "require": {
@@ -4180,7 +4181,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v6.0.17"
+                "source": "https://github.com/symfony/console/tree/v6.0.19"
             },
             "funding": [
                 {
@@ -4196,7 +4197,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-12-28T14:21:34+00:00"
+            "time": "2023-01-01T08:36:10+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -4267,16 +4268,16 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v6.0.13",
+            "version": "v6.0.19",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "3adca49133bd055ebe6011ed1e012be3c908af79"
+                "reference": "3d49eec03fda1f0fc19b7349fbbe55ebc1004214"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/3adca49133bd055ebe6011ed1e012be3c908af79",
-                "reference": "3adca49133bd055ebe6011ed1e012be3c908af79",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/3d49eec03fda1f0fc19b7349fbbe55ebc1004214",
+                "reference": "3d49eec03fda1f0fc19b7349fbbe55ebc1004214",
                 "shasum": ""
             },
             "require": {
@@ -4310,7 +4311,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v6.0.13"
+                "source": "https://github.com/symfony/filesystem/tree/v6.0.19"
             },
             "funding": [
                 {
@@ -4326,7 +4327,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-09-21T20:25:27+00:00"
+            "time": "2023-01-20T17:44:14+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -4659,89 +4660,6 @@
             "time": "2022-11-03T14:55:06+00:00"
         },
         {
-            "name": "symfony/polyfill-php80",
-            "version": "v1.27.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "7a6ff3f1959bb01aefccb463a0f2cd3d3d2fd936"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/7a6ff3f1959bb01aefccb463a0f2cd3d3d2fd936",
-                "reference": "7a6ff3f1959bb01aefccb463a0f2cd3d3d2fd936",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.1"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "1.27-dev"
-                },
-                "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php80\\": ""
-                },
-                "classmap": [
-                    "Resources/stubs"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Ion Bazan",
-                    "email": "ion.bazan@gmail.com"
-                },
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.27.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2022-11-03T14:55:06+00:00"
-        },
-        {
             "name": "symfony/service-contracts",
             "version": "v2.5.2",
             "source": {
@@ -4826,16 +4744,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v6.0.17",
+            "version": "v6.0.19",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "3f57003dd8a67ed76870cc03092f8501db7788d9"
+                "reference": "d9e72497367c23e08bf94176d2be45b00a9d232a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/3f57003dd8a67ed76870cc03092f8501db7788d9",
-                "reference": "3f57003dd8a67ed76870cc03092f8501db7788d9",
+                "url": "https://api.github.com/repos/symfony/string/zipball/d9e72497367c23e08bf94176d2be45b00a9d232a",
+                "reference": "d9e72497367c23e08bf94176d2be45b00a9d232a",
                 "shasum": ""
             },
             "require": {
@@ -4891,7 +4809,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v6.0.17"
+                "source": "https://github.com/symfony/string/tree/v6.0.19"
             },
             "funding": [
                 {
@@ -4907,7 +4825,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-12-14T15:52:41+00:00"
+            "time": "2023-01-01T08:36:10+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -4961,22 +4879,22 @@
         },
         {
             "name": "vimeo/psalm",
-            "version": "5.4.0",
+            "version": "5.13.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vimeo/psalm.git",
-                "reference": "62db5d4f6a7ae0a20f7cc5a4952d730272fc0863"
+                "reference": "086b94371304750d1c673315321a55d15fc59015"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vimeo/psalm/zipball/62db5d4f6a7ae0a20f7cc5a4952d730272fc0863",
-                "reference": "62db5d4f6a7ae0a20f7cc5a4952d730272fc0863",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/086b94371304750d1c673315321a55d15fc59015",
+                "reference": "086b94371304750d1c673315321a55d15fc59015",
                 "shasum": ""
             },
             "require": {
                 "amphp/amp": "^2.4.2",
                 "amphp/byte-stream": "^1.5",
-                "composer/package-versions-deprecated": "^1.10.0",
+                "composer-runtime-api": "^2",
                 "composer/semver": "^1.4 || ^2.0 || ^3.0",
                 "composer/xdebug-handler": "^2.0 || ^3.0",
                 "dnoegel/php-xdg-base-dir": "^0.1.1",
@@ -4989,28 +4907,28 @@
                 "ext-tokenizer": "*",
                 "felixfbecker/advanced-json-rpc": "^3.1",
                 "felixfbecker/language-server-protocol": "^1.5.2",
-                "fidry/cpu-core-counter": "^0.4.0",
+                "fidry/cpu-core-counter": "^0.4.1 || ^0.5.1",
                 "netresearch/jsonmapper": "^1.0 || ^2.0 || ^3.0 || ^4.0",
-                "nikic/php-parser": "^4.13",
+                "nikic/php-parser": "^4.14",
                 "php": "^7.4 || ~8.0.0 || ~8.1.0 || ~8.2.0",
-                "sebastian/diff": "^4.0",
-                "spatie/array-to-xml": "^2.17.0",
+                "sebastian/diff": "^4.0 || ^5.0",
+                "spatie/array-to-xml": "^2.17.0 || ^3.0",
                 "symfony/console": "^4.1.6 || ^5.0 || ^6.0",
-                "symfony/filesystem": "^5.4 || ^6.0",
-                "symfony/polyfill-php80": "^1.25"
+                "symfony/filesystem": "^5.4 || ^6.0"
             },
             "provide": {
                 "psalm/psalm": "self.version"
             },
             "require-dev": {
+                "amphp/phpunit-util": "^2.0",
                 "bamarni/composer-bin-plugin": "^1.4",
-                "brianium/paratest": "^6.0",
+                "brianium/paratest": "^6.9",
                 "ext-curl": "*",
                 "mockery/mockery": "^1.5",
                 "nunomaduro/mock-final-classes": "^1.1",
                 "php-parallel-lint/php-parallel-lint": "^1.2",
                 "phpstan/phpdoc-parser": "^1.6",
-                "phpunit/phpunit": "^9.5",
+                "phpunit/phpunit": "^9.6",
                 "psalm/plugin-mockery": "^1.1",
                 "psalm/plugin-phpunit": "^0.18",
                 "slevomat/coding-standard": "^8.4",
@@ -5056,34 +4974,35 @@
             "keywords": [
                 "code",
                 "inspection",
-                "php"
+                "php",
+                "static analysis"
             ],
             "support": {
                 "issues": "https://github.com/vimeo/psalm/issues",
-                "source": "https://github.com/vimeo/psalm/tree/5.4.0"
+                "source": "https://github.com/vimeo/psalm/tree/5.13.1"
             },
-            "time": "2022-12-19T21:31:12+00:00"
+            "time": "2023-06-27T16:39:49+00:00"
         },
         {
             "name": "webimpress/coding-standard",
-            "version": "1.2.4",
+            "version": "1.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webimpress/coding-standard.git",
-                "reference": "cd0c4b0b97440c337c1f7da17b524674ca2f9ca9"
+                "reference": "b26557e2386711ecb74f22718f4b4bde5ddbc899"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webimpress/coding-standard/zipball/cd0c4b0b97440c337c1f7da17b524674ca2f9ca9",
-                "reference": "cd0c4b0b97440c337c1f7da17b524674ca2f9ca9",
+                "url": "https://api.github.com/repos/webimpress/coding-standard/zipball/b26557e2386711ecb74f22718f4b4bde5ddbc899",
+                "reference": "b26557e2386711ecb74f22718f4b4bde5ddbc899",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.3 || ^8.0",
-                "squizlabs/php_codesniffer": "^3.6.2"
+                "squizlabs/php_codesniffer": "^3.7.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.5.13"
+                "phpunit/phpunit": "^9.6.4"
             },
             "type": "phpcodesniffer-standard",
             "extra": {
@@ -5109,7 +5028,7 @@
             ],
             "support": {
                 "issues": "https://github.com/webimpress/coding-standard/issues",
-                "source": "https://github.com/webimpress/coding-standard/tree/1.2.4"
+                "source": "https://github.com/webimpress/coding-standard/tree/1.3.1"
             },
             "funding": [
                 {
@@ -5117,7 +5036,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-02-15T19:52:12+00:00"
+            "time": "2023-03-09T15:05:18+00:00"
         },
         {
             "name": "webmozart/assert",

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -11,7 +11,7 @@
       <code>$_SERVER[$temp]</code>
     </InvalidReturnStatement>
     <MixedArgument>
-      <code>$options['storage']</code>
+      <code><![CDATA[$options['storage']]]></code>
     </MixedArgument>
     <MixedInferredReturnType>
       <code>bool|string</code>
@@ -20,8 +20,8 @@
       <code>$headers[$header]</code>
     </MixedReturnStatement>
     <PossiblyUndefinedArrayOffset>
-      <code>$_SERVER['ORIG_PATH_INFO']</code>
-      <code>$_SERVER['REQUEST_URI']</code>
+      <code><![CDATA[$_SERVER['ORIG_PATH_INFO']]]></code>
+      <code><![CDATA[$_SERVER['REQUEST_URI']]]></code>
     </PossiblyUndefinedArrayOffset>
     <PropertyNotSetInConstructor>
       <code>$httpResponse</code>
@@ -45,19 +45,19 @@
       <code>strlen($content)</code>
     </InvalidArgument>
     <MixedArgument>
-      <code>$header['replace']</code>
-      <code>$header['replace']</code>
+      <code><![CDATA[$header['replace']]]></code>
+      <code><![CDATA[$header['replace']]]></code>
     </MixedArgument>
     <MixedArrayAccess>
-      <code>$header['name']</code>
-      <code>$header['name']</code>
-      <code>$header['name']</code>
-      <code>$header['name']</code>
-      <code>$header['replace']</code>
-      <code>$header['replace']</code>
-      <code>$header['value']</code>
-      <code>$header['value']</code>
-      <code>$header['value']</code>
+      <code><![CDATA[$header['name']]]></code>
+      <code><![CDATA[$header['name']]]></code>
+      <code><![CDATA[$header['name']]]></code>
+      <code><![CDATA[$header['name']]]></code>
+      <code><![CDATA[$header['replace']]]></code>
+      <code><![CDATA[$header['replace']]]></code>
+      <code><![CDATA[$header['value']]]></code>
+      <code><![CDATA[$header['value']]]></code>
+      <code><![CDATA[$header['value']]]></code>
     </MixedArrayAccess>
     <MixedAssignment>
       <code>$header</code>
@@ -69,13 +69,13 @@
     </MixedInferredReturnType>
     <MixedOperand>
       <code>$code</code>
-      <code>$header['name']</code>
-      <code>$header['name']</code>
-      <code>$header['value']</code>
-      <code>$header['value']</code>
+      <code><![CDATA[$header['name']]]></code>
+      <code><![CDATA[$header['name']]]></code>
+      <code><![CDATA[$header['value']]]></code>
+      <code><![CDATA[$header['value']]]></code>
     </MixedOperand>
     <MixedReturnStatement>
-      <code>$header['value']</code>
+      <code><![CDATA[$header['value']]]></code>
     </MixedReturnStatement>
     <RedundantCastGivenDocblockType>
       <code>(string) $content</code>
@@ -102,7 +102,7 @@
       <code>$data</code>
     </MixedArgumentTypeCoercion>
     <MixedAssignment>
-      <code>$data['created_time']</code>
+      <code><![CDATA[$data['created_time']]]></code>
     </MixedAssignment>
     <MixedInferredReturnType>
       <code>array</code>
@@ -111,7 +111,7 @@
       <code>getArrayCopy</code>
     </MixedMethodCall>
     <MixedOperand>
-      <code>$data['lease_seconds']</code>
+      <code><![CDATA[$data['lease_seconds']]]></code>
       <code>$key</code>
       <code>$key</code>
     </MixedOperand>
@@ -150,9 +150,9 @@
       <code>is_array($options)</code>
     </DocblockTypeContradiction>
     <MixedArgument>
-      <code>$options['hubUrls']</code>
-      <code>$options['parameters']</code>
-      <code>$options['updatedTopicUrls']</code>
+      <code><![CDATA[$options['hubUrls']]]></code>
+      <code><![CDATA[$options['parameters']]]></code>
+      <code><![CDATA[$options['updatedTopicUrls']]]></code>
       <code>$topicUrl</code>
       <code>$url</code>
       <code>$url</code>
@@ -210,15 +210,15 @@
       <code>$auth[1]</code>
       <code>$authentication</code>
       <code>$duplicateKey</code>
-      <code>$options['authentications']</code>
-      <code>$options['callbackUrl']</code>
-      <code>$options['hubUrls']</code>
-      <code>$options['leaseSeconds']</code>
-      <code>$options['parameters']</code>
-      <code>$options['preferredVerificationMode']</code>
-      <code>$options['storage']</code>
-      <code>$options['topicUrl']</code>
-      <code>$options['usePathParameter']</code>
+      <code><![CDATA[$options['authentications']]]></code>
+      <code><![CDATA[$options['callbackUrl']]]></code>
+      <code><![CDATA[$options['hubUrls']]]></code>
+      <code><![CDATA[$options['leaseSeconds']]]></code>
+      <code><![CDATA[$options['parameters']]]></code>
+      <code><![CDATA[$options['preferredVerificationMode']]]></code>
+      <code><![CDATA[$options['storage']]]></code>
+      <code><![CDATA[$options['topicUrl']]]></code>
+      <code><![CDATA[$options['usePathParameter']]]></code>
       <code>$url</code>
       <code>$url</code>
       <code>$url</code>
@@ -231,7 +231,7 @@
       <code>$key</code>
       <code>$name</code>
       <code>$url</code>
-      <code>uksort($params, 'strnatcmp')</code>
+      <code><![CDATA[uksort($params, 'strnatcmp')]]></code>
     </MixedArgumentTypeCoercion>
     <MixedArrayAccess>
       <code>$auth[0]</code>
@@ -254,15 +254,15 @@
       <code>$keyduplicate</code>
       <code>$name</code>
       <code>$name</code>
-      <code>$params['hub.lease_seconds']</code>
-      <code>$params['hub.topic']</code>
+      <code><![CDATA[$params['hub.lease_seconds']]]></code>
+      <code><![CDATA[$params['hub.topic']]]></code>
       <code>$value</code>
     </MixedOperand>
     <PossiblyFalsePropertyAssignmentValue>
       <code>false</code>
     </PossiblyFalsePropertyAssignmentValue>
     <PossiblyInvalidCast>
-      <code>$params['hub.verify_token']</code>
+      <code><![CDATA[$params['hub.verify_token']]]></code>
     </PossiblyInvalidCast>
     <PropertyNotSetInConstructor>
       <code>$leaseSeconds</code>
@@ -299,22 +299,22 @@
       <code><![CDATA[$this->getSubscriberCount()]]></code>
     </InvalidArgument>
     <MixedArgument>
-      <code>$httpGetData['hub_challenge']</code>
-      <code>$httpGetData['hub_mode']</code>
-      <code>$httpGetData['hub_mode']</code>
-      <code>$httpGetData['hub_topic']</code>
-      <code>$httpGetData['hub_verify_token']</code>
-      <code>$params['xhub.subscription']</code>
+      <code><![CDATA[$httpGetData['hub_challenge']]]></code>
+      <code><![CDATA[$httpGetData['hub_mode']]]></code>
+      <code><![CDATA[$httpGetData['hub_mode']]]></code>
+      <code><![CDATA[$httpGetData['hub_topic']]]></code>
+      <code><![CDATA[$httpGetData['hub_verify_token']]]></code>
+      <code><![CDATA[$params['xhub.subscription']]]></code>
     </MixedArgument>
     <MixedAssignment>
-      <code>$data['lease_seconds']</code>
+      <code><![CDATA[$data['lease_seconds']]]></code>
       <code>$verifyToken</code>
     </MixedAssignment>
     <MixedInferredReturnType>
       <code>false|string</code>
     </MixedInferredReturnType>
     <MixedReturnStatement>
-      <code>$httpGetData['xhub_subscription']</code>
+      <code><![CDATA[$httpGetData['xhub_subscription']]]></code>
     </MixedReturnStatement>
     <ParamNameMismatch>
       <code>$httpGetData</code>
@@ -329,22 +329,22 @@
       <code>$contentType</code>
       <code>$contentType</code>
       <code>$contentType</code>
-      <code>$httpGetData['hub_challenge']</code>
-      <code>$httpGetData['hub_mode']</code>
-      <code>$httpGetData['hub_mode']</code>
+      <code><![CDATA[$httpGetData['hub_challenge']]]></code>
+      <code><![CDATA[$httpGetData['hub_mode']]]></code>
+      <code><![CDATA[$httpGetData['hub_mode']]]></code>
     </PossiblyInvalidArgument>
     <PossiblyInvalidCast>
-      <code>$httpGetData['hub_challenge']</code>
+      <code><![CDATA[$httpGetData['hub_challenge']]]></code>
     </PossiblyInvalidCast>
     <PossiblyNullArgument>
-      <code>$httpGetData['hub_verify_token']</code>
+      <code><![CDATA[$httpGetData['hub_verify_token']]]></code>
     </PossiblyNullArgument>
     <PossiblyNullArrayAccess>
-      <code>$httpGetData['hub_verify_token']</code>
+      <code><![CDATA[$httpGetData['hub_verify_token']]]></code>
     </PossiblyNullArrayAccess>
     <PossiblyUndefinedArrayOffset>
-      <code>$_SERVER['REQUEST_METHOD']</code>
-      <code>$_SERVER['REQUEST_METHOD']</code>
+      <code><![CDATA[$_SERVER['REQUEST_METHOD']]]></code>
+      <code><![CDATA[$_SERVER['REQUEST_METHOD']]]></code>
     </PossiblyUndefinedArrayOffset>
     <PossiblyUndefinedMethod>
       <code>setHeader</code>
@@ -365,7 +365,7 @@
       <code>$entry</code>
     </InvalidArgument>
     <MixedArgument>
-      <code>$all['core']</code>
+      <code><![CDATA[$all['core']]]></code>
       <code>$extension</code>
     </MixedArgument>
     <MixedArrayOffset>
@@ -419,7 +419,7 @@
       <code>registerNamespaces</code>
     </MissingReturnType>
     <MixedArgument>
-      <code>$all['core']</code>
+      <code><![CDATA[$all['core']]]></code>
       <code>$extension</code>
       <code>$extension</code>
       <code><![CDATA[$this->entries[$this->key()]]]></code>
@@ -458,7 +458,7 @@
       <code><![CDATA[$this->xpath]]></code>
     </DocblockTypeContradiction>
     <MixedArgument>
-      <code>$all['core']</code>
+      <code><![CDATA[$all['core']]]></code>
       <code>$extension</code>
       <code>$extension</code>
     </MixedArgument>
@@ -587,7 +587,7 @@
       <code>$dateModified</code>
     </MixedArgument>
     <MixedArrayAccess>
-      <code>$author['name']</code>
+      <code><![CDATA[$author['name']]]></code>
     </MixedArrayAccess>
     <MixedAssignment>
       <code>$author</code>
@@ -803,7 +803,7 @@
       <code>Reader\Reader::arrayUnique($authors)</code>
     </InvalidArgument>
     <MixedArgument>
-      <code>$content ?? ''</code>
+      <code><![CDATA[$content ?? '']]></code>
       <code>$dateCreated</code>
       <code>$dateModified</code>
       <code>$link</code>
@@ -1559,7 +1559,7 @@
       <code>registerNamespaces</code>
     </MissingReturnType>
     <MixedArgument>
-      <code>$all['core']</code>
+      <code><![CDATA[$all['core']]]></code>
       <code>$extension</code>
       <code>$extension</code>
       <code>$extension</code>
@@ -1747,6 +1747,14 @@
       <code>void</code>
       <code>void</code>
     </ImplementedReturnTypeMismatch>
+    <MethodSignatureMustProvideReturnType>
+      <code>count</code>
+      <code>current</code>
+      <code>key</code>
+      <code>next</code>
+      <code>rewind</code>
+      <code>valid</code>
+    </MethodSignatureMustProvideReturnType>
     <MixedAssignment>
       <code>$extension</code>
       <code>$extension</code>
@@ -1791,7 +1799,7 @@
       <code>$lastBuildDate</code>
     </MixedArgument>
     <MixedArrayAccess>
-      <code>$author['name']</code>
+      <code><![CDATA[$author['name']]]></code>
     </MixedArrayAccess>
     <MixedArrayOffset>
       <code><![CDATA[$this->entries[$index]]]></code>
@@ -1827,12 +1835,12 @@
       <code>$id</code>
       <code>$id</code>
       <code>$id</code>
-      <code>$image['description']</code>
-      <code>$image['height']</code>
-      <code>$image['link']</code>
-      <code>$image['title']</code>
-      <code>$image['uri']</code>
-      <code>$image['width']</code>
+      <code><![CDATA[$image['description']]]></code>
+      <code><![CDATA[$image['height']]]></code>
+      <code><![CDATA[$image['link']]]></code>
+      <code><![CDATA[$image['title']]]></code>
+      <code><![CDATA[$image['uri']]]></code>
+      <code><![CDATA[$image['width']]]></code>
       <code>$index</code>
       <code>$language</code>
       <code>$language</code>
@@ -2303,7 +2311,7 @@
     <MixedArgument>
       <code>$author</code>
       <code>$category</code>
-      <code>$enclosure['uri']</code>
+      <code><![CDATA[$enclosure['uri']]]></code>
       <code>$ext</code>
       <code>$link</code>
     </MixedArgument>
@@ -2531,10 +2539,10 @@
   </file>
   <file src="src/Writer/Extension/GooglePlayPodcast/Entry.php">
     <RedundantConditionGivenDocblockType>
-      <code>! in_array($value, ['yes', 'no', 'clean'], true)</code>
-      <code>in_array($value, ['yes', 'no', 'clean'], true)</code>
-      <code>in_array($value, ['yes', 'no', 'clean'], true)</code>
-      <code>in_array($value, ['yes', 'no', 'clean'], true)</code>
+      <code><![CDATA[! in_array($value, ['yes', 'no', 'clean'], true)]]></code>
+      <code><![CDATA[in_array($value, ['yes', 'no', 'clean'], true)]]></code>
+      <code><![CDATA[in_array($value, ['yes', 'no', 'clean'], true)]]></code>
+      <code><![CDATA[in_array($value, ['yes', 'no', 'clean'], true)]]></code>
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="src/Writer/Extension/GooglePlayPodcast/Feed.php">
@@ -2561,10 +2569,10 @@
       <code>$value</code>
     </MixedAssignment>
     <RedundantConditionGivenDocblockType>
-      <code>! in_array($value, ['yes', 'no', 'clean'], true)</code>
-      <code>in_array($value, ['yes', 'no', 'clean'], true)</code>
-      <code>in_array($value, ['yes', 'no', 'clean'], true)</code>
-      <code>in_array($value, ['yes', 'no', 'clean'], true)</code>
+      <code><![CDATA[! in_array($value, ['yes', 'no', 'clean'], true)]]></code>
+      <code><![CDATA[in_array($value, ['yes', 'no', 'clean'], true)]]></code>
+      <code><![CDATA[in_array($value, ['yes', 'no', 'clean'], true)]]></code>
+      <code><![CDATA[in_array($value, ['yes', 'no', 'clean'], true)]]></code>
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="src/Writer/Extension/GooglePlayPodcast/Renderer/Entry.php">
@@ -2641,7 +2649,7 @@
       <code>var_export($type, true)</code>
     </RedundantConditionGivenDocblockType>
     <TypeDoesNotContainType>
-      <code>'no'</code>
+      <code><![CDATA['no']]></code>
     </TypeDoesNotContainType>
   </file>
   <file src="src/Writer/Extension/ITunes/Feed.php">
@@ -2656,8 +2664,8 @@
       <code>$value</code>
       <code>$value</code>
       <code>$value</code>
-      <code>$value['email']</code>
-      <code>$value['name']</code>
+      <code><![CDATA[$value['email']]]></code>
+      <code><![CDATA[$value['name']]]></code>
     </MixedArgument>
     <MixedArgumentTypeCoercion>
       <code>$key</code>
@@ -2682,7 +2690,7 @@
       <code>var_export($type, true)</code>
     </RedundantConditionGivenDocblockType>
     <TypeDoesNotContainType>
-      <code>'no'</code>
+      <code><![CDATA['no']]></code>
     </TypeDoesNotContainType>
   </file>
   <file src="src/Writer/Extension/ITunes/Renderer/Entry.php">
@@ -2735,8 +2743,8 @@
       <code>$subcat</code>
     </MixedArgument>
     <MixedArrayAccess>
-      <code>$owner['email']</code>
-      <code>$owner['name']</code>
+      <code><![CDATA[$owner['email']]]></code>
+      <code><![CDATA[$owner['name']]]></code>
     </MixedArrayAccess>
     <MixedAssignment>
       <code>$author</code>
@@ -2801,7 +2809,7 @@
       <code>getPodcastIndexTranscript</code>
     </MixedMethodCall>
     <RedundantCastGivenDocblockType>
-      <code>(string) $soundbite['title']</code>
+      <code><![CDATA[(string) $soundbite['title']]]></code>
     </RedundantCastGivenDocblockType>
   </file>
   <file src="src/Writer/Extension/PodcastIndex/Renderer/Feed.php">
@@ -2810,8 +2818,8 @@
       <code>getPodcastIndexLocked</code>
     </MixedMethodCall>
     <RedundantCastGivenDocblockType>
-      <code>(string) $funding['title']</code>
-      <code>(string) $locked['value']</code>
+      <code><![CDATA[(string) $funding['title']]]></code>
+      <code><![CDATA[(string) $locked['value']]]></code>
     </RedundantCastGivenDocblockType>
   </file>
   <file src="src/Writer/Extension/Slash/Renderer/Entry.php">
@@ -2827,11 +2835,11 @@
       <code>$count</code>
       <code>$count</code>
       <code>$link</code>
-      <code>$link['uri']</code>
+      <code><![CDATA[$link['uri']]]></code>
     </MixedArgument>
     <MixedArrayAccess>
-      <code>$link['type']</code>
-      <code>$link['uri']</code>
+      <code><![CDATA[$link['type']]]></code>
+      <code><![CDATA[$link['uri']]]></code>
     </MixedArrayAccess>
     <MixedAssignment>
       <code>$count</code>
@@ -2848,7 +2856,7 @@
       <code>getCommentLink</code>
     </MixedMethodCall>
     <MixedOperand>
-      <code>$link['type']</code>
+      <code><![CDATA[$link['type']]]></code>
     </MixedOperand>
     <TypeDoesNotContainType>
       <code>empty($links)</code>
@@ -2856,8 +2864,8 @@
   </file>
   <file src="src/Writer/Extension/WellFormedWeb/Renderer/Entry.php">
     <MixedArrayAccess>
-      <code>$link['type']</code>
-      <code>$link['uri']</code>
+      <code><![CDATA[$link['type']]]></code>
+      <code><![CDATA[$link['uri']]]></code>
     </MixedArrayAccess>
     <MixedAssignment>
       <code>$link</code>
@@ -2926,8 +2934,8 @@
     <MixedArgument>
       <code>$key</code>
       <code>$value</code>
-      <code>$value['link']</code>
-      <code>$value['type']</code>
+      <code><![CDATA[$value['link']]]></code>
+      <code><![CDATA[$value['type']]]></code>
     </MixedArgument>
     <MixedArgumentTypeCoercion>
       <code>$key</code>
@@ -2979,28 +2987,28 @@
       <code>format</code>
     </InvalidMethodCall>
     <MixedArgument>
-      <code>$cat['label']</code>
-      <code>$cat['scheme']</code>
-      <code>$cat['term']</code>
-      <code>$cat['term']</code>
+      <code><![CDATA[$cat['label']]]></code>
+      <code><![CDATA[$cat['scheme']]]></code>
+      <code><![CDATA[$cat['term']]]></code>
+      <code><![CDATA[$cat['term']]]></code>
       <code>$content</code>
       <code>$data</code>
-      <code>$data['length']</code>
-      <code>$data['type']</code>
-      <code>$data['uri']</code>
+      <code><![CDATA[$data['length']]]></code>
+      <code><![CDATA[$data['type']]]></code>
+      <code><![CDATA[$data['uri']]]></code>
       <code>$source</code>
       <code><![CDATA[$this->getDataContainer()->getDateCreated()->format(DateTime::ATOM)]]></code>
       <code><![CDATA[$this->getDataContainer()->getDateModified()->format(DateTime::ATOM)]]></code>
     </MixedArgument>
     <MixedArrayAccess>
-      <code>$cat['label']</code>
-      <code>$cat['scheme']</code>
-      <code>$cat['term']</code>
-      <code>$cat['term']</code>
-      <code>$data['length']</code>
-      <code>$data['name']</code>
-      <code>$data['type']</code>
-      <code>$data['uri']</code>
+      <code><![CDATA[$cat['label']]]></code>
+      <code><![CDATA[$cat['scheme']]]></code>
+      <code><![CDATA[$cat['term']]]></code>
+      <code><![CDATA[$cat['term']]]></code>
+      <code><![CDATA[$data['length']]]></code>
+      <code><![CDATA[$data['name']]]></code>
+      <code><![CDATA[$data['type']]]></code>
+      <code><![CDATA[$data['uri']]]></code>
     </MixedArrayAccess>
     <MixedAssignment>
       <code>$cat</code>
@@ -3052,7 +3060,7 @@
       <code><![CDATA[$this->getDataContainer()->getComment()]]></code>
     </MixedArgument>
     <MixedArrayAccess>
-      <code>$data['name']</code>
+      <code><![CDATA[$data['name']]]></code>
     </MixedArrayAccess>
     <MixedAssignment>
       <code>$data</code>
@@ -3085,7 +3093,7 @@
       <code><![CDATA[$this->getDataContainer()->getComment()]]></code>
     </MixedArgument>
     <MixedArrayAccess>
-      <code>$data['name']</code>
+      <code><![CDATA[$data['name']]]></code>
     </MixedArrayAccess>
     <MixedAssignment>
       <code>$data</code>
@@ -3118,22 +3126,22 @@
       <code>format</code>
     </InvalidMethodCall>
     <MixedArgument>
-      <code>$cat['scheme']</code>
-      <code>$cat['term']</code>
+      <code><![CDATA[$cat['scheme']]]></code>
+      <code><![CDATA[$cat['term']]]></code>
       <code>$data</code>
-      <code>$data['type']</code>
-      <code>$data['uri']</code>
+      <code><![CDATA[$data['type']]]></code>
+      <code><![CDATA[$data['uri']]]></code>
       <code><![CDATA[$this->getDataContainer()->getDateModified()->format(DateTime::RSS)]]></code>
     </MixedArgument>
     <MixedArrayAccess>
-      <code>$cat['scheme']</code>
-      <code>$cat['term']</code>
-      <code>$data['length']</code>
-      <code>$data['length']</code>
-      <code>$data['length']</code>
-      <code>$data['name']</code>
-      <code>$data['type']</code>
-      <code>$data['uri']</code>
+      <code><![CDATA[$cat['scheme']]]></code>
+      <code><![CDATA[$cat['term']]]></code>
+      <code><![CDATA[$data['length']]]></code>
+      <code><![CDATA[$data['length']]]></code>
+      <code><![CDATA[$data['length']]]></code>
+      <code><![CDATA[$data['name']]]></code>
+      <code><![CDATA[$data['type']]]></code>
+      <code><![CDATA[$data['uri']]]></code>
     </MixedArrayAccess>
     <MixedAssignment>
       <code>$cat</code>
@@ -3150,8 +3158,8 @@
       <code>setType</code>
     </MixedMethodCall>
     <MixedOperand>
-      <code>$data['email']</code>
-      <code>$data['name']</code>
+      <code><![CDATA[$data['email']]]></code>
+      <code><![CDATA[$data['name']]]></code>
     </MixedOperand>
     <PossiblyNullArgument>
       <code><![CDATA[$this->container->getEncoding()]]></code>
@@ -3177,7 +3185,7 @@
       <code>$gdata</code>
     </InvalidArgument>
     <InvalidArrayOffset>
-      <code>$gdata['name']</code>
+      <code><![CDATA[$gdata['name']]]></code>
     </InvalidArrayOffset>
     <InvalidIterator>
       <code>$categories</code>
@@ -3188,10 +3196,10 @@
       <code>format</code>
     </InvalidMethodCall>
     <MixedArgument>
-      <code>$cat['label']</code>
-      <code>$cat['scheme']</code>
-      <code>$cat['term']</code>
-      <code>$cat['term']</code>
+      <code><![CDATA[$cat['label']]]></code>
+      <code><![CDATA[$cat['scheme']]]></code>
+      <code><![CDATA[$cat['term']]]></code>
+      <code><![CDATA[$cat['term']]]></code>
       <code>$data</code>
       <code>$href</code>
       <code>$hubUrl</code>
@@ -3199,11 +3207,11 @@
       <code>$type</code>
     </MixedArgument>
     <MixedArrayAccess>
-      <code>$cat['label']</code>
-      <code>$cat['scheme']</code>
-      <code>$cat['term']</code>
-      <code>$cat['term']</code>
-      <code>$data['name']</code>
+      <code><![CDATA[$cat['label']]]></code>
+      <code><![CDATA[$cat['scheme']]]></code>
+      <code><![CDATA[$cat['term']]]></code>
+      <code><![CDATA[$cat['term']]]></code>
+      <code><![CDATA[$data['name']]]></code>
     </MixedArrayAccess>
     <MixedAssignment>
       <code>$cat</code>
@@ -3213,14 +3221,14 @@
       <code>$type</code>
     </MixedAssignment>
     <PossiblyNullArgument>
-      <code>$gdata['uri']</code>
-      <code>$gdata['version']</code>
+      <code><![CDATA[$gdata['uri']]]></code>
+      <code><![CDATA[$gdata['version']]]></code>
       <code><![CDATA[$this->getDataContainer()->getLanguage()]]></code>
       <code><![CDATA[$this->getDataContainer()->getLink()]]></code>
       <code><![CDATA[$this->getDataContainer()->getLink()]]></code>
     </PossiblyNullArgument>
     <PossiblyNullArrayAccess>
-      <code>$gdata['name']</code>
+      <code><![CDATA[$gdata['name']]]></code>
     </PossiblyNullArrayAccess>
     <PossiblyNullReference>
       <code>format</code>
@@ -3266,7 +3274,7 @@
       <code>$gdata</code>
     </InvalidArgument>
     <InvalidArrayOffset>
-      <code>$gdata['name']</code>
+      <code><![CDATA[$gdata['name']]]></code>
     </InvalidArrayOffset>
     <InvalidIterator>
       <code>$categories</code>
@@ -3277,10 +3285,10 @@
       <code>format</code>
     </InvalidMethodCall>
     <MixedArgument>
-      <code>$cat['label']</code>
-      <code>$cat['scheme']</code>
-      <code>$cat['term']</code>
-      <code>$cat['term']</code>
+      <code><![CDATA[$cat['label']]]></code>
+      <code><![CDATA[$cat['scheme']]]></code>
+      <code><![CDATA[$cat['term']]]></code>
+      <code><![CDATA[$cat['term']]]></code>
       <code>$data</code>
       <code>$href</code>
       <code>$hubUrl</code>
@@ -3288,11 +3296,11 @@
       <code>$type</code>
     </MixedArgument>
     <MixedArrayAccess>
-      <code>$cat['label']</code>
-      <code>$cat['scheme']</code>
-      <code>$cat['term']</code>
-      <code>$cat['term']</code>
-      <code>$data['name']</code>
+      <code><![CDATA[$cat['label']]]></code>
+      <code><![CDATA[$cat['scheme']]]></code>
+      <code><![CDATA[$cat['term']]]></code>
+      <code><![CDATA[$cat['term']]]></code>
+      <code><![CDATA[$data['name']]]></code>
     </MixedArrayAccess>
     <MixedAssignment>
       <code>$cat</code>
@@ -3302,14 +3310,14 @@
       <code>$type</code>
     </MixedAssignment>
     <PossiblyNullArgument>
-      <code>$gdata['uri']</code>
-      <code>$gdata['version']</code>
+      <code><![CDATA[$gdata['uri']]]></code>
+      <code><![CDATA[$gdata['version']]]></code>
       <code><![CDATA[$this->getDataContainer()->getLanguage()]]></code>
       <code><![CDATA[$this->getDataContainer()->getLink()]]></code>
       <code><![CDATA[$this->getDataContainer()->getLink()]]></code>
     </PossiblyNullArgument>
     <PossiblyNullArrayAccess>
-      <code>$gdata['name']</code>
+      <code><![CDATA[$gdata['name']]]></code>
     </PossiblyNullArrayAccess>
     <PossiblyNullReference>
       <code>format</code>
@@ -3329,7 +3337,7 @@
       <code>$gdata</code>
     </InvalidArgument>
     <InvalidArrayOffset>
-      <code>$gdata['name']</code>
+      <code><![CDATA[$gdata['name']]]></code>
     </InvalidArrayOffset>
     <MixedAssignment>
       <code>$ext</code>
@@ -3341,12 +3349,12 @@
       <code>setType</code>
     </MixedMethodCall>
     <PossiblyNullArgument>
-      <code>$gdata['uri']</code>
-      <code>$gdata['version']</code>
+      <code><![CDATA[$gdata['uri']]]></code>
+      <code><![CDATA[$gdata['version']]]></code>
       <code><![CDATA[$this->container->getEncoding()]]></code>
     </PossiblyNullArgument>
     <PossiblyNullArrayAccess>
-      <code>$gdata['name']</code>
+      <code><![CDATA[$gdata['name']]]></code>
     </PossiblyNullArrayAccess>
     <PropertyNotSetInConstructor>
       <code>Source</code>
@@ -3362,7 +3370,7 @@
       <code>$gdata</code>
     </InvalidArgument>
     <InvalidArrayOffset>
-      <code>$gdata['name']</code>
+      <code><![CDATA[$gdata['name']]]></code>
     </InvalidArrayOffset>
     <MixedAssignment>
       <code>$ext</code>
@@ -3374,12 +3382,12 @@
       <code>setType</code>
     </MixedMethodCall>
     <PossiblyNullArgument>
-      <code>$gdata['uri']</code>
-      <code>$gdata['version']</code>
+      <code><![CDATA[$gdata['uri']]]></code>
+      <code><![CDATA[$gdata['version']]]></code>
       <code><![CDATA[$this->container->getEncoding()]]></code>
     </PossiblyNullArgument>
     <PossiblyNullArrayAccess>
-      <code>$gdata['name']</code>
+      <code><![CDATA[$gdata['name']]]></code>
     </PossiblyNullArrayAccess>
     <PropertyNotSetInConstructor>
       <code>AtomSource</code>
@@ -3395,7 +3403,7 @@
       <code>$gdata</code>
     </InvalidArgument>
     <InvalidArrayOffset>
-      <code>$gdata['name']</code>
+      <code><![CDATA[$gdata['name']]]></code>
     </InvalidArrayOffset>
     <InvalidIterator>
       <code>$categories</code>
@@ -3405,15 +3413,15 @@
       <code>format</code>
     </InvalidMethodCall>
     <MixedArgument>
-      <code>$cat['scheme']</code>
+      <code><![CDATA[$cat['scheme']]]></code>
       <code>$data</code>
       <code><![CDATA[$this->getDataContainer()->getDateModified()->format(DateTime::RSS)]]></code>
       <code><![CDATA[$this->getDataContainer()->getLastBuildDate()->format(DateTime::RSS)]]></code>
     </MixedArgument>
     <MixedArrayAccess>
-      <code>$cat['scheme']</code>
-      <code>$cat['term']</code>
-      <code>$data['name']</code>
+      <code><![CDATA[$cat['scheme']]]></code>
+      <code><![CDATA[$cat['term']]]></code>
+      <code><![CDATA[$data['name']]]></code>
     </MixedArrayAccess>
     <MixedAssignment>
       <code>$cat</code>
@@ -3431,8 +3439,8 @@
       <code>setType</code>
     </MixedMethodCall>
     <MixedOperand>
-      <code>$data['email']</code>
-      <code>$data['name']</code>
+      <code><![CDATA[$data['email']]]></code>
+      <code><![CDATA[$data['name']]]></code>
       <code>$name</code>
       <code>$name</code>
     </MixedOperand>
@@ -3440,11 +3448,11 @@
       <code><![CDATA[$this->container->getEncoding()]]></code>
     </PossiblyNullArgument>
     <PossiblyNullArrayAccess>
-      <code>$gdata['name']</code>
+      <code><![CDATA[$gdata['name']]]></code>
     </PossiblyNullArrayAccess>
     <PossiblyNullOperand>
-      <code>$gdata['uri']</code>
-      <code>$gdata['version']</code>
+      <code><![CDATA[$gdata['uri']]]></code>
+      <code><![CDATA[$gdata['version']]]></code>
     </PossiblyNullOperand>
     <PossiblyNullReference>
       <code>format</code>
@@ -3491,16 +3499,16 @@
       <code>ExtensionManagerInterface</code>
     </DeprecatedInterface>
     <MixedArgument>
-      <code>static::$extensions['entry']</code>
-      <code>static::$extensions['entryRenderer']</code>
-      <code>static::$extensions['feed']</code>
-      <code>static::$extensions['feedRenderer']</code>
+      <code><![CDATA[static::$extensions['entry']]]></code>
+      <code><![CDATA[static::$extensions['entryRenderer']]]></code>
+      <code><![CDATA[static::$extensions['feed']]]></code>
+      <code><![CDATA[static::$extensions['feedRenderer']]]></code>
     </MixedArgument>
     <MixedArrayAssignment>
-      <code>static::$extensions['entry'][]</code>
-      <code>static::$extensions['entryRenderer'][]</code>
-      <code>static::$extensions['feed'][]</code>
-      <code>static::$extensions['feedRenderer'][]</code>
+      <code><![CDATA[static::$extensions['entry'][]]]></code>
+      <code><![CDATA[static::$extensions['entryRenderer'][]]]></code>
+      <code><![CDATA[static::$extensions['feed'][]]]></code>
+      <code><![CDATA[static::$extensions['feedRenderer'][]]]></code>
     </MixedArrayAssignment>
     <RedundantPropertyInitializationCheck>
       <code>isset(static::$extensionManager)</code>
@@ -3542,8 +3550,8 @@
     <ArgumentTypeCoercion>
       <code>$className</code>
       <code>$className</code>
-      <code>'Result'</code>
-      <code>'Result'</code>
+      <code><![CDATA['Result']]></code>
+      <code><![CDATA['Result']]></code>
     </ArgumentTypeCoercion>
     <DeprecatedMethod>
       <code>setMethods</code>
@@ -3552,7 +3560,7 @@
     </DeprecatedMethod>
     <InvalidArgument>
       <code><![CDATA[$this->tableGateway]]></code>
-      <code>''</code>
+      <code><![CDATA['']]></code>
       <code>new stdClass()</code>
     </InvalidArgument>
     <InvalidPropertyAssignmentValue>
@@ -3573,8 +3581,8 @@
       <code>getHeader</code>
     </PossiblyUndefinedMethod>
     <UndefinedClass>
-      <code>'Result'</code>
-      <code>'Result'</code>
+      <code><![CDATA['Result']]></code>
+      <code><![CDATA['Result']]></code>
     </UndefinedClass>
     <UnevaluatedCode>
       <code><![CDATA[$this->assertFalse($this->callback->isValidHubVerification($this->get));]]></code>
@@ -3595,7 +3603,7 @@
       <code><![CDATA[$this->storage]]></code>
     </InvalidArgument>
     <PossiblyFalsePropertyAssignmentValue>
-      <code>getenv('TESTS_LAMINAS_FEED_PUBSUBHUBBUB_BASEURI')</code>
+      <code><![CDATA[getenv('TESTS_LAMINAS_FEED_PUBSUBHUBBUB_BASEURI')]]></code>
     </PossiblyFalsePropertyAssignmentValue>
     <TooFewArguments>
       <code>getSubscription</code>
@@ -3611,8 +3619,8 @@
       <code>setMethods</code>
     </DeprecatedMethod>
     <InvalidArgument>
-      <code>'0aa'</code>
-      <code>'10000'</code>
+      <code><![CDATA['0aa']]></code>
+      <code><![CDATA['10000']]></code>
       <code>123</code>
       <code>123</code>
       <code>123</code>
@@ -4112,7 +4120,7 @@
         }]]></code>
     </InvalidArgument>
     <InvalidArrayOffset>
-      <code>$link['feed']</code>
+      <code><![CDATA[$link['feed']]]></code>
     </InvalidArrayOffset>
     <MixedArgument>
       <code>$message</code>
@@ -4139,6 +4147,11 @@
       <code>Extension\AbstractEntry|Extension\AbstractFeed</code>
     </MoreSpecificReturnType>
   </file>
+  <file src="test/Reader/TestAsset/Psr7Stream.php">
+    <MethodSignatureMustProvideReturnType>
+      <code>__toString</code>
+    </MethodSignatureMustProvideReturnType>
+  </file>
   <file src="test/Reader/_files/My/Extension/JungleBooks/Entry.php">
     <MixedAssignment>
       <code>$isbn</code>
@@ -4160,7 +4173,7 @@
       <code>assertNull</code>
     </DocblockTypeContradiction>
     <InvalidArgument>
-      <code>'abc'</code>
+      <code><![CDATA['abc']]></code>
     </InvalidArgument>
     <UnevaluatedCode>
       <code>$entry = new Writer\Deleted();</code>
@@ -4170,8 +4183,8 @@
   </file>
   <file src="test/Writer/EntryTest.php">
     <InvalidArgument>
-      <code>'abc'</code>
-      <code>'abc'</code>
+      <code><![CDATA['abc']]></code>
+      <code><![CDATA['abc']]></code>
       <code><![CDATA[static function (int $_errno, string $errstr) use ($notices): ?bool {
             $notices->messages[] = $errstr;
 
@@ -4237,7 +4250,7 @@
   </file>
   <file src="test/Writer/FeedFactoryTest.php">
     <InvalidArgument>
-      <code>'string'</code>
+      <code><![CDATA['string']]></code>
     </InvalidArgument>
     <InvalidMethodCall>
       <code>format</code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,54 +1,54 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.4.0@62db5d4f6a7ae0a20f7cc5a4952d730272fc0863">
+<files psalm-version="5.13.1@086b94371304750d1c673315321a55d15fc59015">
   <file src="src/PubSubHubbub/AbstractCallback.php">
-    <DocblockTypeContradiction occurrences="3">
-      <code>$this-&gt;httpResponse === null</code>
-      <code>$this-&gt;storage === null</code>
+    <DocblockTypeContradiction>
+      <code><![CDATA[$this->httpResponse === null]]></code>
+      <code><![CDATA[$this->storage === null]]></code>
       <code>is_array($options)</code>
     </DocblockTypeContradiction>
-    <InvalidReturnStatement occurrences="2">
+    <InvalidReturnStatement>
       <code>$_SERVER[$temp]</code>
       <code>$_SERVER[$temp]</code>
     </InvalidReturnStatement>
-    <MixedArgument occurrences="1">
+    <MixedArgument>
       <code>$options['storage']</code>
     </MixedArgument>
-    <MixedInferredReturnType occurrences="1">
+    <MixedInferredReturnType>
       <code>bool|string</code>
     </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="1">
+    <MixedReturnStatement>
       <code>$headers[$header]</code>
     </MixedReturnStatement>
-    <PossiblyUndefinedArrayOffset occurrences="2">
+    <PossiblyUndefinedArrayOffset>
       <code>$_SERVER['ORIG_PATH_INFO']</code>
       <code>$_SERVER['REQUEST_URI']</code>
     </PossiblyUndefinedArrayOffset>
-    <PropertyNotSetInConstructor occurrences="2">
+    <PropertyNotSetInConstructor>
       <code>$httpResponse</code>
       <code>$storage</code>
     </PropertyNotSetInConstructor>
-    <RedundantCondition occurrences="1">
+    <RedundantConditionGivenDocblockType>
       <code>is_array($options)</code>
-    </RedundantCondition>
+    </RedundantConditionGivenDocblockType>
   </file>
   <file src="src/PubSubHubbub/CallbackInterface.php">
-    <MissingReturnType occurrences="2">
+    <MissingReturnType>
       <code>handle</code>
       <code>setHttpResponse</code>
     </MissingReturnType>
   </file>
   <file src="src/PubSubHubbub/HttpResponse.php">
-    <DocblockTypeContradiction occurrences="1">
+    <DocblockTypeContradiction>
       <code>! is_int($code)</code>
     </DocblockTypeContradiction>
-    <InvalidArgument occurrences="1">
+    <InvalidArgument>
       <code>strlen($content)</code>
     </InvalidArgument>
-    <MixedArgument occurrences="2">
+    <MixedArgument>
       <code>$header['replace']</code>
       <code>$header['replace']</code>
     </MixedArgument>
-    <MixedArrayAccess occurrences="9">
+    <MixedArrayAccess>
       <code>$header['name']</code>
       <code>$header['name']</code>
       <code>$header['name']</code>
@@ -59,90 +59,97 @@
       <code>$header['value']</code>
       <code>$header['value']</code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="3">
+    <MixedAssignment>
       <code>$header</code>
       <code>$header</code>
       <code>$header</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="1">
+    <MixedInferredReturnType>
       <code>string|null</code>
     </MixedInferredReturnType>
-    <MixedOperand occurrences="4">
+    <MixedOperand>
+      <code>$code</code>
       <code>$header['name']</code>
       <code>$header['name']</code>
       <code>$header['value']</code>
       <code>$header['value']</code>
     </MixedOperand>
-    <MixedReturnStatement occurrences="1">
+    <MixedReturnStatement>
       <code>$header['value']</code>
     </MixedReturnStatement>
-    <RedundantCastGivenDocblockType occurrences="3">
+    <RedundantCastGivenDocblockType>
       <code>(string) $content</code>
       <code>(string) $name</code>
       <code>(string) $value</code>
     </RedundantCastGivenDocblockType>
   </file>
   <file src="src/PubSubHubbub/Model/AbstractModel.php">
-    <NullArgument occurrences="1">
+    <NullArgument>
       <code>null</code>
     </NullArgument>
   </file>
   <file src="src/PubSubHubbub/Model/Subscription.php">
-    <DocblockTypeContradiction occurrences="1">
-      <code>null === $this-&gt;now</code>
+    <DocblockTypeContradiction>
+      <code>empty($key) || ! is_string($key)</code>
+      <code>empty($key) || ! is_string($key)</code>
+      <code><![CDATA[null === $this->now]]></code>
     </DocblockTypeContradiction>
-    <FalsableReturnStatement occurrences="1">
+    <FalsableReturnStatement>
       <code>false</code>
     </FalsableReturnStatement>
-    <MixedArgumentTypeCoercion occurrences="2">
+    <MixedArgumentTypeCoercion>
       <code>$data</code>
       <code>$data</code>
     </MixedArgumentTypeCoercion>
-    <MixedAssignment occurrences="1">
+    <MixedAssignment>
       <code>$data['created_time']</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="1">
+    <MixedInferredReturnType>
       <code>array</code>
     </MixedInferredReturnType>
-    <MixedMethodCall occurrences="1">
+    <MixedMethodCall>
       <code>getArrayCopy</code>
     </MixedMethodCall>
-    <MixedOperand occurrences="1">
+    <MixedOperand>
       <code>$data['lease_seconds']</code>
+      <code>$key</code>
+      <code>$key</code>
     </MixedOperand>
-    <MixedReturnStatement occurrences="1">
-      <code>$result-&gt;current()-&gt;getArrayCopy()</code>
+    <MixedReturnStatement>
+      <code><![CDATA[$result->current()->getArrayCopy()]]></code>
     </MixedReturnStatement>
-    <PropertyNotSetInConstructor occurrences="1">
+    <PropertyNotSetInConstructor>
       <code>$now</code>
     </PropertyNotSetInConstructor>
-    <TypeDoesNotContainType occurrences="2">
+    <TypeDoesNotContainType>
       <code>! is_string($key)</code>
       <code>! is_string($key)</code>
     </TypeDoesNotContainType>
   </file>
   <file src="src/PubSubHubbub/PubSubHubbub.php">
-    <DocblockTypeContradiction occurrences="1">
+    <DocblockTypeContradiction>
       <code>null === static::$escaper</code>
     </DocblockTypeContradiction>
-    <MixedInferredReturnType occurrences="1">
-      <code>array&lt;array-key, mixed&gt;|null</code>
+    <MixedInferredReturnType>
+      <code><![CDATA[array<array-key, mixed>|null]]></code>
     </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="1">
-      <code>$feed-&gt;getHubs()</code>
+    <MixedReturnStatement>
+      <code><![CDATA[$feed->getHubs()]]></code>
     </MixedReturnStatement>
-    <PossiblyUndefinedMethod occurrences="1">
+    <PossiblyUndefinedMethod>
       <code>getHubs</code>
     </PossiblyUndefinedMethod>
-    <RedundantConditionGivenDocblockType occurrences="1">
+    <RedundantConditionGivenDocblockType>
       <code>$source instanceof Reader\Feed\AbstractFeed</code>
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="src/PubSubHubbub/Publisher.php">
-    <DocblockTypeContradiction occurrences="1">
+    <DocblockTypeContradiction>
+      <code>empty($name) || ! is_string($name)</code>
+      <code>empty($name) || ! is_string($name)</code>
       <code>is_array($options)</code>
     </DocblockTypeContradiction>
-    <MixedArgument occurrences="9">
+    <MixedArgument>
       <code>$options['hubUrls']</code>
       <code>$options['parameters']</code>
       <code>$options['updatedTopicUrls']</code>
@@ -153,11 +160,11 @@
       <code>$value</code>
       <code>$value</code>
     </MixedArgument>
-    <MixedArgumentTypeCoercion occurrences="2">
+    <MixedArgumentTypeCoercion>
       <code>$name</code>
       <code>$name</code>
     </MixedArgumentTypeCoercion>
-    <MixedAssignment occurrences="6">
+    <MixedAssignment>
       <code>$topicUrl</code>
       <code>$url</code>
       <code>$url</code>
@@ -165,13 +172,15 @@
       <code>$value</code>
       <code>$value</code>
     </MixedAssignment>
-    <MixedOperand occurrences="1">
-      <code>$response-&gt;getContent()</code>
+    <MixedOperand>
+      <code>$name</code>
+      <code>$name</code>
+      <code><![CDATA[$response->getContent()]]></code>
     </MixedOperand>
-    <RedundantCondition occurrences="1">
-      <code>! is_string($value) &amp;&amp; $value !== null</code>
+    <RedundantCondition>
+      <code><![CDATA[! is_string($value) && $value !== null]]></code>
     </RedundantCondition>
-    <TypeDoesNotContainType occurrences="9">
+    <TypeDoesNotContainType>
       <code>! is_string($name)</code>
       <code>! is_string($name)</code>
       <code>! is_string($url)</code>
@@ -184,17 +193,19 @@
     </TypeDoesNotContainType>
   </file>
   <file src="src/PubSubHubbub/Subscriber.php">
-    <DocblockTypeContradiction occurrences="2">
-      <code>$this-&gt;storage === null</code>
+    <DocblockTypeContradiction>
+      <code><![CDATA[$this->storage === null]]></code>
+      <code>empty($name) || ! is_string($name)</code>
+      <code>empty($name) || ! is_string($name)</code>
       <code>is_array($options)</code>
     </DocblockTypeContradiction>
-    <InvalidPropertyAssignmentValue occurrences="1">
+    <InvalidPropertyAssignmentValue>
       <code>$bool</code>
     </InvalidPropertyAssignmentValue>
-    <MissingReturnType occurrences="1">
+    <MissingReturnType>
       <code>setTestStaticToken</code>
     </MissingReturnType>
-    <MixedArgument occurrences="19">
+    <MixedArgument>
       <code>$auth[0]</code>
       <code>$auth[1]</code>
       <code>$authentication</code>
@@ -215,18 +226,18 @@
       <code>$value</code>
       <code>$value</code>
     </MixedArgument>
-    <MixedArgumentTypeCoercion occurrences="5">
+    <MixedArgumentTypeCoercion>
       <code>$key</code>
       <code>$key</code>
       <code>$name</code>
       <code>$url</code>
       <code>uksort($params, 'strnatcmp')</code>
     </MixedArgumentTypeCoercion>
-    <MixedArrayAccess occurrences="2">
+    <MixedArrayAccess>
       <code>$auth[0]</code>
       <code>$auth[1]</code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="11">
+    <MixedAssignment>
       <code>$auth</code>
       <code>$authentication</code>
       <code>$duplicateKey</code>
@@ -239,32 +250,34 @@
       <code>$value</code>
       <code>$value</code>
     </MixedAssignment>
-    <MixedOperand occurrences="4">
+    <MixedOperand>
       <code>$keyduplicate</code>
+      <code>$name</code>
+      <code>$name</code>
       <code>$params['hub.lease_seconds']</code>
       <code>$params['hub.topic']</code>
       <code>$value</code>
     </MixedOperand>
-    <PossiblyFalsePropertyAssignmentValue occurrences="1">
+    <PossiblyFalsePropertyAssignmentValue>
       <code>false</code>
     </PossiblyFalsePropertyAssignmentValue>
-    <PossiblyInvalidCast occurrences="1">
+    <PossiblyInvalidCast>
       <code>$params['hub.verify_token']</code>
     </PossiblyInvalidCast>
-    <PropertyNotSetInConstructor occurrences="2">
+    <PropertyNotSetInConstructor>
       <code>$leaseSeconds</code>
       <code>$storage</code>
     </PropertyNotSetInConstructor>
-    <RedundantCast occurrences="1">
+    <RedundantCast>
       <code>(string) $token</code>
     </RedundantCast>
-    <RedundantCondition occurrences="1">
-      <code>! is_string($value) &amp;&amp; $value !== null</code>
+    <RedundantCondition>
+      <code><![CDATA[! is_string($value) && $value !== null]]></code>
     </RedundantCondition>
-    <RedundantConditionGivenDocblockType occurrences="1">
-      <code>$this-&gt;getLeaseSeconds() !== null</code>
+    <RedundantConditionGivenDocblockType>
+      <code><![CDATA[$this->getLeaseSeconds() !== null]]></code>
     </RedundantConditionGivenDocblockType>
-    <TypeDoesNotContainType occurrences="11">
+    <TypeDoesNotContainType>
       <code>! is_string($name)</code>
       <code>! is_string($name)</code>
       <code>! is_string($url)</code>
@@ -279,13 +292,13 @@
     </TypeDoesNotContainType>
   </file>
   <file src="src/PubSubHubbub/Subscriber/Callback.php">
-    <DocblockTypeContradiction occurrences="1">
-      <code>$this-&gt;feedUpdate === null</code>
+    <DocblockTypeContradiction>
+      <code><![CDATA[$this->feedUpdate === null]]></code>
     </DocblockTypeContradiction>
-    <InvalidArgument occurrences="1">
-      <code>$this-&gt;getSubscriberCount()</code>
+    <InvalidArgument>
+      <code><![CDATA[$this->getSubscriberCount()]]></code>
     </InvalidArgument>
-    <MixedArgument occurrences="6">
+    <MixedArgument>
       <code>$httpGetData['hub_challenge']</code>
       <code>$httpGetData['hub_mode']</code>
       <code>$httpGetData['hub_mode']</code>
@@ -293,24 +306,24 @@
       <code>$httpGetData['hub_verify_token']</code>
       <code>$params['xhub.subscription']</code>
     </MixedArgument>
-    <MixedAssignment occurrences="2">
+    <MixedAssignment>
       <code>$data['lease_seconds']</code>
       <code>$verifyToken</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="1">
+    <MixedInferredReturnType>
       <code>false|string</code>
     </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="1">
+    <MixedReturnStatement>
       <code>$httpGetData['xhub_subscription']</code>
     </MixedReturnStatement>
-    <ParamNameMismatch occurrences="1">
+    <ParamNameMismatch>
       <code>$httpGetData</code>
     </ParamNameMismatch>
-    <PossiblyFalseArgument occurrences="2">
-      <code>$this-&gt;_getRawBody()</code>
+    <PossiblyFalseArgument>
+      <code><![CDATA[$this->_getRawBody()]]></code>
       <code>$verifyTokenKey</code>
     </PossiblyFalseArgument>
-    <PossiblyInvalidArgument occurrences="8">
+    <PossiblyInvalidArgument>
       <code>$contentType</code>
       <code>$contentType</code>
       <code>$contentType</code>
@@ -320,23 +333,23 @@
       <code>$httpGetData['hub_mode']</code>
       <code>$httpGetData['hub_mode']</code>
     </PossiblyInvalidArgument>
-    <PossiblyInvalidCast occurrences="1">
+    <PossiblyInvalidCast>
       <code>$httpGetData['hub_challenge']</code>
     </PossiblyInvalidCast>
-    <PossiblyNullArgument occurrences="1">
+    <PossiblyNullArgument>
       <code>$httpGetData['hub_verify_token']</code>
     </PossiblyNullArgument>
-    <PossiblyNullArrayAccess occurrences="1">
+    <PossiblyNullArrayAccess>
       <code>$httpGetData['hub_verify_token']</code>
     </PossiblyNullArrayAccess>
-    <PossiblyUndefinedArrayOffset occurrences="2">
+    <PossiblyUndefinedArrayOffset>
       <code>$_SERVER['REQUEST_METHOD']</code>
       <code>$_SERVER['REQUEST_METHOD']</code>
     </PossiblyUndefinedArrayOffset>
-    <PossiblyUndefinedMethod occurrences="1">
+    <PossiblyUndefinedMethod>
       <code>setHeader</code>
     </PossiblyUndefinedMethod>
-    <PropertyNotSetInConstructor occurrences="4">
+    <PropertyNotSetInConstructor>
       <code>$currentSubscriptionData</code>
       <code>$feedUpdate</code>
       <code>Callback</code>
@@ -344,146 +357,151 @@
     </PropertyNotSetInConstructor>
   </file>
   <file src="src/Reader/AbstractEntry.php">
-    <DocblockTypeContradiction occurrences="2">
-      <code>! $this-&gt;xpath</code>
-      <code>$this-&gt;xpath</code>
+    <DocblockTypeContradiction>
+      <code><![CDATA[! $this->xpath]]></code>
+      <code><![CDATA[$this->xpath]]></code>
     </DocblockTypeContradiction>
-    <InvalidArgument occurrences="1">
+    <InvalidArgument>
       <code>$entry</code>
     </InvalidArgument>
-    <MixedArgument occurrences="2">
+    <MixedArgument>
       <code>$all['core']</code>
       <code>$extension</code>
     </MixedArgument>
-    <MixedArrayOffset occurrences="1">
-      <code>$this-&gt;extensions[$extension]</code>
+    <MixedArrayOffset>
+      <code><![CDATA[$this->extensions[$extension]]]></code>
     </MixedArrayOffset>
-    <MixedAssignment occurrences="4">
+    <MixedAssignment>
       <code>$className</code>
       <code>$extension</code>
       <code>$extension</code>
       <code>$feed</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="2">
+    <MixedInferredReturnType>
       <code>null|Extension\AbstractEntry</code>
       <code>string</code>
     </MixedInferredReturnType>
-    <MixedMethodCall occurrences="2">
+    <MixedMethodCall>
       <code>getClassName</code>
+      <code><![CDATA[new $className(
+                $this->getElement(),
+                $this->entryKey,
+                $this->data['type']
+            )]]></code>
     </MixedMethodCall>
-    <MixedReturnStatement occurrences="2">
-      <code>$this-&gt;data['type']</code>
-      <code>$this-&gt;extensions[$name . '\Entry']</code>
+    <MixedReturnStatement>
+      <code><![CDATA[$this->data['type']]]></code>
+      <code><![CDATA[$this->extensions[$name . '\Entry']]]></code>
     </MixedReturnStatement>
-    <PossiblyNullPropertyAssignmentValue occurrences="1">
-      <code>$entry-&gt;ownerDocument</code>
+    <PossiblyNullPropertyAssignmentValue>
+      <code><![CDATA[$entry->ownerDocument]]></code>
     </PossiblyNullPropertyAssignmentValue>
-    <PropertyNotSetInConstructor occurrences="1">
+    <PropertyNotSetInConstructor>
       <code>$xpath</code>
     </PropertyNotSetInConstructor>
-    <UndefinedMethod occurrences="1">
+    <UndefinedMethod>
       <code>Reader::getPluginLoader()</code>
     </UndefinedMethod>
   </file>
   <file src="src/Reader/AbstractFeed.php">
-    <ImplementedReturnTypeMismatch occurrences="1">
+    <ImplementedReturnTypeMismatch>
       <code>Entry\AbstractEntry</code>
     </ImplementedReturnTypeMismatch>
-    <InvalidArgument occurrences="1">
-      <code>$this-&gt;key()</code>
+    <InvalidArgument>
+      <code><![CDATA[$this->key()]]></code>
     </InvalidArgument>
-    <InvalidTemplateParam occurrences="1">
+    <InvalidTemplateParam>
       <code>Feed\FeedInterface</code>
     </InvalidTemplateParam>
-    <MissingReturnType occurrences="3">
+    <MissingReturnType>
       <code>indexEntries</code>
       <code>loadExtensions</code>
       <code>registerNamespaces</code>
     </MissingReturnType>
-    <MixedArgument occurrences="5">
+    <MixedArgument>
       <code>$all['core']</code>
       <code>$extension</code>
       <code>$extension</code>
-      <code>$this-&gt;entries[$this-&gt;key()]</code>
-      <code>$this-&gt;entries[$this-&gt;key()]</code>
+      <code><![CDATA[$this->entries[$this->key()]]]></code>
+      <code><![CDATA[$this->entries[$this->key()]]]></code>
     </MixedArgument>
-    <MixedArrayOffset occurrences="1">
-      <code>$this-&gt;extensions[$extension]</code>
+    <MixedArrayOffset>
+      <code><![CDATA[$this->extensions[$extension]]]></code>
     </MixedArrayOffset>
-    <MixedAssignment occurrences="4">
+    <MixedAssignment>
       <code>$extension</code>
       <code>$extension</code>
       <code>$feed</code>
       <code>$plugin</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="1">
+    <MixedInferredReturnType>
       <code>string</code>
     </MixedInferredReturnType>
-    <MixedMethodCall occurrences="3">
+    <MixedMethodCall>
       <code>setDomDocument</code>
       <code>setType</code>
       <code>setXpath</code>
     </MixedMethodCall>
-    <MixedReturnStatement occurrences="1">
-      <code>$this-&gt;data['type']</code>
+    <MixedReturnStatement>
+      <code><![CDATA[$this->data['type']]]></code>
     </MixedReturnStatement>
-    <PropertyNotSetInConstructor occurrences="1">
+    <PropertyNotSetInConstructor>
       <code>$originalSourceUri</code>
     </PropertyNotSetInConstructor>
-    <TooManyTemplateParams occurrences="1">
+    <TooManyTemplateParams>
       <code>Feed\FeedInterface</code>
     </TooManyTemplateParams>
   </file>
   <file src="src/Reader/Entry/AbstractEntry.php">
-    <DocblockTypeContradiction occurrences="2">
-      <code>! $this-&gt;xpath</code>
-      <code>$this-&gt;xpath</code>
+    <DocblockTypeContradiction>
+      <code><![CDATA[! $this->xpath]]></code>
+      <code><![CDATA[$this->xpath]]></code>
     </DocblockTypeContradiction>
-    <MixedArgument occurrences="3">
+    <MixedArgument>
       <code>$all['core']</code>
       <code>$extension</code>
       <code>$extension</code>
     </MixedArgument>
-    <MixedArrayOffset occurrences="1">
-      <code>$this-&gt;extensions[$extension]</code>
+    <MixedArrayOffset>
+      <code><![CDATA[$this->extensions[$extension]]]></code>
     </MixedArrayOffset>
-    <MixedAssignment occurrences="4">
+    <MixedAssignment>
       <code>$extension</code>
       <code>$extension</code>
       <code>$feed</code>
       <code>$plugin</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="1">
+    <MixedInferredReturnType>
       <code>string</code>
     </MixedInferredReturnType>
-    <MixedMethodCall occurrences="3">
+    <MixedMethodCall>
       <code>setEntryElement</code>
       <code>setEntryKey</code>
       <code>setType</code>
     </MixedMethodCall>
-    <MixedReturnStatement occurrences="1">
-      <code>$this-&gt;data['type']</code>
+    <MixedReturnStatement>
+      <code><![CDATA[$this->data['type']]]></code>
     </MixedReturnStatement>
-    <PossiblyNullPropertyAssignmentValue occurrences="1">
-      <code>$entry-&gt;ownerDocument</code>
+    <PossiblyNullPropertyAssignmentValue>
+      <code><![CDATA[$entry->ownerDocument]]></code>
     </PossiblyNullPropertyAssignmentValue>
-    <PropertyNotSetInConstructor occurrences="1">
+    <PropertyNotSetInConstructor>
       <code>$xpath</code>
     </PropertyNotSetInConstructor>
   </file>
   <file src="src/Reader/Entry/Atom.php">
-    <ImplementedReturnTypeMismatch occurrences="2">
+    <ImplementedReturnTypeMismatch>
       <code>null|string</code>
       <code>void</code>
     </ImplementedReturnTypeMismatch>
-    <InvalidNullableReturnType occurrences="1">
+    <InvalidNullableReturnType>
       <code>string</code>
     </InvalidNullableReturnType>
-    <MixedAssignment occurrences="2">
+    <MixedAssignment>
       <code>$extension</code>
       <code>$extension</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="15">
+    <MixedInferredReturnType>
       <code>AuthorCollection</code>
       <code>Reader\Collection\Category</code>
       <code>array</code>
@@ -500,63 +518,78 @@
       <code>string</code>
       <code>string</code>
     </MixedInferredReturnType>
-    <MixedMethodCall occurrences="4">
+    <MixedMethodCall>
       <code>setEntryElement</code>
       <code>setEntryKey</code>
       <code>setType</code>
       <code>setXpath</code>
     </MixedMethodCall>
-    <MixedReturnStatement occurrences="16">
-      <code>$this-&gt;data['authors']</code>
-      <code>$this-&gt;data['categories']</code>
-      <code>$this-&gt;data['commentcount']</code>
-      <code>$this-&gt;data['commentfeedlink']</code>
-      <code>$this-&gt;data['commentlink']</code>
-      <code>$this-&gt;data['content']</code>
-      <code>$this-&gt;data['datecreated']</code>
-      <code>$this-&gt;data['datemodified']</code>
-      <code>$this-&gt;data['description']</code>
-      <code>$this-&gt;data['enclosure']</code>
-      <code>$this-&gt;data['id']</code>
-      <code>$this-&gt;data['links']</code>
-      <code>$this-&gt;data['source']</code>
-      <code>$this-&gt;data['title']</code>
+    <MixedReturnStatement>
+      <code><![CDATA[$this->data['authors']]]></code>
+      <code><![CDATA[$this->data['categories']]]></code>
+      <code><![CDATA[$this->data['commentcount']]]></code>
+      <code><![CDATA[$this->data['commentfeedlink']]]></code>
+      <code><![CDATA[$this->data['commentlink']]]></code>
+      <code><![CDATA[$this->data['content']]]></code>
+      <code><![CDATA[$this->data['datecreated']]]></code>
+      <code><![CDATA[$this->data['datemodified']]]></code>
+      <code><![CDATA[$this->data['description']]]></code>
+      <code><![CDATA[$this->data['enclosure']]]></code>
+      <code><![CDATA[$this->data['id']]]></code>
+      <code><![CDATA[$this->data['links']]]></code>
+      <code><![CDATA[$this->data['source']]]></code>
+      <code><![CDATA[$this->data['title']]]></code>
+      <code><![CDATA[isset($this->data['links'][$index]) && is_string($this->data['links'][$index])
+            ? $this->data['links'][$index]
+            : null]]></code>
+      <code><![CDATA[isset($this->data['links'][$index]) && is_string($this->data['links'][$index])
+            ? $this->data['links'][$index]
+            : null]]></code>
     </MixedReturnStatement>
-    <MixedReturnTypeCoercion occurrences="2">
-      <code>null|array&lt;string, string&gt;</code>
+    <MixedReturnTypeCoercion>
+      <code><![CDATA[isset($authors[$index]) && is_array($authors[$index])
+            ? $authors[$index]
+            : null]]></code>
+      <code><![CDATA[null|array<string, string>]]></code>
     </MixedReturnTypeCoercion>
-    <NullableReturnStatement occurrences="1">
-      <code>$this-&gt;getLink(0)</code>
+    <NullableReturnStatement>
+      <code><![CDATA[$this->getLink(0)]]></code>
     </NullableReturnStatement>
-    <PropertyNotSetInConstructor occurrences="1">
+    <PropertyNotSetInConstructor>
       <code>Atom</code>
     </PropertyNotSetInConstructor>
   </file>
   <file src="src/Reader/Entry/Rss.php">
-    <ArgumentTypeCoercion occurrences="1"/>
-    <ImplementedReturnTypeMismatch occurrences="3">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[[
+                    'term'   => $category->nodeValue,
+                    'scheme' => $category->getAttribute('domain'),
+                    'label'  => $category->nodeValue,
+                ]]]></code>
+    </ArgumentTypeCoercion>
+    <ImplementedReturnTypeMismatch>
       <code>null|string</code>
       <code>null|string</code>
       <code>void</code>
     </ImplementedReturnTypeMismatch>
-    <InvalidArgument occurrences="2">
+    <InvalidArgument>
       <code>$entryKey</code>
       <code>Reader\Reader::arrayUnique($authors)</code>
     </InvalidArgument>
-    <InvalidNullableReturnType occurrences="1">
+    <InvalidNullableReturnType>
       <code>string</code>
     </InvalidNullableReturnType>
-    <InvalidReturnStatement occurrences="1">
-      <code>$this-&gt;data['authors']</code>
+    <InvalidReturnStatement>
+      <code><![CDATA[$this->data['authors']]]></code>
     </InvalidReturnStatement>
-    <MixedArgument occurrences="2">
+    <MixedArgument>
       <code>$dateModified</code>
       <code>$dateModified</code>
     </MixedArgument>
-    <MixedArrayAccess occurrences="1">
+    <MixedArrayAccess>
       <code>$author['name']</code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="8">
+    <MixedAssignment>
       <code>$author</code>
       <code>$commentlink</code>
       <code>$dateModified</code>
@@ -566,7 +599,7 @@
       <code>$id</code>
       <code>$title</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="13">
+    <MixedInferredReturnType>
       <code>DateTime</code>
       <code>Reader\Collection\Category</code>
       <code>array</code>
@@ -581,76 +614,85 @@
       <code>string</code>
       <code>string</code>
     </MixedInferredReturnType>
-    <MixedMethodCall occurrences="4">
+    <MixedMethodCall>
       <code>setEntryElement</code>
       <code>setEntryKey</code>
       <code>setType</code>
       <code>setXpath</code>
     </MixedMethodCall>
-    <MixedReturnStatement occurrences="18">
-      <code>$this-&gt;data['authors']</code>
-      <code>$this-&gt;data['categories']</code>
-      <code>$this-&gt;data['commentcount']</code>
-      <code>$this-&gt;data['commentfeedlink']</code>
-      <code>$this-&gt;data['commentlink']</code>
-      <code>$this-&gt;data['commentlink']</code>
-      <code>$this-&gt;data['commentlink']</code>
-      <code>$this-&gt;data['content']</code>
-      <code>$this-&gt;data['datemodified']</code>
-      <code>$this-&gt;data['description']</code>
-      <code>$this-&gt;data['enclosure']</code>
-      <code>$this-&gt;data['id']</code>
-      <code>$this-&gt;data['id']</code>
-      <code>$this-&gt;data['id']</code>
-      <code>$this-&gt;data['links']</code>
-      <code>$this-&gt;data['title']</code>
+    <MixedReturnStatement>
+      <code><![CDATA[$this->data['authors']]]></code>
+      <code><![CDATA[$this->data['categories']]]></code>
+      <code><![CDATA[$this->data['commentcount']]]></code>
+      <code><![CDATA[$this->data['commentfeedlink']]]></code>
+      <code><![CDATA[$this->data['commentlink']]]></code>
+      <code><![CDATA[$this->data['commentlink']]]></code>
+      <code><![CDATA[$this->data['commentlink']]]></code>
+      <code><![CDATA[$this->data['content']]]></code>
+      <code><![CDATA[$this->data['datemodified']]]></code>
+      <code><![CDATA[$this->data['description']]]></code>
+      <code><![CDATA[$this->data['enclosure']]]></code>
+      <code><![CDATA[$this->data['id']]]></code>
+      <code><![CDATA[$this->data['id']]]></code>
+      <code><![CDATA[$this->data['id']]]></code>
+      <code><![CDATA[$this->data['links']]]></code>
+      <code><![CDATA[$this->data['title']]]></code>
+      <code><![CDATA[isset($this->data['links'][$index]) && is_string($this->data['links'][$index])
+            ? $this->data['links'][$index]
+            : null]]></code>
+      <code><![CDATA[isset($this->data['links'][$index]) && is_string($this->data['links'][$index])
+            ? $this->data['links'][$index]
+            : null]]></code>
     </MixedReturnStatement>
-    <MixedReturnTypeCoercion occurrences="2">
-      <code>null|array&lt;string, string&gt;</code>
+    <MixedReturnTypeCoercion>
+      <code><![CDATA[isset($authors[$index]) && is_array($authors[$index])
+            ? $authors[$index]
+            : null]]></code>
+      <code><![CDATA[null|array<string, string>]]></code>
     </MixedReturnTypeCoercion>
-    <NullArgument occurrences="1">
+    <NullArgument>
       <code>$categoryCollection</code>
     </NullArgument>
-    <NullableReturnStatement occurrences="5">
-      <code>$this-&gt;data['commentfeedlink']</code>
-      <code>$this-&gt;data['commentlink']</code>
-      <code>$this-&gt;data['datemodified']</code>
-      <code>$this-&gt;data['id']</code>
-      <code>$this-&gt;getLink(0)</code>
+    <NullableReturnStatement>
+      <code><![CDATA[$this->data['commentfeedlink']]]></code>
+      <code><![CDATA[$this->data['commentlink']]]></code>
+      <code><![CDATA[$this->data['datemodified']]]></code>
+      <code><![CDATA[$this->data['id']]]></code>
+      <code><![CDATA[$this->getLink(0)]]></code>
     </NullableReturnStatement>
-    <PossiblyNullArgument occurrences="2">
-      <code>$author-&gt;nodeValue</code>
+    <PossiblyNullArgument>
+      <code><![CDATA[$author->nodeValue]]></code>
       <code>$standard</code>
     </PossiblyNullArgument>
-    <PropertyNotSetInConstructor occurrences="1">
+    <PropertyNotSetInConstructor>
       <code>Rss</code>
     </PropertyNotSetInConstructor>
-    <RedundantCondition occurrences="4">
+    <RedundantCondition>
       <code>$list instanceof DOMNodeList</code>
       <code>$list instanceof DOMNodeList</code>
       <code>$list instanceof DOMNodeList</code>
       <code>$nodeList instanceof DOMNodeList</code>
     </RedundantCondition>
-    <UndefinedMethod occurrences="1">
+    <UndefinedMethod>
       <code>getAttribute</code>
     </UndefinedMethod>
   </file>
   <file src="src/Reader/Extension/AbstractEntry.php">
-    <DocblockTypeContradiction occurrences="3">
-      <code>! $this-&gt;xpath</code>
-      <code>$this-&gt;xpath</code>
+    <DocblockTypeContradiction>
+      <code><![CDATA[! $this->xpath]]></code>
+      <code><![CDATA[$this->xpath]]></code>
       <code>null === $type</code>
     </DocblockTypeContradiction>
-    <InvalidArgument occurrences="1">
-      <code>$this-&gt;getEntryElement()</code>
+    <InvalidArgument>
+      <code><![CDATA[$this->getEntryElement()]]></code>
     </InvalidArgument>
-    <InvalidNullableReturnType occurrences="1">
+    <InvalidNullableReturnType>
       <code>string</code>
     </InvalidNullableReturnType>
-    <InvalidPropertyAssignmentValue occurrences="1">
+    <InvalidPropertyAssignmentValue>
       <code>$entryKey</code>
     </InvalidPropertyAssignmentValue>
-    <MissingConstructor occurrences="33">
+    <MissingConstructor>
       <code>$domDocument</code>
       <code>$domDocument</code>
       <code>$domDocument</code>
@@ -685,36 +727,36 @@
       <code>$xpath</code>
       <code>$xpath</code>
     </MissingConstructor>
-    <MixedAssignment occurrences="1">
+    <MixedAssignment>
       <code>$type</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="1">
+    <MixedInferredReturnType>
       <code>string</code>
     </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="2">
+    <MixedReturnStatement>
       <code>$type</code>
       <code>$type</code>
     </MixedReturnStatement>
-    <NullableReturnStatement occurrences="1">
-      <code>$this-&gt;getDomDocument()-&gt;encoding</code>
+    <NullableReturnStatement>
+      <code><![CDATA[$this->getDomDocument()->encoding]]></code>
     </NullableReturnStatement>
-    <PossiblyNullPropertyAssignmentValue occurrences="1">
-      <code>$entry-&gt;ownerDocument</code>
+    <PossiblyNullPropertyAssignmentValue>
+      <code><![CDATA[$entry->ownerDocument]]></code>
     </PossiblyNullPropertyAssignmentValue>
-    <RedundantCastGivenDocblockType occurrences="3">
-      <code>(int) $this-&gt;entryKey</code>
-      <code>(int) $this-&gt;entryKey</code>
-      <code>(int) $this-&gt;entryKey</code>
+    <RedundantCastGivenDocblockType>
+      <code><![CDATA[(int) $this->entryKey]]></code>
+      <code><![CDATA[(int) $this->entryKey]]></code>
+      <code><![CDATA[(int) $this->entryKey]]></code>
     </RedundantCastGivenDocblockType>
   </file>
   <file src="src/Reader/Extension/AbstractFeed.php">
-    <DocblockTypeContradiction occurrences="1">
-      <code>null === $this-&gt;xpath</code>
+    <DocblockTypeContradiction>
+      <code><![CDATA[null === $this->xpath]]></code>
     </DocblockTypeContradiction>
-    <InvalidNullableReturnType occurrences="1">
+    <InvalidNullableReturnType>
       <code>string</code>
     </InvalidNullableReturnType>
-    <MissingConstructor occurrences="16">
+    <MissingConstructor>
       <code>$domDocument</code>
       <code>$domDocument</code>
       <code>$domDocument</code>
@@ -732,43 +774,50 @@
       <code>$xpath</code>
       <code>$xpath</code>
     </MissingConstructor>
-    <MissingReturnType occurrences="1">
+    <MissingReturnType>
       <code>registerNamespaces</code>
     </MissingReturnType>
-    <MixedAssignment occurrences="1">
+    <MixedAssignment>
       <code>$type</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="1">
+    <MixedInferredReturnType>
       <code>string</code>
     </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="2">
+    <MixedReturnStatement>
       <code>$type</code>
       <code>$type</code>
     </MixedReturnStatement>
-    <NullableReturnStatement occurrences="1">
-      <code>$this-&gt;getDomDocument()-&gt;encoding</code>
+    <NullableReturnStatement>
+      <code><![CDATA[$this->getDomDocument()->encoding]]></code>
     </NullableReturnStatement>
-    <PossiblyNullPropertyAssignmentValue occurrences="1">
+    <PossiblyNullPropertyAssignmentValue>
       <code>null</code>
     </PossiblyNullPropertyAssignmentValue>
   </file>
   <file src="src/Reader/Extension/Atom/Entry.php">
-    <ArgumentTypeCoercion occurrences="3">
+    <ArgumentTypeCoercion>
       <code>$author</code>
       <code>$element</code>
     </ArgumentTypeCoercion>
-    <InvalidArgument occurrences="1">
+    <InvalidArgument>
       <code>Reader\Reader::arrayUnique($authors)</code>
     </InvalidArgument>
-    <MixedArgument occurrences="6">
+    <MixedArgument>
       <code>$content ?? ''</code>
       <code>$dateCreated</code>
       <code>$dateModified</code>
       <code>$link</code>
       <code>$link</code>
-      <code>$link-&gt;value</code>
+      <code><![CDATA[$link->value]]></code>
     </MixedArgument>
-    <MixedAssignment occurrences="14">
+    <MixedArgumentTypeCoercion>
+      <code><![CDATA[[
+                    'term'   => $category->getAttribute('term'),
+                    'scheme' => $category->getAttribute('scheme'),
+                    'label'  => $category->getAttribute('label'),
+                ]]]></code>
+    </MixedArgumentTypeCoercion>
+    <MixedAssignment>
       <code>$baseUrl</code>
       <code>$baseUrl</code>
       <code>$content</code>
@@ -784,7 +833,7 @@
       <code>$title</code>
       <code>$type</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="15">
+    <MixedInferredReturnType>
       <code>Collection\Author</code>
       <code>Collection\Category</code>
       <code>array</code>
@@ -801,48 +850,48 @@
       <code>string</code>
       <code>string</code>
     </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="23">
-      <code>$this-&gt;data['authors']</code>
-      <code>$this-&gt;data['baseUrl']</code>
-      <code>$this-&gt;data['baseUrl']</code>
-      <code>$this-&gt;data['baseUrl']</code>
-      <code>$this-&gt;data['categories']</code>
-      <code>$this-&gt;data['commentcount']</code>
-      <code>$this-&gt;data['commentcount']</code>
-      <code>$this-&gt;data['commentcount']</code>
-      <code>$this-&gt;data['commentfeedlink']</code>
-      <code>$this-&gt;data['commentlink']</code>
-      <code>$this-&gt;data['content']</code>
-      <code>$this-&gt;data['datecreated']</code>
-      <code>$this-&gt;data['datemodified']</code>
-      <code>$this-&gt;data['description']</code>
-      <code>$this-&gt;data['description']</code>
-      <code>$this-&gt;data['description']</code>
-      <code>$this-&gt;data['enclosure']</code>
-      <code>$this-&gt;data['id']</code>
-      <code>$this-&gt;data['id']</code>
-      <code>$this-&gt;data['id']</code>
-      <code>$this-&gt;data['links']</code>
-      <code>$this-&gt;data['source']</code>
-      <code>$this-&gt;data['title']</code>
+    <MixedReturnStatement>
+      <code><![CDATA[$this->data['authors']]]></code>
+      <code><![CDATA[$this->data['baseUrl']]]></code>
+      <code><![CDATA[$this->data['baseUrl']]]></code>
+      <code><![CDATA[$this->data['baseUrl']]]></code>
+      <code><![CDATA[$this->data['categories']]]></code>
+      <code><![CDATA[$this->data['commentcount']]]></code>
+      <code><![CDATA[$this->data['commentcount']]]></code>
+      <code><![CDATA[$this->data['commentcount']]]></code>
+      <code><![CDATA[$this->data['commentfeedlink']]]></code>
+      <code><![CDATA[$this->data['commentlink']]]></code>
+      <code><![CDATA[$this->data['content']]]></code>
+      <code><![CDATA[$this->data['datecreated']]]></code>
+      <code><![CDATA[$this->data['datemodified']]]></code>
+      <code><![CDATA[$this->data['description']]]></code>
+      <code><![CDATA[$this->data['description']]]></code>
+      <code><![CDATA[$this->data['description']]]></code>
+      <code><![CDATA[$this->data['enclosure']]]></code>
+      <code><![CDATA[$this->data['id']]]></code>
+      <code><![CDATA[$this->data['id']]]></code>
+      <code><![CDATA[$this->data['id']]]></code>
+      <code><![CDATA[$this->data['links']]]></code>
+      <code><![CDATA[$this->data['source']]]></code>
+      <code><![CDATA[$this->data['title']]]></code>
     </MixedReturnStatement>
-    <NullArgument occurrences="1">
+    <NullArgument>
       <code>$categoryCollection</code>
     </NullArgument>
-    <NullableReturnStatement occurrences="5">
-      <code>$this-&gt;data['commentfeedlink']</code>
-      <code>$this-&gt;data['commentlink']</code>
-      <code>$this-&gt;data['description']</code>
-      <code>$this-&gt;data['id']</code>
-      <code>$this-&gt;data['title']</code>
+    <NullableReturnStatement>
+      <code><![CDATA[$this->data['commentfeedlink']]]></code>
+      <code><![CDATA[$this->data['commentlink']]]></code>
+      <code><![CDATA[$this->data['description']]]></code>
+      <code><![CDATA[$this->data['id']]]></code>
+      <code><![CDATA[$this->data['title']]]></code>
     </NullableReturnStatement>
-    <PossiblyNullArgument occurrences="1">
-      <code>$d-&gt;lookupPrefix('http://www.w3.org/1999/xhtml')</code>
+    <PossiblyNullArgument>
+      <code><![CDATA[$d->lookupPrefix('http://www.w3.org/1999/xhtml')]]></code>
     </PossiblyNullArgument>
-    <PossiblyNullOperand occurrences="1">
-      <code>$this-&gt;getBaseUrl()</code>
+    <PossiblyNullOperand>
+      <code><![CDATA[$this->getBaseUrl()]]></code>
     </PossiblyNullOperand>
-    <RedundantCondition occurrences="8">
+    <RedundantCondition>
       <code>$list instanceof DOMNodeList</code>
       <code>$list instanceof DOMNodeList</code>
       <code>$list instanceof DOMNodeList</code>
@@ -852,35 +901,42 @@
       <code>$list instanceof DOMNodeList</code>
       <code>$nodeList instanceof DOMNodeList</code>
     </RedundantCondition>
-    <TypeDoesNotContainType occurrences="1">
+    <TypeDoesNotContainType>
       <code>! $list instanceof DOMNodeList</code>
     </TypeDoesNotContainType>
-    <UndefinedMethod occurrences="4">
+    <UndefinedMethod>
       <code>getAttribute</code>
       <code>getAttribute</code>
       <code>getAttribute</code>
       <code>getAttribute</code>
     </UndefinedMethod>
-    <UndefinedPropertyFetch occurrences="4">
-      <code>$link-&gt;value</code>
-      <code>$list-&gt;item(0)-&gt;value</code>
-      <code>$list-&gt;item(0)-&gt;value</code>
-      <code>$list-&gt;item(0)-&gt;value</code>
+    <UndefinedPropertyFetch>
+      <code><![CDATA[$link->value]]></code>
+      <code><![CDATA[$list->item(0)->value]]></code>
+      <code><![CDATA[$list->item(0)->value]]></code>
+      <code><![CDATA[$list->item(0)->value]]></code>
     </UndefinedPropertyFetch>
   </file>
   <file src="src/Reader/Extension/Atom/Feed.php">
-    <ArgumentTypeCoercion occurrences="2">
+    <ArgumentTypeCoercion>
       <code>$author</code>
     </ArgumentTypeCoercion>
-    <InvalidArgument occurrences="1">
+    <InvalidArgument>
       <code>Reader\Reader::arrayUnique($authors)</code>
     </InvalidArgument>
-    <MixedArgument occurrences="3">
+    <MixedArgument>
       <code>$dateCreated</code>
       <code>$dateModified</code>
       <code>$link</code>
     </MixedArgument>
-    <MixedAssignment occurrences="14">
+    <MixedArgumentTypeCoercion>
+      <code><![CDATA[[
+                    'term'   => $category->getAttribute('term'),
+                    'scheme' => $category->getAttribute('scheme'),
+                    'label'  => $category->getAttribute('label'),
+                ]]]></code>
+    </MixedArgumentTypeCoercion>
+    <MixedAssignment>
       <code>$baseUrl</code>
       <code>$copyright</code>
       <code>$dateCreated</code>
@@ -896,7 +952,7 @@
       <code>$link</code>
       <code>$title</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="15">
+    <MixedInferredReturnType>
       <code>Collection\Author</code>
       <code>Collection\Category</code>
       <code>null|DateTime</code>
@@ -913,96 +969,101 @@
       <code>null|string</code>
       <code>null|string</code>
     </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="25">
-      <code>$this-&gt;data['authors']</code>
-      <code>$this-&gt;data['baseUrl']</code>
-      <code>$this-&gt;data['baseUrl']</code>
-      <code>$this-&gt;data['baseUrl']</code>
-      <code>$this-&gt;data['categories']</code>
-      <code>$this-&gt;data['copyright']</code>
-      <code>$this-&gt;data['datecreated']</code>
-      <code>$this-&gt;data['datemodified']</code>
-      <code>$this-&gt;data['description']</code>
-      <code>$this-&gt;data['feedlink']</code>
-      <code>$this-&gt;data['generator']</code>
-      <code>$this-&gt;data['generator']</code>
-      <code>$this-&gt;data['generator']</code>
-      <code>$this-&gt;data['hubs']</code>
-      <code>$this-&gt;data['id']</code>
-      <code>$this-&gt;data['id']</code>
-      <code>$this-&gt;data['id']</code>
-      <code>$this-&gt;data['image']</code>
-      <code>$this-&gt;data['language']</code>
-      <code>$this-&gt;data['language']</code>
-      <code>$this-&gt;data['language']</code>
-      <code>$this-&gt;data['link']</code>
-      <code>$this-&gt;data['title']</code>
-      <code>$this-&gt;data['title']</code>
-      <code>$this-&gt;data['title']</code>
+    <MixedReturnStatement>
+      <code><![CDATA[$this->data['authors']]]></code>
+      <code><![CDATA[$this->data['baseUrl']]]></code>
+      <code><![CDATA[$this->data['baseUrl']]]></code>
+      <code><![CDATA[$this->data['baseUrl']]]></code>
+      <code><![CDATA[$this->data['categories']]]></code>
+      <code><![CDATA[$this->data['copyright']]]></code>
+      <code><![CDATA[$this->data['datecreated']]]></code>
+      <code><![CDATA[$this->data['datemodified']]]></code>
+      <code><![CDATA[$this->data['description']]]></code>
+      <code><![CDATA[$this->data['feedlink']]]></code>
+      <code><![CDATA[$this->data['generator']]]></code>
+      <code><![CDATA[$this->data['generator']]]></code>
+      <code><![CDATA[$this->data['generator']]]></code>
+      <code><![CDATA[$this->data['hubs']]]></code>
+      <code><![CDATA[$this->data['id']]]></code>
+      <code><![CDATA[$this->data['id']]]></code>
+      <code><![CDATA[$this->data['id']]]></code>
+      <code><![CDATA[$this->data['image']]]></code>
+      <code><![CDATA[$this->data['language']]]></code>
+      <code><![CDATA[$this->data['language']]]></code>
+      <code><![CDATA[$this->data['language']]]></code>
+      <code><![CDATA[$this->data['link']]]></code>
+      <code><![CDATA[$this->data['title']]]></code>
+      <code><![CDATA[$this->data['title']]]></code>
+      <code><![CDATA[$this->data['title']]]></code>
     </MixedReturnStatement>
-    <NullArgument occurrences="1">
+    <NullArgument>
       <code>$categoryCollection</code>
     </NullArgument>
-    <PossiblyNullArgument occurrences="1">
-      <code>$uri-&gt;nodeValue</code>
+    <PossiblyNullArgument>
+      <code><![CDATA[$uri->nodeValue]]></code>
     </PossiblyNullArgument>
-    <PossiblyNullOperand occurrences="1">
-      <code>$this-&gt;getBaseUrl()</code>
+    <PossiblyNullOperand>
+      <code><![CDATA[$this->getBaseUrl()]]></code>
     </PossiblyNullOperand>
-    <UndefinedMethod occurrences="3">
+    <UndefinedMethod>
       <code>getAttribute</code>
       <code>getAttribute</code>
       <code>getAttribute</code>
     </UndefinedMethod>
   </file>
   <file src="src/Reader/Extension/Content/Entry.php">
-    <MixedInferredReturnType occurrences="1">
+    <MixedInferredReturnType>
       <code>string</code>
     </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="2">
-      <code>$this-&gt;xpath-&gt;evaluate('string(' . $this-&gt;getXpathPrefix() . '/content:encoded)')</code>
-      <code>$this-&gt;xpath-&gt;evaluate('string(' . $this-&gt;getXpathPrefix() . '/content:encoded)')</code>
+    <MixedReturnStatement>
+      <code><![CDATA[$this->xpath->evaluate('string(' . $this->getXpathPrefix() . '/content:encoded)')]]></code>
+      <code><![CDATA[$this->xpath->evaluate('string(' . $this->getXpathPrefix() . '/content:encoded)')]]></code>
     </MixedReturnStatement>
   </file>
   <file src="src/Reader/Extension/CreativeCommons/Entry.php">
-    <MixedAssignment occurrences="1">
+    <MixedAssignment>
       <code>$list</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="1">
+    <MixedInferredReturnType>
       <code>array</code>
     </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="1">
-      <code>$this-&gt;data[$name]</code>
+    <MixedReturnStatement>
+      <code><![CDATA[$this->data[$name]]]></code>
     </MixedReturnStatement>
   </file>
   <file src="src/Reader/Extension/CreativeCommons/Feed.php">
-    <MixedAssignment occurrences="3">
+    <MixedAssignment>
       <code>$license</code>
       <code>$licenses[]</code>
       <code>$list</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="1">
+    <MixedInferredReturnType>
       <code>array</code>
     </MixedInferredReturnType>
-    <MixedPropertyFetch occurrences="2">
-      <code>$license-&gt;nodeValue</code>
-      <code>$list-&gt;length</code>
+    <MixedPropertyFetch>
+      <code><![CDATA[$license->nodeValue]]></code>
+      <code><![CDATA[$list->length]]></code>
     </MixedPropertyFetch>
-    <MixedReturnStatement occurrences="1">
-      <code>$this-&gt;data[$name]</code>
+    <MixedReturnStatement>
+      <code><![CDATA[$this->data[$name]]]></code>
     </MixedReturnStatement>
   </file>
   <file src="src/Reader/Extension/DublinCore/Entry.php">
-    <ArgumentTypeCoercion occurrences="2">
+    <ArgumentTypeCoercion>
       <code>Reader\Reader::arrayUnique($authors)</code>
+      <code><![CDATA[[
+                    'term'   => $category->nodeValue,
+                    'scheme' => null,
+                    'label'  => $category->nodeValue,
+                ]]]></code>
     </ArgumentTypeCoercion>
-    <InvalidReturnStatement occurrences="1">
-      <code>$this-&gt;data['authors']</code>
+    <InvalidReturnStatement>
+      <code><![CDATA[$this->data['authors']]]></code>
     </InvalidReturnStatement>
-    <MixedArgument occurrences="1">
+    <MixedArgument>
       <code>$date</code>
     </MixedArgument>
-    <MixedAssignment occurrences="14">
+    <MixedAssignment>
       <code>$date</code>
       <code>$date</code>
       <code>$description</code>
@@ -1018,7 +1079,7 @@
       <code>$title</code>
       <code>$title</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="6">
+    <MixedInferredReturnType>
       <code>Collection\Category</code>
       <code>array</code>
       <code>null|DateTime</code>
@@ -1026,42 +1087,50 @@
       <code>string</code>
       <code>string</code>
     </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="11">
-      <code>$this-&gt;data['authors']</code>
-      <code>$this-&gt;data['categories']</code>
-      <code>$this-&gt;data['date']</code>
-      <code>$this-&gt;data['description']</code>
-      <code>$this-&gt;data['description']</code>
-      <code>$this-&gt;data['description']</code>
-      <code>$this-&gt;data['id']</code>
-      <code>$this-&gt;data['id']</code>
-      <code>$this-&gt;data['title']</code>
-      <code>$this-&gt;data['title']</code>
-      <code>$this-&gt;data['title']</code>
+    <MixedReturnStatement>
+      <code><![CDATA[$this->data['authors']]]></code>
+      <code><![CDATA[$this->data['categories']]]></code>
+      <code><![CDATA[$this->data['date']]]></code>
+      <code><![CDATA[$this->data['description']]]></code>
+      <code><![CDATA[$this->data['description']]]></code>
+      <code><![CDATA[$this->data['description']]]></code>
+      <code><![CDATA[$this->data['id']]]></code>
+      <code><![CDATA[$this->data['id']]]></code>
+      <code><![CDATA[$this->data['title']]]></code>
+      <code><![CDATA[$this->data['title']]]></code>
+      <code><![CDATA[$this->data['title']]]></code>
     </MixedReturnStatement>
-    <MixedReturnTypeCoercion occurrences="2">
-      <code>null|array&lt;string, string&gt;</code>
+    <MixedReturnTypeCoercion>
+      <code><![CDATA[isset($authors[$index]) && is_array($authors[$index])
+            ? $authors[$index]
+            : null]]></code>
+      <code><![CDATA[null|array<string, string>]]></code>
     </MixedReturnTypeCoercion>
-    <NullArgument occurrences="1">
+    <NullArgument>
       <code>$categoryCollection</code>
     </NullArgument>
-    <NullableReturnStatement occurrences="3">
-      <code>$this-&gt;data['authors']</code>
-      <code>$this-&gt;data['description']</code>
-      <code>$this-&gt;data['title']</code>
+    <NullableReturnStatement>
+      <code><![CDATA[$this->data['authors']]]></code>
+      <code><![CDATA[$this->data['description']]]></code>
+      <code><![CDATA[$this->data['title']]]></code>
     </NullableReturnStatement>
   </file>
   <file src="src/Reader/Extension/DublinCore/Feed.php">
-    <ArgumentTypeCoercion occurrences="2">
+    <ArgumentTypeCoercion>
       <code>Reader\Reader::arrayUnique($authors)</code>
+      <code><![CDATA[[
+                    'term'   => $category->nodeValue,
+                    'scheme' => null,
+                    'label'  => $category->nodeValue,
+                ]]]></code>
     </ArgumentTypeCoercion>
-    <InvalidReturnStatement occurrences="1">
-      <code>$this-&gt;data['authors']</code>
+    <InvalidReturnStatement>
+      <code><![CDATA[$this->data['authors']]]></code>
     </InvalidReturnStatement>
-    <MixedArgument occurrences="1">
+    <MixedArgument>
       <code>$date</code>
     </MixedArgument>
-    <MixedAssignment occurrences="14">
+    <MixedAssignment>
       <code>$copyright</code>
       <code>$copyright</code>
       <code>$date</code>
@@ -1077,7 +1146,7 @@
       <code>$title</code>
       <code>$title</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="8">
+    <MixedInferredReturnType>
       <code>Collection\Category</code>
       <code>array</code>
       <code>null|DateTime</code>
@@ -1087,69 +1156,69 @@
       <code>null|string</code>
       <code>null|string</code>
     </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="17">
-      <code>$this-&gt;data['authors']</code>
-      <code>$this-&gt;data['categories']</code>
-      <code>$this-&gt;data['copyright']</code>
-      <code>$this-&gt;data['copyright']</code>
-      <code>$this-&gt;data['copyright']</code>
-      <code>$this-&gt;data['date']</code>
-      <code>$this-&gt;data['description']</code>
-      <code>$this-&gt;data['description']</code>
-      <code>$this-&gt;data['description']</code>
-      <code>$this-&gt;data['id']</code>
-      <code>$this-&gt;data['id']</code>
-      <code>$this-&gt;data['language']</code>
-      <code>$this-&gt;data['language']</code>
-      <code>$this-&gt;data['language']</code>
-      <code>$this-&gt;data['title']</code>
-      <code>$this-&gt;data['title']</code>
-      <code>$this-&gt;data['title']</code>
+    <MixedReturnStatement>
+      <code><![CDATA[$this->data['authors']]]></code>
+      <code><![CDATA[$this->data['categories']]]></code>
+      <code><![CDATA[$this->data['copyright']]]></code>
+      <code><![CDATA[$this->data['copyright']]]></code>
+      <code><![CDATA[$this->data['copyright']]]></code>
+      <code><![CDATA[$this->data['date']]]></code>
+      <code><![CDATA[$this->data['description']]]></code>
+      <code><![CDATA[$this->data['description']]]></code>
+      <code><![CDATA[$this->data['description']]]></code>
+      <code><![CDATA[$this->data['id']]]></code>
+      <code><![CDATA[$this->data['id']]]></code>
+      <code><![CDATA[$this->data['language']]]></code>
+      <code><![CDATA[$this->data['language']]]></code>
+      <code><![CDATA[$this->data['language']]]></code>
+      <code><![CDATA[$this->data['title']]]></code>
+      <code><![CDATA[$this->data['title']]]></code>
+      <code><![CDATA[$this->data['title']]]></code>
     </MixedReturnStatement>
-    <NullArgument occurrences="1">
+    <NullArgument>
       <code>$categoryCollection</code>
     </NullArgument>
-    <NullableReturnStatement occurrences="1">
-      <code>$this-&gt;data['authors']</code>
+    <NullableReturnStatement>
+      <code><![CDATA[$this->data['authors']]]></code>
     </NullableReturnStatement>
   </file>
   <file src="src/Reader/Extension/GooglePlayPodcast/Entry.php">
-    <MixedAssignment occurrences="3">
+    <MixedAssignment>
       <code>$block</code>
       <code>$description</code>
       <code>$explicit</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="3">
+    <MixedInferredReturnType>
       <code>string</code>
       <code>string</code>
       <code>string</code>
     </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="9">
-      <code>$this-&gt;data['block']</code>
-      <code>$this-&gt;data['block']</code>
-      <code>$this-&gt;data['block']</code>
-      <code>$this-&gt;data['description']</code>
-      <code>$this-&gt;data['description']</code>
-      <code>$this-&gt;data['description']</code>
-      <code>$this-&gt;data['explicit']</code>
-      <code>$this-&gt;data['explicit']</code>
-      <code>$this-&gt;data['explicit']</code>
+    <MixedReturnStatement>
+      <code><![CDATA[$this->data['block']]]></code>
+      <code><![CDATA[$this->data['block']]]></code>
+      <code><![CDATA[$this->data['block']]]></code>
+      <code><![CDATA[$this->data['description']]]></code>
+      <code><![CDATA[$this->data['description']]]></code>
+      <code><![CDATA[$this->data['description']]]></code>
+      <code><![CDATA[$this->data['explicit']]]></code>
+      <code><![CDATA[$this->data['explicit']]]></code>
+      <code><![CDATA[$this->data['explicit']]]></code>
     </MixedReturnStatement>
-    <NullableReturnStatement occurrences="3">
-      <code>$this-&gt;data['block']</code>
-      <code>$this-&gt;data['description']</code>
-      <code>$this-&gt;data['explicit']</code>
+    <NullableReturnStatement>
+      <code><![CDATA[$this->data['block']]]></code>
+      <code><![CDATA[$this->data['description']]]></code>
+      <code><![CDATA[$this->data['explicit']]]></code>
     </NullableReturnStatement>
   </file>
   <file src="src/Reader/Extension/GooglePlayPodcast/Feed.php">
-    <MixedAssignment occurrences="5">
+    <MixedAssignment>
       <code>$author</code>
       <code>$block</code>
       <code>$description</code>
       <code>$explicit</code>
       <code>$image</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="6">
+    <MixedInferredReturnType>
       <code>null|array</code>
       <code>string</code>
       <code>string</code>
@@ -1157,38 +1226,38 @@
       <code>string</code>
       <code>string</code>
     </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="16">
-      <code>$this-&gt;data['author']</code>
-      <code>$this-&gt;data['author']</code>
-      <code>$this-&gt;data['author']</code>
-      <code>$this-&gt;data['block']</code>
-      <code>$this-&gt;data['block']</code>
-      <code>$this-&gt;data['block']</code>
-      <code>$this-&gt;data['categories']</code>
-      <code>$this-&gt;data['description']</code>
-      <code>$this-&gt;data['description']</code>
-      <code>$this-&gt;data['description']</code>
-      <code>$this-&gt;data['explicit']</code>
-      <code>$this-&gt;data['explicit']</code>
-      <code>$this-&gt;data['explicit']</code>
-      <code>$this-&gt;data['image']</code>
-      <code>$this-&gt;data['image']</code>
-      <code>$this-&gt;data['image']</code>
+    <MixedReturnStatement>
+      <code><![CDATA[$this->data['author']]]></code>
+      <code><![CDATA[$this->data['author']]]></code>
+      <code><![CDATA[$this->data['author']]]></code>
+      <code><![CDATA[$this->data['block']]]></code>
+      <code><![CDATA[$this->data['block']]]></code>
+      <code><![CDATA[$this->data['block']]]></code>
+      <code><![CDATA[$this->data['categories']]]></code>
+      <code><![CDATA[$this->data['description']]]></code>
+      <code><![CDATA[$this->data['description']]]></code>
+      <code><![CDATA[$this->data['description']]]></code>
+      <code><![CDATA[$this->data['explicit']]]></code>
+      <code><![CDATA[$this->data['explicit']]]></code>
+      <code><![CDATA[$this->data['explicit']]]></code>
+      <code><![CDATA[$this->data['image']]]></code>
+      <code><![CDATA[$this->data['image']]]></code>
+      <code><![CDATA[$this->data['image']]]></code>
     </MixedReturnStatement>
-    <NullableReturnStatement occurrences="5">
-      <code>$this-&gt;data['author']</code>
-      <code>$this-&gt;data['block']</code>
-      <code>$this-&gt;data['description']</code>
-      <code>$this-&gt;data['explicit']</code>
-      <code>$this-&gt;data['image']</code>
+    <NullableReturnStatement>
+      <code><![CDATA[$this->data['author']]]></code>
+      <code><![CDATA[$this->data['block']]]></code>
+      <code><![CDATA[$this->data['description']]]></code>
+      <code><![CDATA[$this->data['explicit']]]></code>
+      <code><![CDATA[$this->data['image']]]></code>
     </NullableReturnStatement>
-    <UndefinedMethod occurrences="2">
+    <UndefinedMethod>
       <code>getAttribute</code>
       <code>getAttribute</code>
     </UndefinedMethod>
   </file>
   <file src="src/Reader/Extension/Podcast/Entry.php">
-    <MixedAssignment occurrences="13">
+    <MixedAssignment>
       <code>$author</code>
       <code>$block</code>
       <code>$duration</code>
@@ -1203,7 +1272,7 @@
       <code>$title</code>
       <code>$type</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="13">
+    <MixedInferredReturnType>
       <code>bool</code>
       <code>null|int</code>
       <code>null|int</code>
@@ -1218,53 +1287,53 @@
       <code>string</code>
       <code>string</code>
     </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="31">
-      <code>$this-&gt;data['author']</code>
-      <code>$this-&gt;data['author']</code>
-      <code>$this-&gt;data['author']</code>
-      <code>$this-&gt;data['block']</code>
-      <code>$this-&gt;data['block']</code>
-      <code>$this-&gt;data['block']</code>
-      <code>$this-&gt;data['duration']</code>
-      <code>$this-&gt;data['duration']</code>
-      <code>$this-&gt;data['duration']</code>
-      <code>$this-&gt;data['episode']</code>
-      <code>$this-&gt;data['episodeType']</code>
-      <code>$this-&gt;data['explicit']</code>
-      <code>$this-&gt;data['explicit']</code>
-      <code>$this-&gt;data['explicit']</code>
-      <code>$this-&gt;data['image']</code>
-      <code>$this-&gt;data['image']</code>
-      <code>$this-&gt;data['image']</code>
-      <code>$this-&gt;data['isClosedCaptioned']</code>
-      <code>$this-&gt;data['keywords']</code>
-      <code>$this-&gt;data['keywords']</code>
-      <code>$this-&gt;data['keywords']</code>
-      <code>$this-&gt;data['season']</code>
-      <code>$this-&gt;data['subtitle']</code>
-      <code>$this-&gt;data['subtitle']</code>
-      <code>$this-&gt;data['subtitle']</code>
-      <code>$this-&gt;data['summary']</code>
-      <code>$this-&gt;data['summary']</code>
-      <code>$this-&gt;data['summary']</code>
-      <code>$this-&gt;data['title']</code>
-      <code>$this-&gt;data['title']</code>
-      <code>$this-&gt;data['title']</code>
+    <MixedReturnStatement>
+      <code><![CDATA[$this->data['author']]]></code>
+      <code><![CDATA[$this->data['author']]]></code>
+      <code><![CDATA[$this->data['author']]]></code>
+      <code><![CDATA[$this->data['block']]]></code>
+      <code><![CDATA[$this->data['block']]]></code>
+      <code><![CDATA[$this->data['block']]]></code>
+      <code><![CDATA[$this->data['duration']]]></code>
+      <code><![CDATA[$this->data['duration']]]></code>
+      <code><![CDATA[$this->data['duration']]]></code>
+      <code><![CDATA[$this->data['episode']]]></code>
+      <code><![CDATA[$this->data['episodeType']]]></code>
+      <code><![CDATA[$this->data['explicit']]]></code>
+      <code><![CDATA[$this->data['explicit']]]></code>
+      <code><![CDATA[$this->data['explicit']]]></code>
+      <code><![CDATA[$this->data['image']]]></code>
+      <code><![CDATA[$this->data['image']]]></code>
+      <code><![CDATA[$this->data['image']]]></code>
+      <code><![CDATA[$this->data['isClosedCaptioned']]]></code>
+      <code><![CDATA[$this->data['keywords']]]></code>
+      <code><![CDATA[$this->data['keywords']]]></code>
+      <code><![CDATA[$this->data['keywords']]]></code>
+      <code><![CDATA[$this->data['season']]]></code>
+      <code><![CDATA[$this->data['subtitle']]]></code>
+      <code><![CDATA[$this->data['subtitle']]]></code>
+      <code><![CDATA[$this->data['subtitle']]]></code>
+      <code><![CDATA[$this->data['summary']]]></code>
+      <code><![CDATA[$this->data['summary']]]></code>
+      <code><![CDATA[$this->data['summary']]]></code>
+      <code><![CDATA[$this->data['title']]]></code>
+      <code><![CDATA[$this->data['title']]]></code>
+      <code><![CDATA[$this->data['title']]]></code>
     </MixedReturnStatement>
-    <NullableReturnStatement occurrences="9">
-      <code>$this-&gt;data['author']</code>
-      <code>$this-&gt;data['block']</code>
-      <code>$this-&gt;data['duration']</code>
-      <code>$this-&gt;data['explicit']</code>
-      <code>$this-&gt;data['image']</code>
-      <code>$this-&gt;data['keywords']</code>
-      <code>$this-&gt;data['subtitle']</code>
-      <code>$this-&gt;data['summary']</code>
-      <code>$this-&gt;data['title']</code>
+    <NullableReturnStatement>
+      <code><![CDATA[$this->data['author']]]></code>
+      <code><![CDATA[$this->data['block']]]></code>
+      <code><![CDATA[$this->data['duration']]]></code>
+      <code><![CDATA[$this->data['explicit']]]></code>
+      <code><![CDATA[$this->data['image']]]></code>
+      <code><![CDATA[$this->data['keywords']]]></code>
+      <code><![CDATA[$this->data['subtitle']]]></code>
+      <code><![CDATA[$this->data['summary']]]></code>
+      <code><![CDATA[$this->data['title']]]></code>
     </NullableReturnStatement>
   </file>
   <file src="src/Reader/Extension/Podcast/Feed.php">
-    <MixedAssignment occurrences="13">
+    <MixedAssignment>
       <code>$author</code>
       <code>$block</code>
       <code>$complete</code>
@@ -1279,7 +1348,7 @@
       <code>$summary</code>
       <code>$type</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="12">
+    <MixedInferredReturnType>
       <code>bool</code>
       <code>null|array</code>
       <code>string</code>
@@ -1293,248 +1362,248 @@
       <code>string</code>
       <code>string</code>
     </MixedInferredReturnType>
-    <MixedOperand occurrences="2">
+    <MixedOperand>
       <code>$email</code>
       <code>$name</code>
     </MixedOperand>
-    <MixedReturnStatement occurrences="30">
-      <code>$this-&gt;data['author']</code>
-      <code>$this-&gt;data['author']</code>
-      <code>$this-&gt;data['author']</code>
-      <code>$this-&gt;data['block']</code>
-      <code>$this-&gt;data['block']</code>
-      <code>$this-&gt;data['block']</code>
-      <code>$this-&gt;data['categories']</code>
-      <code>$this-&gt;data['complete']</code>
-      <code>$this-&gt;data['explicit']</code>
-      <code>$this-&gt;data['explicit']</code>
-      <code>$this-&gt;data['explicit']</code>
-      <code>$this-&gt;data['image']</code>
-      <code>$this-&gt;data['image']</code>
-      <code>$this-&gt;data['image']</code>
-      <code>$this-&gt;data['keywords']</code>
-      <code>$this-&gt;data['keywords']</code>
-      <code>$this-&gt;data['keywords']</code>
-      <code>$this-&gt;data['new-feed-url']</code>
-      <code>$this-&gt;data['new-feed-url']</code>
-      <code>$this-&gt;data['new-feed-url']</code>
-      <code>$this-&gt;data['owner']</code>
-      <code>$this-&gt;data['owner']</code>
-      <code>$this-&gt;data['owner']</code>
-      <code>$this-&gt;data['podcastType']</code>
-      <code>$this-&gt;data['subtitle']</code>
-      <code>$this-&gt;data['subtitle']</code>
-      <code>$this-&gt;data['subtitle']</code>
-      <code>$this-&gt;data['summary']</code>
-      <code>$this-&gt;data['summary']</code>
-      <code>$this-&gt;data['summary']</code>
+    <MixedReturnStatement>
+      <code><![CDATA[$this->data['author']]]></code>
+      <code><![CDATA[$this->data['author']]]></code>
+      <code><![CDATA[$this->data['author']]]></code>
+      <code><![CDATA[$this->data['block']]]></code>
+      <code><![CDATA[$this->data['block']]]></code>
+      <code><![CDATA[$this->data['block']]]></code>
+      <code><![CDATA[$this->data['categories']]]></code>
+      <code><![CDATA[$this->data['complete']]]></code>
+      <code><![CDATA[$this->data['explicit']]]></code>
+      <code><![CDATA[$this->data['explicit']]]></code>
+      <code><![CDATA[$this->data['explicit']]]></code>
+      <code><![CDATA[$this->data['image']]]></code>
+      <code><![CDATA[$this->data['image']]]></code>
+      <code><![CDATA[$this->data['image']]]></code>
+      <code><![CDATA[$this->data['keywords']]]></code>
+      <code><![CDATA[$this->data['keywords']]]></code>
+      <code><![CDATA[$this->data['keywords']]]></code>
+      <code><![CDATA[$this->data['new-feed-url']]]></code>
+      <code><![CDATA[$this->data['new-feed-url']]]></code>
+      <code><![CDATA[$this->data['new-feed-url']]]></code>
+      <code><![CDATA[$this->data['owner']]]></code>
+      <code><![CDATA[$this->data['owner']]]></code>
+      <code><![CDATA[$this->data['owner']]]></code>
+      <code><![CDATA[$this->data['podcastType']]]></code>
+      <code><![CDATA[$this->data['subtitle']]]></code>
+      <code><![CDATA[$this->data['subtitle']]]></code>
+      <code><![CDATA[$this->data['subtitle']]]></code>
+      <code><![CDATA[$this->data['summary']]]></code>
+      <code><![CDATA[$this->data['summary']]]></code>
+      <code><![CDATA[$this->data['summary']]]></code>
     </MixedReturnStatement>
-    <NullableReturnStatement occurrences="9">
-      <code>$this-&gt;data['author']</code>
-      <code>$this-&gt;data['block']</code>
-      <code>$this-&gt;data['explicit']</code>
-      <code>$this-&gt;data['image']</code>
-      <code>$this-&gt;data['keywords']</code>
-      <code>$this-&gt;data['new-feed-url']</code>
-      <code>$this-&gt;data['owner']</code>
-      <code>$this-&gt;data['subtitle']</code>
-      <code>$this-&gt;data['summary']</code>
+    <NullableReturnStatement>
+      <code><![CDATA[$this->data['author']]]></code>
+      <code><![CDATA[$this->data['block']]]></code>
+      <code><![CDATA[$this->data['explicit']]]></code>
+      <code><![CDATA[$this->data['image']]]></code>
+      <code><![CDATA[$this->data['keywords']]]></code>
+      <code><![CDATA[$this->data['new-feed-url']]]></code>
+      <code><![CDATA[$this->data['owner']]]></code>
+      <code><![CDATA[$this->data['subtitle']]]></code>
+      <code><![CDATA[$this->data['summary']]]></code>
     </NullableReturnStatement>
-    <UndefinedMethod occurrences="2">
+    <UndefinedMethod>
       <code>getAttribute</code>
       <code>getAttribute</code>
     </UndefinedMethod>
   </file>
   <file src="src/Reader/Extension/PodcastIndex/Entry.php">
-    <MismatchingDocblockReturnType occurrences="2">
+    <MismatchingDocblockReturnType>
       <code>null|object{url: string, type: string, language: string, rel: string}</code>
       <code>null|object{url: string, type: string}</code>
     </MismatchingDocblockReturnType>
-    <MixedInferredReturnType occurrences="3">
-      <code>array&lt;int, object{title: string, startTime: string, duration: string}&gt;</code>
+    <MixedInferredReturnType>
+      <code><![CDATA[array<int, object{title: string, startTime: string, duration: string}>]]></code>
       <code>null|object{url: string, type: string, language: string, rel: string}</code>
       <code>null|object{url: string, type: string}</code>
     </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="1">
-      <code>$this-&gt;data['soundbites']</code>
+    <MixedReturnStatement>
+      <code><![CDATA[$this->data['soundbites']]]></code>
     </MixedReturnStatement>
   </file>
   <file src="src/Reader/Extension/PodcastIndex/Feed.php">
-    <MismatchingDocblockReturnType occurrences="1">
+    <MismatchingDocblockReturnType>
       <code>null|object{url: string, title: string}</code>
     </MismatchingDocblockReturnType>
-    <MixedAssignment occurrences="2">
+    <MixedAssignment>
       <code>$locked</code>
       <code>$owner</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="3">
+    <MixedInferredReturnType>
       <code>?string</code>
       <code>bool</code>
       <code>null|object{url: string, title: string}</code>
     </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="4">
-      <code>$this-&gt;data['locked']</code>
-      <code>$this-&gt;data['owner']</code>
-      <code>$this-&gt;data['owner']</code>
-      <code>$this-&gt;data['owner']</code>
+    <MixedReturnStatement>
+      <code><![CDATA[$this->data['locked']]]></code>
+      <code><![CDATA[$this->data['owner']]]></code>
+      <code><![CDATA[$this->data['owner']]]></code>
+      <code><![CDATA[$this->data['owner']]]></code>
     </MixedReturnStatement>
   </file>
   <file src="src/Reader/Extension/Slash/Entry.php">
-    <InvalidOperand occurrences="1">
+    <InvalidOperand>
       <code>$hit</code>
     </InvalidOperand>
-    <MixedArgument occurrences="1">
+    <MixedArgument>
       <code>$stringParade</code>
     </MixedArgument>
-    <MixedAssignment occurrences="3">
+    <MixedAssignment>
       <code>$comments</code>
       <code>$data</code>
       <code>$stringParade</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="4">
+    <MixedInferredReturnType>
       <code>array</code>
       <code>int</code>
       <code>null|string</code>
       <code>null|string</code>
     </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="7">
+    <MixedReturnStatement>
       <code>$comments</code>
-      <code>$this-&gt;data[$name]</code>
-      <code>$this-&gt;data[$name]</code>
-      <code>$this-&gt;getData('department')</code>
-      <code>$this-&gt;getData('department')</code>
-      <code>$this-&gt;getData('section')</code>
-      <code>$this-&gt;getData('section')</code>
+      <code><![CDATA[$this->data[$name]]]></code>
+      <code><![CDATA[$this->data[$name]]]></code>
+      <code><![CDATA[$this->getData('department')]]></code>
+      <code><![CDATA[$this->getData('department')]]></code>
+      <code><![CDATA[$this->getData('section')]]></code>
+      <code><![CDATA[$this->getData('section')]]></code>
     </MixedReturnStatement>
-    <NullableReturnStatement occurrences="1">
-      <code>$this-&gt;data[$name]</code>
+    <NullableReturnStatement>
+      <code><![CDATA[$this->data[$name]]]></code>
     </NullableReturnStatement>
   </file>
   <file src="src/Reader/Extension/Syndication/Feed.php">
-    <MixedArgument occurrences="1">
+    <MixedArgument>
       <code>$updateBase</code>
     </MixedArgument>
-    <MixedAssignment occurrences="5">
+    <MixedAssignment>
       <code>$data</code>
       <code>$freq</code>
       <code>$freq</code>
       <code>$period</code>
       <code>$updateBase</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="3">
+    <MixedInferredReturnType>
       <code>int</code>
       <code>int</code>
       <code>string</code>
     </MixedInferredReturnType>
-    <MixedOperand occurrences="1">
+    <MixedOperand>
       <code>$freq</code>
     </MixedOperand>
-    <MixedReturnStatement occurrences="3">
+    <MixedReturnStatement>
       <code>$freq</code>
       <code>$period</code>
       <code>$ticks / $freq</code>
     </MixedReturnStatement>
   </file>
   <file src="src/Reader/Extension/Thread/Entry.php">
-    <MixedAssignment occurrences="1">
+    <MixedAssignment>
       <code>$data</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="1">
+    <MixedInferredReturnType>
       <code>null|int</code>
     </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="2">
-      <code>$this-&gt;getData('total')</code>
-      <code>$this-&gt;getData('total')</code>
+    <MixedReturnStatement>
+      <code><![CDATA[$this->getData('total')]]></code>
+      <code><![CDATA[$this->getData('total')]]></code>
     </MixedReturnStatement>
   </file>
   <file src="src/Reader/Extension/WellFormedWeb/Entry.php">
-    <MixedAssignment occurrences="1">
+    <MixedAssignment>
       <code>$data</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="1">
+    <MixedInferredReturnType>
       <code>null|string</code>
     </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="3">
+    <MixedReturnStatement>
       <code>$data</code>
       <code>$data</code>
-      <code>$this-&gt;data[$name]</code>
+      <code><![CDATA[$this->data[$name]]]></code>
     </MixedReturnStatement>
   </file>
   <file src="src/Reader/ExtensionManager.php">
-    <DeprecatedInterface occurrences="1">
+    <DeprecatedInterface>
       <code>ExtensionManager</code>
     </DeprecatedInterface>
-    <MixedInferredReturnType occurrences="1">
+    <MixedInferredReturnType>
       <code>Extension\AbstractEntry|Extension\AbstractFeed</code>
     </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="2">
-      <code>$this-&gt;pluginManager-&gt;get($extension)</code>
-      <code>$this-&gt;pluginManager-&gt;get($extension)</code>
+    <MixedReturnStatement>
+      <code><![CDATA[$this->pluginManager->get($extension)]]></code>
+      <code><![CDATA[$this->pluginManager->get($extension)]]></code>
     </MixedReturnStatement>
   </file>
   <file src="src/Reader/ExtensionPluginManager.php">
-    <DeprecatedInterface occurrences="1">
+    <DeprecatedInterface>
       <code>ExtensionPluginManager</code>
     </DeprecatedInterface>
   </file>
   <file src="src/Reader/Feed/AbstractFeed.php">
-    <InvalidArgument occurrences="1">
-      <code>$this-&gt;key()</code>
+    <InvalidArgument>
+      <code><![CDATA[$this->key()]]></code>
     </InvalidArgument>
-    <LessSpecificImplementedReturnType occurrences="1">
+    <LessSpecificImplementedReturnType>
       <code>Reader\Entry\EntryInterface</code>
     </LessSpecificImplementedReturnType>
-    <MissingReturnType occurrences="3">
+    <MissingReturnType>
       <code>indexEntries</code>
       <code>loadExtensions</code>
       <code>registerNamespaces</code>
     </MissingReturnType>
-    <MixedArgument occurrences="7">
+    <MixedArgument>
       <code>$all['core']</code>
       <code>$extension</code>
       <code>$extension</code>
       <code>$extension</code>
       <code>$extension</code>
-      <code>$this-&gt;entries[$this-&gt;key()]</code>
-      <code>$this-&gt;entries[$this-&gt;key()]</code>
+      <code><![CDATA[$this->entries[$this->key()]]]></code>
+      <code><![CDATA[$this->entries[$this->key()]]]></code>
     </MixedArgument>
-    <MixedArrayOffset occurrences="1">
-      <code>$this-&gt;extensions[$extension]</code>
+    <MixedArrayOffset>
+      <code><![CDATA[$this->extensions[$extension]]]></code>
     </MixedArrayOffset>
-    <MixedAssignment occurrences="4">
+    <MixedAssignment>
       <code>$extension</code>
       <code>$extension</code>
       <code>$feed</code>
       <code>$plugin</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="2">
+    <MixedInferredReturnType>
       <code>null|Reader\Extension\AbstractFeed</code>
       <code>string</code>
     </MixedInferredReturnType>
-    <MixedMethodCall occurrences="3">
+    <MixedMethodCall>
       <code>setDomDocument</code>
       <code>setType</code>
       <code>setXpath</code>
     </MixedMethodCall>
-    <MixedReturnStatement occurrences="2">
-      <code>$this-&gt;data['type']</code>
-      <code>$this-&gt;extensions[$name . '\\Feed']</code>
+    <MixedReturnStatement>
+      <code><![CDATA[$this->data['type']]]></code>
+      <code><![CDATA[$this->extensions[$name . '\\Feed']]]></code>
     </MixedReturnStatement>
-    <PropertyNotSetInConstructor occurrences="1">
+    <PropertyNotSetInConstructor>
       <code>$originalSourceUri</code>
     </PropertyNotSetInConstructor>
   </file>
   <file src="src/Reader/Feed/Atom.php">
-    <ImplementedReturnTypeMismatch occurrences="1">
-      <code>null|array&lt;string, string&gt;</code>
+    <ImplementedReturnTypeMismatch>
+      <code><![CDATA[null|array<string, string>]]></code>
     </ImplementedReturnTypeMismatch>
-    <MixedArgument occurrences="1">
+    <MixedArgument>
       <code>$categoryCollection</code>
     </MixedArgument>
-    <MixedArrayOffset occurrences="1">
-      <code>$this-&gt;entries[$index]</code>
+    <MixedArrayOffset>
+      <code><![CDATA[$this->entries[$index]]]></code>
     </MixedArrayOffset>
-    <MixedAssignment occurrences="23">
+    <MixedAssignment>
       <code>$atomFeed</code>
       <code>$atomFeed</code>
       <code>$authors</code>
@@ -1559,7 +1628,7 @@
       <code>$link</code>
       <code>$title</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="15">
+    <MixedInferredReturnType>
       <code>Reader\Collection\Category</code>
       <code>array</code>
       <code>null|DateTime</code>
@@ -1576,7 +1645,7 @@
       <code>null|string</code>
       <code>null|string</code>
     </MixedInferredReturnType>
-    <MixedMethodCall occurrences="7">
+    <MixedMethodCall>
       <code>setDomDocument</code>
       <code>setDomDocument</code>
       <code>setType</code>
@@ -1585,48 +1654,51 @@
       <code>setXpath</code>
       <code>setXpathPrefix</code>
     </MixedMethodCall>
-    <MixedReturnStatement occurrences="36">
-      <code>$this-&gt;data['authors']</code>
-      <code>$this-&gt;data['authors']</code>
-      <code>$this-&gt;data['baseUrl']</code>
-      <code>$this-&gt;data['baseUrl']</code>
-      <code>$this-&gt;data['categories']</code>
-      <code>$this-&gt;data['categories']</code>
-      <code>$this-&gt;data['copyright']</code>
-      <code>$this-&gt;data['copyright']</code>
-      <code>$this-&gt;data['copyright']</code>
-      <code>$this-&gt;data['datecreated']</code>
-      <code>$this-&gt;data['datecreated']</code>
-      <code>$this-&gt;data['datecreated']</code>
-      <code>$this-&gt;data['datemodified']</code>
-      <code>$this-&gt;data['datemodified']</code>
-      <code>$this-&gt;data['datemodified']</code>
-      <code>$this-&gt;data['description']</code>
-      <code>$this-&gt;data['description']</code>
-      <code>$this-&gt;data['description']</code>
-      <code>$this-&gt;data['feedlink']</code>
-      <code>$this-&gt;data['feedlink']</code>
-      <code>$this-&gt;data['feedlink']</code>
-      <code>$this-&gt;data['generator']</code>
-      <code>$this-&gt;data['generator']</code>
-      <code>$this-&gt;data['hubs']</code>
-      <code>$this-&gt;data['hubs']</code>
-      <code>$this-&gt;data['id']</code>
-      <code>$this-&gt;data['id']</code>
-      <code>$this-&gt;data['image']</code>
-      <code>$this-&gt;data['image']</code>
-      <code>$this-&gt;data['language']</code>
-      <code>$this-&gt;data['language']</code>
-      <code>$this-&gt;data['language']</code>
-      <code>$this-&gt;data['link']</code>
-      <code>$this-&gt;data['link']</code>
-      <code>$this-&gt;data['title']</code>
-      <code>$this-&gt;data['title']</code>
+    <MixedReturnStatement>
+      <code><![CDATA[$this->data['authors']]]></code>
+      <code><![CDATA[$this->data['authors']]]></code>
+      <code><![CDATA[$this->data['baseUrl']]]></code>
+      <code><![CDATA[$this->data['baseUrl']]]></code>
+      <code><![CDATA[$this->data['categories']]]></code>
+      <code><![CDATA[$this->data['categories']]]></code>
+      <code><![CDATA[$this->data['copyright']]]></code>
+      <code><![CDATA[$this->data['copyright']]]></code>
+      <code><![CDATA[$this->data['copyright']]]></code>
+      <code><![CDATA[$this->data['datecreated']]]></code>
+      <code><![CDATA[$this->data['datecreated']]]></code>
+      <code><![CDATA[$this->data['datecreated']]]></code>
+      <code><![CDATA[$this->data['datemodified']]]></code>
+      <code><![CDATA[$this->data['datemodified']]]></code>
+      <code><![CDATA[$this->data['datemodified']]]></code>
+      <code><![CDATA[$this->data['description']]]></code>
+      <code><![CDATA[$this->data['description']]]></code>
+      <code><![CDATA[$this->data['description']]]></code>
+      <code><![CDATA[$this->data['feedlink']]]></code>
+      <code><![CDATA[$this->data['feedlink']]]></code>
+      <code><![CDATA[$this->data['feedlink']]]></code>
+      <code><![CDATA[$this->data['generator']]]></code>
+      <code><![CDATA[$this->data['generator']]]></code>
+      <code><![CDATA[$this->data['hubs']]]></code>
+      <code><![CDATA[$this->data['hubs']]]></code>
+      <code><![CDATA[$this->data['id']]]></code>
+      <code><![CDATA[$this->data['id']]]></code>
+      <code><![CDATA[$this->data['image']]]></code>
+      <code><![CDATA[$this->data['image']]]></code>
+      <code><![CDATA[$this->data['language']]]></code>
+      <code><![CDATA[$this->data['language']]]></code>
+      <code><![CDATA[$this->data['language']]]></code>
+      <code><![CDATA[$this->data['link']]]></code>
+      <code><![CDATA[$this->data['link']]]></code>
+      <code><![CDATA[$this->data['title']]]></code>
+      <code><![CDATA[$this->data['title']]]></code>
     </MixedReturnStatement>
-    <MixedReturnTypeCoercion occurrences="2">
-      <code>null|array&lt;string, string&gt;</code>
+    <MixedReturnTypeCoercion>
+      <code><![CDATA[isset($authors[$index]) && is_array($authors[$index])
+            ? $authors[$index]
+            : null]]></code>
+      <code><![CDATA[null|array<string, string>]]></code>
     </MixedReturnTypeCoercion>
-    <PossiblyNullReference occurrences="16">
+    <PossiblyNullReference>
       <code>getAuthors</code>
       <code>getBaseUrl</code>
       <code>getCategories</code>
@@ -1644,10 +1716,10 @@
       <code>getLink</code>
       <code>getTitle</code>
     </PossiblyNullReference>
-    <PropertyNotSetInConstructor occurrences="1">
+    <PropertyNotSetInConstructor>
       <code>Atom</code>
     </PropertyNotSetInConstructor>
-    <UndefinedMethod occurrences="16">
+    <UndefinedMethod>
       <code>getAuthors</code>
       <code>getBaseUrl</code>
       <code>getCategories</code>
@@ -1667,7 +1739,7 @@
     </UndefinedMethod>
   </file>
   <file src="src/Reader/Feed/Atom/Source.php">
-    <ImplementedReturnTypeMismatch occurrences="6">
+    <ImplementedReturnTypeMismatch>
       <code>void</code>
       <code>void</code>
       <code>void</code>
@@ -1675,36 +1747,42 @@
       <code>void</code>
       <code>void</code>
     </ImplementedReturnTypeMismatch>
-    <MixedAssignment occurrences="2">
+    <MixedAssignment>
       <code>$extension</code>
       <code>$extension</code>
     </MixedAssignment>
-    <MixedMethodCall occurrences="4">
+    <MixedMethodCall>
       <code>setDomDocument</code>
       <code>setType</code>
       <code>setXpath</code>
       <code>setXpathPrefix</code>
     </MixedMethodCall>
-    <PossiblyNullArgument occurrences="1">
-      <code>$this-&gt;domDocument</code>
+    <PossiblyNullArgument>
+      <code><![CDATA[$this->domDocument]]></code>
     </PossiblyNullArgument>
-    <PossiblyNullPropertyAssignmentValue occurrences="1">
-      <code>$source-&gt;ownerDocument</code>
+    <PossiblyNullPropertyAssignmentValue>
+      <code><![CDATA[$source->ownerDocument]]></code>
     </PossiblyNullPropertyAssignmentValue>
-    <PropertyNotSetInConstructor occurrences="1">
+    <PropertyNotSetInConstructor>
       <code>Source</code>
     </PropertyNotSetInConstructor>
   </file>
   <file src="src/Reader/Feed/Rss.php">
-    <ArgumentTypeCoercion occurrences="1"/>
-    <ImplementedReturnTypeMismatch occurrences="1">
-      <code>null|array&lt;string, string&gt;</code>
+    <ArgumentTypeCoercion>
+      <code><![CDATA[[
+                    'term'   => $category->nodeValue,
+                    'scheme' => $category->getAttribute('domain'),
+                    'label'  => $category->nodeValue,
+                ]]]></code>
+    </ArgumentTypeCoercion>
+    <ImplementedReturnTypeMismatch>
+      <code><![CDATA[null|array<string, string>]]></code>
     </ImplementedReturnTypeMismatch>
-    <InvalidArgument occurrences="2">
+    <InvalidArgument>
       <code>$lastBuildDateParsed</code>
       <code>Reader\Reader::arrayUnique($authors)</code>
     </InvalidArgument>
-    <MixedArgument occurrences="6">
+    <MixedArgument>
       <code>$authors</code>
       <code>$categoryCollection</code>
       <code>$dateModified</code>
@@ -1712,13 +1790,13 @@
       <code>$hubs</code>
       <code>$lastBuildDate</code>
     </MixedArgument>
-    <MixedArrayAccess occurrences="1">
+    <MixedArrayAccess>
       <code>$author['name']</code>
     </MixedArrayAccess>
-    <MixedArrayOffset occurrences="1">
-      <code>$this-&gt;entries[$index]</code>
+    <MixedArrayOffset>
+      <code><![CDATA[$this->entries[$index]]]></code>
     </MixedArrayOffset>
-    <MixedAssignment occurrences="56">
+    <MixedAssignment>
       <code>$author</code>
       <code>$authors</code>
       <code>$authorsDc</code>
@@ -1776,7 +1854,7 @@
       <code>$value</code>
       <code>$value</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="14">
+    <MixedInferredReturnType>
       <code>DateTime</code>
       <code>DateTime</code>
       <code>Reader\Collection\Category</code>
@@ -1792,7 +1870,7 @@
       <code>null|string</code>
       <code>null|string</code>
     </MixedInferredReturnType>
-    <MixedMethodCall occurrences="7">
+    <MixedMethodCall>
       <code>setDomDocument</code>
       <code>setDomDocument</code>
       <code>setType</code>
@@ -1801,60 +1879,63 @@
       <code>setXpath</code>
       <code>setXpathPrefix</code>
     </MixedMethodCall>
-    <MixedReturnStatement occurrences="36">
-      <code>$this-&gt;data['authors']</code>
-      <code>$this-&gt;data['authors']</code>
-      <code>$this-&gt;data['authors']</code>
-      <code>$this-&gt;data['categories']</code>
-      <code>$this-&gt;data['categories']</code>
-      <code>$this-&gt;data['categories']</code>
-      <code>$this-&gt;data['copyright']</code>
-      <code>$this-&gt;data['copyright']</code>
-      <code>$this-&gt;data['copyright']</code>
-      <code>$this-&gt;data['datemodified']</code>
-      <code>$this-&gt;data['datemodified']</code>
-      <code>$this-&gt;data['datemodified']</code>
-      <code>$this-&gt;data['description']</code>
-      <code>$this-&gt;data['description']</code>
-      <code>$this-&gt;data['description']</code>
-      <code>$this-&gt;data['feedlink']</code>
-      <code>$this-&gt;data['feedlink']</code>
-      <code>$this-&gt;data['feedlink']</code>
-      <code>$this-&gt;data['generator']</code>
-      <code>$this-&gt;data['generator']</code>
-      <code>$this-&gt;data['generator']</code>
-      <code>$this-&gt;data['hubs']</code>
-      <code>$this-&gt;data['id']</code>
-      <code>$this-&gt;data['id']</code>
-      <code>$this-&gt;data['id']</code>
-      <code>$this-&gt;data['image']</code>
-      <code>$this-&gt;data['language']</code>
-      <code>$this-&gt;data['language']</code>
-      <code>$this-&gt;data['language']</code>
-      <code>$this-&gt;data['lastBuildDate']</code>
-      <code>$this-&gt;data['link']</code>
-      <code>$this-&gt;data['link']</code>
-      <code>$this-&gt;data['link']</code>
-      <code>$this-&gt;data['title']</code>
-      <code>$this-&gt;data['title']</code>
-      <code>$this-&gt;data['title']</code>
+    <MixedReturnStatement>
+      <code><![CDATA[$this->data['authors']]]></code>
+      <code><![CDATA[$this->data['authors']]]></code>
+      <code><![CDATA[$this->data['authors']]]></code>
+      <code><![CDATA[$this->data['categories']]]></code>
+      <code><![CDATA[$this->data['categories']]]></code>
+      <code><![CDATA[$this->data['categories']]]></code>
+      <code><![CDATA[$this->data['copyright']]]></code>
+      <code><![CDATA[$this->data['copyright']]]></code>
+      <code><![CDATA[$this->data['copyright']]]></code>
+      <code><![CDATA[$this->data['datemodified']]]></code>
+      <code><![CDATA[$this->data['datemodified']]]></code>
+      <code><![CDATA[$this->data['datemodified']]]></code>
+      <code><![CDATA[$this->data['description']]]></code>
+      <code><![CDATA[$this->data['description']]]></code>
+      <code><![CDATA[$this->data['description']]]></code>
+      <code><![CDATA[$this->data['feedlink']]]></code>
+      <code><![CDATA[$this->data['feedlink']]]></code>
+      <code><![CDATA[$this->data['feedlink']]]></code>
+      <code><![CDATA[$this->data['generator']]]></code>
+      <code><![CDATA[$this->data['generator']]]></code>
+      <code><![CDATA[$this->data['generator']]]></code>
+      <code><![CDATA[$this->data['hubs']]]></code>
+      <code><![CDATA[$this->data['id']]]></code>
+      <code><![CDATA[$this->data['id']]]></code>
+      <code><![CDATA[$this->data['id']]]></code>
+      <code><![CDATA[$this->data['image']]]></code>
+      <code><![CDATA[$this->data['language']]]></code>
+      <code><![CDATA[$this->data['language']]]></code>
+      <code><![CDATA[$this->data['language']]]></code>
+      <code><![CDATA[$this->data['lastBuildDate']]]></code>
+      <code><![CDATA[$this->data['link']]]></code>
+      <code><![CDATA[$this->data['link']]]></code>
+      <code><![CDATA[$this->data['link']]]></code>
+      <code><![CDATA[$this->data['title']]]></code>
+      <code><![CDATA[$this->data['title']]]></code>
+      <code><![CDATA[$this->data['title']]]></code>
     </MixedReturnStatement>
-    <MixedReturnTypeCoercion occurrences="2">
-      <code>null|array&lt;string, string&gt;</code>
+    <MixedReturnTypeCoercion>
+      <code><![CDATA[isset($authors[$index]) && is_array($authors[$index])
+            ? $authors[$index]
+            : null]]></code>
+      <code><![CDATA[null|array<string, string>]]></code>
     </MixedReturnTypeCoercion>
-    <NullArgument occurrences="1">
+    <NullArgument>
       <code>$categoryCollection</code>
     </NullArgument>
-    <NullableReturnStatement occurrences="3">
-      <code>$this-&gt;data['authors']</code>
-      <code>$this-&gt;data['datemodified']</code>
-      <code>$this-&gt;data['lastBuildDate']</code>
+    <NullableReturnStatement>
+      <code><![CDATA[$this->data['authors']]]></code>
+      <code><![CDATA[$this->data['datemodified']]]></code>
+      <code><![CDATA[$this->data['lastBuildDate']]]></code>
     </NullableReturnStatement>
-    <PossiblyNullArgument occurrences="2">
-      <code>$author-&gt;nodeValue</code>
+    <PossiblyNullArgument>
+      <code><![CDATA[$author->nodeValue]]></code>
       <code>$standard</code>
     </PossiblyNullArgument>
-    <PossiblyNullReference occurrences="20">
+    <PossiblyNullReference>
       <code>getAuthors</code>
       <code>getAuthors</code>
       <code>getCategories</code>
@@ -1876,10 +1957,10 @@
       <code>getTitle</code>
       <code>getTitle</code>
     </PossiblyNullReference>
-    <PropertyNotSetInConstructor occurrences="1">
+    <PropertyNotSetInConstructor>
       <code>Rss</code>
     </PropertyNotSetInConstructor>
-    <UndefinedMethod occurrences="21">
+    <UndefinedMethod>
       <code>getAttribute</code>
       <code>getAuthors</code>
       <code>getAuthors</code>
@@ -1904,110 +1985,113 @@
     </UndefinedMethod>
   </file>
   <file src="src/Reader/FeedSet.php">
-    <NullArgument occurrences="1">
+    <NullArgument>
       <code>$this</code>
     </NullArgument>
-    <PossiblyInvalidArgument occurrences="1">
-      <code>$this-&gt;offsetGet('href')</code>
+    <PossiblyInvalidArgument>
+      <code><![CDATA[$this->offsetGet('href')]]></code>
     </PossiblyInvalidArgument>
-    <PossiblyInvalidCast occurrences="1">
-      <code>$this-&gt;offsetGet('href')</code>
+    <PossiblyInvalidCast>
+      <code><![CDATA[$this->offsetGet('href')]]></code>
     </PossiblyInvalidCast>
-    <UnsafeInstantiation occurrences="1"/>
+    <UnsafeInstantiation>
+      <code><![CDATA[new static([
+                'rel'   => 'alternate',
+                'type'  => $link->getAttribute('type'),
+                'href'  => $this->absolutiseUri(trim($link->getAttribute('href')), $uri),
+                'title' => $link->getAttribute('title'),
+            ])]]></code>
+    </UnsafeInstantiation>
   </file>
   <file src="src/Reader/Http/LaminasHttpClientDecorator.php">
-    <MixedArgumentTypeCoercion occurrences="1">
+    <MixedArgumentTypeCoercion>
       <code>$value</code>
     </MixedArgumentTypeCoercion>
-    <MixedAssignment occurrences="3">
+    <MixedAssignment>
       <code>$normalized[$name]</code>
       <code>$value</code>
       <code>$value</code>
     </MixedAssignment>
-    <PossiblyInvalidArgument occurrences="1">
+    <PossiblyInvalidArgument>
       <code>$value</code>
     </PossiblyInvalidArgument>
-    <PossiblyInvalidMethodCall occurrences="1">
+    <PossiblyInvalidMethodCall>
       <code>addHeaderLine</code>
     </PossiblyInvalidMethodCall>
-    <PossiblyUndefinedMethod occurrences="1">
+    <PossiblyUndefinedMethod>
       <code>addHeaderLine</code>
     </PossiblyUndefinedMethod>
   </file>
   <file src="src/Reader/Http/Psr7ResponseDecorator.php">
-    <MixedInferredReturnType occurrences="1">
+    <MixedInferredReturnType>
       <code>getHeaderLine</code>
     </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="2">
+    <MixedReturnStatement>
       <code>$default</code>
       <code>$default</code>
     </MixedReturnStatement>
-    <NullableReturnStatement occurrences="1">
+    <NullableReturnStatement>
       <code>$default</code>
     </NullableReturnStatement>
   </file>
   <file src="src/Reader/Http/Response.php">
-    <DocblockTypeContradiction occurrences="3">
+    <DocblockTypeContradiction>
       <code>! is_numeric($statusCode)</code>
-      <code>is_object($statusCode)</code>
       <code>is_string($statusCode)</code>
     </DocblockTypeContradiction>
-    <MixedArgument occurrences="1">
+    <MixedArgument>
       <code>$statusCode</code>
     </MixedArgument>
-    <MixedArgumentTypeCoercion occurrences="1">
+    <MixedArgumentTypeCoercion>
       <code>$name</code>
     </MixedArgumentTypeCoercion>
-    <MixedAssignment occurrences="2">
+    <MixedAssignment>
       <code>$normalized[strtolower($name)]</code>
       <code>$value</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="1">
+    <MixedInferredReturnType>
       <code>getHeaderLine</code>
     </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="2">
-      <code>$this-&gt;headers[$normalizedName] ?? $default</code>
-      <code>$this-&gt;headers[$normalizedName] ?? $default</code>
+    <MixedReturnStatement>
+      <code><![CDATA[$this->headers[$normalizedName] ?? $default]]></code>
+      <code><![CDATA[$this->headers[$normalizedName] ?? $default]]></code>
     </MixedReturnStatement>
-    <NullableReturnStatement occurrences="1">
-      <code>$this-&gt;headers[$normalizedName] ?? $default</code>
+    <NullableReturnStatement>
+      <code><![CDATA[$this->headers[$normalizedName] ?? $default]]></code>
     </NullableReturnStatement>
-    <PossiblyInvalidCast occurrences="1">
+    <PossiblyInvalidCast>
       <code>$body</code>
     </PossiblyInvalidCast>
-    <RedundantCastGivenDocblockType occurrences="1">
+    <RedundantCastGivenDocblockType>
       <code>(int) $statusCode</code>
     </RedundantCastGivenDocblockType>
-    <RedundantConditionGivenDocblockType occurrences="1">
-      <code>gettype($statusCode)</code>
-    </RedundantConditionGivenDocblockType>
   </file>
   <file src="src/Reader/Reader.php">
-    <DeprecatedInterface occurrences="3">
+    <DeprecatedInterface>
       <code>ExtensionManagerInterface</code>
       <code>ExtensionManagerInterface</code>
       <code>null|ExtensionManagerInterface</code>
     </DeprecatedInterface>
-    <DocblockTypeContradiction occurrences="3">
+    <DocblockTypeContradiction>
       <code>! static::$httpClient</code>
       <code>gettype($response)</code>
       <code>static::$httpClient</code>
     </DocblockTypeContradiction>
-    <InvalidReturnStatement occurrences="2">
+    <InvalidReturnStatement>
       <code>$array</code>
       <code>$reader</code>
     </InvalidReturnStatement>
-    <InvalidReturnType occurrences="2">
+    <InvalidReturnType>
       <code>Feed\FeedInterface</code>
       <code>TInput</code>
     </InvalidReturnType>
-    <MixedArgument occurrences="4">
+    <MixedArgument>
       <code>$data</code>
       <code>$responseXml</code>
       <code>$value</code>
       <code>$version</code>
     </MixedArgument>
-    <MixedAssignment occurrences="9">
+    <MixedAssignment>
       <code>$data</code>
       <code>$data</code>
       <code>$etag</code>
@@ -2018,66 +2102,77 @@
       <code>$value</code>
       <code>$version</code>
     </MixedAssignment>
-    <RedundantCastGivenDocblockType occurrences="3">
-      <code>(int) $response-&gt;getStatusCode()</code>
-      <code>(int) $response-&gt;getStatusCode()</code>
-      <code>(int) $response-&gt;getStatusCode()</code>
+    <RedundantCastGivenDocblockType>
+      <code><![CDATA[(int) $response->getStatusCode()]]></code>
+      <code><![CDATA[(int) $response->getStatusCode()]]></code>
+      <code><![CDATA[(int) $response->getStatusCode()]]></code>
     </RedundantCastGivenDocblockType>
-    <RedundantConditionGivenDocblockType occurrences="5">
+    <RedundantConditionGivenDocblockType>
       <code>$cache</code>
       <code>$cache</code>
       <code>is_object($response)</code>
       <code>is_string($feed)</code>
-      <code>static::$httpConditionalGet &amp;&amp; $cache</code>
+      <code><![CDATA[static::$httpConditionalGet && $cache]]></code>
     </RedundantConditionGivenDocblockType>
-    <TooManyArguments occurrences="1">
+    <TooManyArguments>
       <code>get</code>
     </TooManyArguments>
-    <TypeDoesNotContainType occurrences="1">
+    <TypeDoesNotContainType>
       <code>! is_string($string)</code>
     </TypeDoesNotContainType>
-    <UndefinedInterfaceMethod occurrences="2">
+    <UndefinedInterfaceMethod>
       <code>setOriginalSourceUri</code>
       <code>setOriginalSourceUri</code>
     </UndefinedInterfaceMethod>
-    <UndefinedVariable occurrences="1">
+    <UndefinedVariable>
       <code>$phpErrormsg</code>
     </UndefinedVariable>
   </file>
   <file src="src/Reader/StandaloneExtensionManager.php">
-    <DeprecatedInterface occurrences="1">
+    <DeprecatedInterface>
       <code>StandaloneExtensionManager</code>
     </DeprecatedInterface>
-    <LessSpecificReturnStatement occurrences="1">
+    <LessSpecificReturnStatement>
       <code>new $class()</code>
     </LessSpecificReturnStatement>
-    <MixedMethodCall occurrences="1">
+    <MixedArgument>
+      <code>$class</code>
+    </MixedArgument>
+    <MixedMethodCall>
       <code>new $class()</code>
     </MixedMethodCall>
-    <MoreSpecificReturnType occurrences="1">
+    <MoreSpecificReturnType>
       <code>Extension\AbstractEntry|Extension\AbstractFeed</code>
     </MoreSpecificReturnType>
-    <RedundantConditionGivenDocblockType occurrences="1">
+    <RedundantConditionGivenDocblockType>
       <code>is_string($class)</code>
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="src/Uri.php">
-    <InvalidNullableReturnType occurrences="3">
+    <InvalidNullableReturnType>
       <code>string</code>
       <code>string</code>
       <code>string</code>
     </InvalidNullableReturnType>
-    <NullableReturnStatement occurrences="3">
-      <code>$this-&gt;host</code>
-      <code>$this-&gt;path</code>
-      <code>$this-&gt;scheme</code>
+    <NullableReturnStatement>
+      <code><![CDATA[$this->host]]></code>
+      <code><![CDATA[$this->path]]></code>
+      <code><![CDATA[$this->scheme]]></code>
     </NullableReturnStatement>
-    <UnsafeInstantiation occurrences="1">
+    <UnsafeInstantiation>
       <code>new static($uri)</code>
     </UnsafeInstantiation>
   </file>
   <file src="src/Writer/AbstractFeed.php">
-    <MixedArgument occurrences="6">
+    <DocblockTypeContradiction>
+      <code>empty($copyright) || ! is_string($copyright)</code>
+      <code>empty($description) || ! is_string($description)</code>
+      <code>empty($encoding) || ! is_string($encoding)</code>
+      <code>empty($language) || ! is_string($language)</code>
+      <code>empty($name) || ! is_string($name)</code>
+      <code>empty($version) || ! is_string($version)</code>
+    </DocblockTypeContradiction>
+    <MixedArgument>
       <code>$author</code>
       <code>$category</code>
       <code>$ext</code>
@@ -2085,23 +2180,23 @@
       <code>$ext</code>
       <code>$url</code>
     </MixedArgument>
-    <MixedArrayAssignment occurrences="4">
-      <code>$this-&gt;data['authors'][]</code>
-      <code>$this-&gt;data['categories'][]</code>
-      <code>$this-&gt;data['feedLinks'][strtolower($type)]</code>
-      <code>$this-&gt;data['hubs'][]</code>
+    <MixedArrayAssignment>
+      <code><![CDATA[$this->data['authors'][]]]></code>
+      <code><![CDATA[$this->data['categories'][]]]></code>
+      <code><![CDATA[$this->data['feedLinks'][strtolower($type)]]]></code>
+      <code><![CDATA[$this->data['hubs'][]]]></code>
     </MixedArrayAssignment>
-    <MixedArrayOffset occurrences="1">
-      <code>$this-&gt;extensions[$ext]</code>
+    <MixedArrayOffset>
+      <code><![CDATA[$this->extensions[$ext]]]></code>
     </MixedArrayOffset>
-    <MixedAssignment occurrences="5">
+    <MixedAssignment>
       <code>$author</code>
       <code>$category</code>
       <code>$ext</code>
       <code>$exts</code>
       <code>$url</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="18">
+    <MixedInferredReturnType>
       <code>null|array</code>
       <code>null|array</code>
       <code>null|string</code>
@@ -2121,37 +2216,37 @@
       <code>null|string</code>
       <code>null|string</code>
     </MixedInferredReturnType>
-    <MixedMethodCall occurrences="1">
+    <MixedMethodCall>
       <code>setEncoding</code>
     </MixedMethodCall>
-    <MixedPropertyTypeCoercion occurrences="1">
-      <code>$this-&gt;extensions</code>
+    <MixedPropertyTypeCoercion>
+      <code><![CDATA[$this->extensions]]></code>
     </MixedPropertyTypeCoercion>
-    <MixedReturnStatement occurrences="18">
-      <code>$this-&gt;data['authors']</code>
-      <code>$this-&gt;data['authors'][$index]</code>
-      <code>$this-&gt;data['baseUrl']</code>
-      <code>$this-&gt;data['categories']</code>
-      <code>$this-&gt;data['copyright']</code>
-      <code>$this-&gt;data['dateCreated']</code>
-      <code>$this-&gt;data['dateModified']</code>
-      <code>$this-&gt;data['description']</code>
-      <code>$this-&gt;data['encoding']</code>
-      <code>$this-&gt;data['feedLinks']</code>
-      <code>$this-&gt;data['generator']</code>
-      <code>$this-&gt;data['hubs']</code>
-      <code>$this-&gt;data['id']</code>
-      <code>$this-&gt;data['image']</code>
-      <code>$this-&gt;data['language']</code>
-      <code>$this-&gt;data['lastBuildDate']</code>
-      <code>$this-&gt;data['link']</code>
-      <code>$this-&gt;data['title']</code>
+    <MixedReturnStatement>
+      <code><![CDATA[$this->data['authors']]]></code>
+      <code><![CDATA[$this->data['authors'][$index]]]></code>
+      <code><![CDATA[$this->data['baseUrl']]]></code>
+      <code><![CDATA[$this->data['categories']]]></code>
+      <code><![CDATA[$this->data['copyright']]]></code>
+      <code><![CDATA[$this->data['dateCreated']]]></code>
+      <code><![CDATA[$this->data['dateModified']]]></code>
+      <code><![CDATA[$this->data['description']]]></code>
+      <code><![CDATA[$this->data['encoding']]]></code>
+      <code><![CDATA[$this->data['feedLinks']]]></code>
+      <code><![CDATA[$this->data['generator']]]></code>
+      <code><![CDATA[$this->data['hubs']]]></code>
+      <code><![CDATA[$this->data['id']]]></code>
+      <code><![CDATA[$this->data['image']]]></code>
+      <code><![CDATA[$this->data['language']]]></code>
+      <code><![CDATA[$this->data['lastBuildDate']]]></code>
+      <code><![CDATA[$this->data['link']]]></code>
+      <code><![CDATA[$this->data['title']]]></code>
     </MixedReturnStatement>
-    <PropertyNotSetInConstructor occurrences="2">
+    <PropertyNotSetInConstructor>
       <code>$extensions</code>
       <code>$type</code>
     </PropertyNotSetInConstructor>
-    <TypeDoesNotContainType occurrences="18">
+    <TypeDoesNotContainType>
       <code>! is_string($copyright)</code>
       <code>! is_string($description)</code>
       <code>! is_string($encoding)</code>
@@ -2173,44 +2268,54 @@
     </TypeDoesNotContainType>
   </file>
   <file src="src/Writer/Deleted.php">
-    <MissingConstructor occurrences="1">
+    <DocblockTypeContradiction>
+      <code>empty($reference) || ! is_string($reference)</code>
+    </DocblockTypeContradiction>
+    <MissingConstructor>
       <code>$type</code>
     </MissingConstructor>
-    <MixedInferredReturnType occurrences="5">
+    <MixedInferredReturnType>
       <code>DateTime</code>
       <code>null|string</code>
       <code>null|string</code>
       <code>null|string</code>
       <code>string</code>
     </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="5">
-      <code>$this-&gt;data['by']</code>
-      <code>$this-&gt;data['comment']</code>
-      <code>$this-&gt;data['encoding']</code>
-      <code>$this-&gt;data['reference']</code>
-      <code>$this-&gt;data['when']</code>
+    <MixedReturnStatement>
+      <code><![CDATA[$this->data['by']]]></code>
+      <code><![CDATA[$this->data['comment']]]></code>
+      <code><![CDATA[$this->data['encoding']]]></code>
+      <code><![CDATA[$this->data['reference']]]></code>
+      <code><![CDATA[$this->data['when']]]></code>
     </MixedReturnStatement>
-    <TypeDoesNotContainType occurrences="1">
+    <TypeDoesNotContainType>
       <code>! is_string($reference)</code>
     </TypeDoesNotContainType>
   </file>
   <file src="src/Writer/Entry.php">
-    <MixedArgument occurrences="5">
+    <DocblockTypeContradiction>
+      <code>empty($content) || ! is_string($content)</code>
+      <code>empty($copyright) || ! is_string($copyright)</code>
+      <code>empty($description) || ! is_string($description)</code>
+      <code>empty($encoding) || ! is_string($encoding)</code>
+      <code>empty($id) || ! is_string($id)</code>
+    </DocblockTypeContradiction>
+    <MixedArgument>
       <code>$author</code>
       <code>$category</code>
       <code>$enclosure['uri']</code>
       <code>$ext</code>
       <code>$link</code>
     </MixedArgument>
-    <MixedArrayAssignment occurrences="3">
-      <code>$this-&gt;data['authors'][]</code>
-      <code>$this-&gt;data['categories'][]</code>
-      <code>$this-&gt;data['commentFeedLinks'][]</code>
+    <MixedArrayAssignment>
+      <code><![CDATA[$this->data['authors'][]]]></code>
+      <code><![CDATA[$this->data['categories'][]]]></code>
+      <code><![CDATA[$this->data['commentFeedLinks'][]]]></code>
     </MixedArrayAssignment>
-    <MixedArrayOffset occurrences="1">
-      <code>$this-&gt;extensions[$ext]</code>
+    <MixedArrayOffset>
+      <code><![CDATA[$this->extensions[$ext]]]></code>
     </MixedArrayOffset>
-    <MixedAssignment occurrences="6">
+    <MixedAssignment>
       <code>$author</code>
       <code>$category</code>
       <code>$ext</code>
@@ -2218,7 +2323,7 @@
       <code>$exts</code>
       <code>$link</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="16">
+    <MixedInferredReturnType>
       <code>array</code>
       <code>array</code>
       <code>array</code>
@@ -2236,34 +2341,34 @@
       <code>string</code>
       <code>string</code>
     </MixedInferredReturnType>
-    <MixedMethodCall occurrences="1">
+    <MixedMethodCall>
       <code>setEncoding</code>
     </MixedMethodCall>
-    <MixedReturnStatement occurrences="16">
-      <code>$this-&gt;data['authors']</code>
-      <code>$this-&gt;data['categories']</code>
-      <code>$this-&gt;data['commentCount']</code>
-      <code>$this-&gt;data['commentFeedLinks']</code>
-      <code>$this-&gt;data['commentLink']</code>
-      <code>$this-&gt;data['content']</code>
-      <code>$this-&gt;data['copyright']</code>
-      <code>$this-&gt;data['dateCreated']</code>
-      <code>$this-&gt;data['dateModified']</code>
-      <code>$this-&gt;data['description']</code>
-      <code>$this-&gt;data['enclosure']</code>
-      <code>$this-&gt;data['encoding']</code>
-      <code>$this-&gt;data['id']</code>
-      <code>$this-&gt;data['link']</code>
-      <code>$this-&gt;data['links']</code>
-      <code>$this-&gt;data['title']</code>
+    <MixedReturnStatement>
+      <code><![CDATA[$this->data['authors']]]></code>
+      <code><![CDATA[$this->data['categories']]]></code>
+      <code><![CDATA[$this->data['commentCount']]]></code>
+      <code><![CDATA[$this->data['commentFeedLinks']]]></code>
+      <code><![CDATA[$this->data['commentLink']]]></code>
+      <code><![CDATA[$this->data['content']]]></code>
+      <code><![CDATA[$this->data['copyright']]]></code>
+      <code><![CDATA[$this->data['dateCreated']]]></code>
+      <code><![CDATA[$this->data['dateModified']]]></code>
+      <code><![CDATA[$this->data['description']]]></code>
+      <code><![CDATA[$this->data['enclosure']]]></code>
+      <code><![CDATA[$this->data['encoding']]]></code>
+      <code><![CDATA[$this->data['id']]]></code>
+      <code><![CDATA[$this->data['link']]]></code>
+      <code><![CDATA[$this->data['links']]]></code>
+      <code><![CDATA[$this->data['title']]]></code>
     </MixedReturnStatement>
-    <PossiblyNullArgument occurrences="1">
-      <code>$this-&gt;getEncoding()</code>
+    <PossiblyNullArgument>
+      <code><![CDATA[$this->getEncoding()]]></code>
     </PossiblyNullArgument>
-    <PropertyNotSetInConstructor occurrences="1">
+    <PropertyNotSetInConstructor>
       <code>$type</code>
     </PropertyNotSetInConstructor>
-    <TypeDoesNotContainType occurrences="9">
+    <TypeDoesNotContainType>
       <code>! is_string($content)</code>
       <code>! is_string($copyright)</code>
       <code>! is_string($description)</code>
@@ -2276,7 +2381,7 @@
     </TypeDoesNotContainType>
   </file>
   <file src="src/Writer/Extension/AbstractRenderer.php">
-    <ImplementedReturnTypeMismatch occurrences="28">
+    <ImplementedReturnTypeMismatch>
       <code>$this</code>
       <code>$this</code>
       <code>$this</code>
@@ -2306,7 +2411,7 @@
       <code>$this</code>
       <code>$this</code>
     </ImplementedReturnTypeMismatch>
-    <MissingConstructor occurrences="52">
+    <MissingConstructor>
       <code>$base</code>
       <code>$base</code>
       <code>$base</code>
@@ -2362,70 +2467,70 @@
     </MissingConstructor>
   </file>
   <file src="src/Writer/Extension/Atom/Renderer/Feed.php">
-    <MixedArgument occurrences="3">
+    <MixedArgument>
       <code>$href</code>
       <code>$hubUrl</code>
       <code>$type</code>
     </MixedArgument>
-    <MixedAssignment occurrences="5">
+    <MixedAssignment>
       <code>$flinks</code>
       <code>$href</code>
       <code>$hubUrl</code>
       <code>$hubs</code>
       <code>$type</code>
     </MixedAssignment>
-    <MixedMethodCall occurrences="2">
+    <MixedMethodCall>
       <code>getFeedLinks</code>
       <code>getHubs</code>
     </MixedMethodCall>
-    <TypeDoesNotContainType occurrences="2">
+    <TypeDoesNotContainType>
       <code>empty($flinks)</code>
       <code>empty($hubs)</code>
     </TypeDoesNotContainType>
   </file>
   <file src="src/Writer/Extension/Content/Renderer/Entry.php">
-    <MixedArgument occurrences="1">
+    <MixedArgument>
       <code>$content</code>
     </MixedArgument>
-    <MixedAssignment occurrences="1">
+    <MixedAssignment>
       <code>$content</code>
     </MixedAssignment>
-    <MixedMethodCall occurrences="1">
+    <MixedMethodCall>
       <code>getContent</code>
     </MixedMethodCall>
   </file>
   <file src="src/Writer/Extension/DublinCore/Renderer/Entry.php">
-    <MixedArgument occurrences="1">
+    <MixedArgument>
       <code>$data</code>
     </MixedArgument>
-    <MixedAssignment occurrences="2">
+    <MixedAssignment>
       <code>$authors</code>
       <code>$data</code>
     </MixedAssignment>
-    <MixedMethodCall occurrences="1">
+    <MixedMethodCall>
       <code>getAuthors</code>
     </MixedMethodCall>
-    <TypeDoesNotContainType occurrences="1">
+    <TypeDoesNotContainType>
       <code>empty($authors)</code>
     </TypeDoesNotContainType>
   </file>
   <file src="src/Writer/Extension/DublinCore/Renderer/Feed.php">
-    <MixedArgument occurrences="1">
+    <MixedArgument>
       <code>$data</code>
     </MixedArgument>
-    <MixedAssignment occurrences="2">
+    <MixedAssignment>
       <code>$authors</code>
       <code>$data</code>
     </MixedAssignment>
-    <MixedMethodCall occurrences="1">
+    <MixedMethodCall>
       <code>getAuthors</code>
     </MixedMethodCall>
-    <TypeDoesNotContainType occurrences="1">
+    <TypeDoesNotContainType>
       <code>empty($authors)</code>
     </TypeDoesNotContainType>
   </file>
   <file src="src/Writer/Extension/GooglePlayPodcast/Entry.php">
-    <RedundantConditionGivenDocblockType occurrences="4">
+    <RedundantConditionGivenDocblockType>
       <code>! in_array($value, ['yes', 'no', 'clean'], true)</code>
       <code>in_array($value, ['yes', 'no', 'clean'], true)</code>
       <code>in_array($value, ['yes', 'no', 'clean'], true)</code>
@@ -2433,29 +2538,29 @@
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="src/Writer/Extension/GooglePlayPodcast/Feed.php">
-    <DocblockTypeContradiction occurrences="1">
+    <DocblockTypeContradiction>
       <code>! is_string($value)</code>
     </DocblockTypeContradiction>
-    <MixedArgument occurrences="3">
+    <MixedArgument>
       <code>$val</code>
       <code>$value</code>
       <code>$value</code>
     </MixedArgument>
-    <MixedArgumentTypeCoercion occurrences="1">
+    <MixedArgumentTypeCoercion>
       <code>$key</code>
     </MixedArgumentTypeCoercion>
-    <MixedArrayAssignment occurrences="4">
-      <code>$this-&gt;data['authors'][]</code>
-      <code>$this-&gt;data['categories'][$key]</code>
-      <code>$this-&gt;data['categories'][$key]</code>
-      <code>$this-&gt;data['categories'][]</code>
+    <MixedArrayAssignment>
+      <code><![CDATA[$this->data['authors'][]]]></code>
+      <code><![CDATA[$this->data['categories'][$key]]]></code>
+      <code><![CDATA[$this->data['categories'][$key]]]></code>
+      <code><![CDATA[$this->data['categories'][]]]></code>
     </MixedArrayAssignment>
-    <MixedAssignment occurrences="3">
+    <MixedAssignment>
       <code>$val</code>
       <code>$value</code>
       <code>$value</code>
     </MixedAssignment>
-    <RedundantConditionGivenDocblockType occurrences="4">
+    <RedundantConditionGivenDocblockType>
       <code>! in_array($value, ['yes', 'no', 'clean'], true)</code>
       <code>in_array($value, ['yes', 'no', 'clean'], true)</code>
       <code>in_array($value, ['yes', 'no', 'clean'], true)</code>
@@ -2463,25 +2568,25 @@
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="src/Writer/Extension/GooglePlayPodcast/Renderer/Entry.php">
-    <MixedAssignment occurrences="3">
+    <MixedAssignment>
       <code>$block</code>
       <code>$description</code>
       <code>$explicit</code>
     </MixedAssignment>
-    <MixedMethodCall occurrences="3">
+    <MixedMethodCall>
       <code>getPlayPodcastBlock</code>
       <code>getPlayPodcastDescription</code>
       <code>getPlayPodcastExplicit</code>
     </MixedMethodCall>
   </file>
   <file src="src/Writer/Extension/GooglePlayPodcast/Renderer/Feed.php">
-    <MixedArgument occurrences="4">
+    <MixedArgument>
       <code>$cat</code>
       <code>$image</code>
       <code>$key</code>
       <code>$subcat</code>
     </MixedArgument>
-    <MixedAssignment occurrences="10">
+    <MixedAssignment>
       <code>$author</code>
       <code>$authors</code>
       <code>$block</code>
@@ -2493,7 +2598,7 @@
       <code>$key</code>
       <code>$subcat</code>
     </MixedAssignment>
-    <MixedMethodCall occurrences="6">
+    <MixedMethodCall>
       <code>getPlayPodcastAuthors</code>
       <code>getPlayPodcastBlock</code>
       <code>getPlayPodcastCategories</code>
@@ -2501,58 +2606,52 @@
       <code>getPlayPodcastExplicit</code>
       <code>getPlayPodcastImage</code>
     </MixedMethodCall>
-    <TypeDoesNotContainType occurrences="2">
+    <TypeDoesNotContainType>
       <code>empty($authors)</code>
       <code>empty($cats)</code>
     </TypeDoesNotContainType>
   </file>
   <file src="src/Writer/Extension/ITunes/Entry.php">
-    <DocblockTypeContradiction occurrences="10">
+    <DocblockTypeContradiction>
       <code>! is_bool($value)</code>
       <code>! is_numeric($number)</code>
       <code>! is_numeric($number)</code>
+      <code>! is_numeric($number) || is_float($number)</code>
+      <code>! is_numeric($number) || is_float($number)</code>
       <code>! is_string($value)</code>
       <code>is_bool($status)</code>
       <code>is_float($number)</code>
       <code>is_float($number)</code>
-      <code>is_object($number)</code>
-      <code>is_object($number)</code>
       <code>is_object($type)</code>
     </DocblockTypeContradiction>
-    <MixedArgument occurrences="1">
+    <MixedArgument>
       <code>$value</code>
     </MixedArgument>
-    <MixedArrayAssignment occurrences="1">
-      <code>$this-&gt;data['authors'][]</code>
+    <MixedArrayAssignment>
+      <code><![CDATA[$this->data['authors'][]]]></code>
     </MixedArrayAssignment>
-    <MixedAssignment occurrences="1">
+    <MixedAssignment>
       <code>$value</code>
     </MixedAssignment>
-    <NoValue occurrences="2">
-      <code>$value</code>
-      <code>$value</code>
-    </NoValue>
-    <RedundantCastGivenDocblockType occurrences="2">
+    <RedundantCastGivenDocblockType>
       <code>(int) $number</code>
       <code>(int) $number</code>
     </RedundantCastGivenDocblockType>
-    <RedundantConditionGivenDocblockType occurrences="3">
-      <code>gettype($number)</code>
-      <code>gettype($number)</code>
+    <RedundantConditionGivenDocblockType>
       <code>var_export($type, true)</code>
     </RedundantConditionGivenDocblockType>
-    <TypeDoesNotContainType occurrences="1">
+    <TypeDoesNotContainType>
       <code>'no'</code>
     </TypeDoesNotContainType>
   </file>
   <file src="src/Writer/Extension/ITunes/Feed.php">
-    <DocblockTypeContradiction occurrences="4">
+    <DocblockTypeContradiction>
       <code>! is_bool($value)</code>
       <code>! is_string($value)</code>
       <code>is_bool($status)</code>
       <code>is_object($type)</code>
     </DocblockTypeContradiction>
-    <MixedArgument occurrences="6">
+    <MixedArgument>
       <code>$val</code>
       <code>$value</code>
       <code>$value</code>
@@ -2560,38 +2659,38 @@
       <code>$value['email']</code>
       <code>$value['name']</code>
     </MixedArgument>
-    <MixedArgumentTypeCoercion occurrences="1">
+    <MixedArgumentTypeCoercion>
       <code>$key</code>
     </MixedArgumentTypeCoercion>
-    <MixedArrayAssignment occurrences="5">
-      <code>$this-&gt;data['authors'][]</code>
-      <code>$this-&gt;data['categories'][$key]</code>
-      <code>$this-&gt;data['categories'][$key]</code>
-      <code>$this-&gt;data['categories'][]</code>
-      <code>$this-&gt;data['owners'][]</code>
+    <MixedArrayAssignment>
+      <code><![CDATA[$this->data['authors'][]]]></code>
+      <code><![CDATA[$this->data['categories'][$key]]]></code>
+      <code><![CDATA[$this->data['categories'][$key]]]></code>
+      <code><![CDATA[$this->data['categories'][]]]></code>
+      <code><![CDATA[$this->data['owners'][]]]></code>
     </MixedArrayAssignment>
-    <MixedAssignment occurrences="4">
+    <MixedAssignment>
       <code>$val</code>
       <code>$value</code>
       <code>$value</code>
       <code>$value</code>
     </MixedAssignment>
-    <RedundantCastGivenDocblockType occurrences="1">
+    <RedundantCastGivenDocblockType>
       <code>(string) $value</code>
     </RedundantCastGivenDocblockType>
-    <RedundantConditionGivenDocblockType occurrences="1">
+    <RedundantConditionGivenDocblockType>
       <code>var_export($type, true)</code>
     </RedundantConditionGivenDocblockType>
-    <TypeDoesNotContainType occurrences="1">
+    <TypeDoesNotContainType>
       <code>'no'</code>
     </TypeDoesNotContainType>
   </file>
   <file src="src/Writer/Extension/ITunes/Renderer/Entry.php">
-    <MixedArgument occurrences="2">
+    <MixedArgument>
       <code>$image</code>
       <code>$keywords</code>
     </MixedArgument>
-    <MixedAssignment occurrences="14">
+    <MixedAssignment>
       <code>$author</code>
       <code>$authors</code>
       <code>$block</code>
@@ -2607,7 +2706,7 @@
       <code>$title</code>
       <code>$type</code>
     </MixedAssignment>
-    <MixedMethodCall occurrences="13">
+    <MixedMethodCall>
       <code>getItunesAuthors</code>
       <code>getItunesBlock</code>
       <code>getItunesDuration</code>
@@ -2622,24 +2721,24 @@
       <code>getItunesSummary</code>
       <code>getItunesTitle</code>
     </MixedMethodCall>
-    <TypeDoesNotContainType occurrences="2">
+    <TypeDoesNotContainType>
       <code>empty($authors)</code>
       <code>empty($keywords)</code>
     </TypeDoesNotContainType>
   </file>
   <file src="src/Writer/Extension/ITunes/Renderer/Feed.php">
-    <MixedArgument occurrences="5">
+    <MixedArgument>
       <code>$cat</code>
       <code>$image</code>
       <code>$key</code>
       <code>$keywords</code>
       <code>$subcat</code>
     </MixedArgument>
-    <MixedArrayAccess occurrences="2">
+    <MixedArrayAccess>
       <code>$owner['email']</code>
       <code>$owner['name']</code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="18">
+    <MixedAssignment>
       <code>$author</code>
       <code>$authors</code>
       <code>$block</code>
@@ -2659,7 +2758,7 @@
       <code>$type</code>
       <code>$url</code>
     </MixedAssignment>
-    <MixedMethodCall occurrences="13">
+    <MixedMethodCall>
       <code>getItunesAuthors</code>
       <code>getItunesBlock</code>
       <code>getItunesCategories</code>
@@ -2674,7 +2773,7 @@
       <code>getItunesSummary</code>
       <code>getItunesType</code>
     </MixedMethodCall>
-    <TypeDoesNotContainType occurrences="4">
+    <TypeDoesNotContainType>
       <code>empty($authors)</code>
       <code>empty($cats)</code>
       <code>empty($keywords)</code>
@@ -2682,204 +2781,204 @@
     </TypeDoesNotContainType>
   </file>
   <file src="src/Writer/Extension/PodcastIndex/Entry.php">
-    <MixedArgument occurrences="1">
+    <MixedArgument>
       <code>$value</code>
     </MixedArgument>
-    <MixedArrayAssignment occurrences="1">
-      <code>$this-&gt;data['soundbites'][]</code>
+    <MixedArrayAssignment>
+      <code><![CDATA[$this->data['soundbites'][]]]></code>
     </MixedArrayAssignment>
-    <MixedAssignment occurrences="1">
+    <MixedAssignment>
       <code>$value</code>
     </MixedAssignment>
   </file>
   <file src="src/Writer/Extension/PodcastIndex/Renderer/Entry.php">
-    <MixedAssignment occurrences="1">
+    <MixedAssignment>
       <code>$soundbite</code>
     </MixedAssignment>
-    <MixedMethodCall occurrences="3">
+    <MixedMethodCall>
       <code>getPodcastIndexChapters</code>
       <code>getPodcastIndexSoundbites</code>
       <code>getPodcastIndexTranscript</code>
     </MixedMethodCall>
-    <RedundantCastGivenDocblockType occurrences="1">
+    <RedundantCastGivenDocblockType>
       <code>(string) $soundbite['title']</code>
     </RedundantCastGivenDocblockType>
   </file>
   <file src="src/Writer/Extension/PodcastIndex/Renderer/Feed.php">
-    <MixedMethodCall occurrences="2">
+    <MixedMethodCall>
       <code>getPodcastIndexFunding</code>
       <code>getPodcastIndexLocked</code>
     </MixedMethodCall>
-    <RedundantCastGivenDocblockType occurrences="2">
+    <RedundantCastGivenDocblockType>
       <code>(string) $funding['title']</code>
       <code>(string) $locked['value']</code>
     </RedundantCastGivenDocblockType>
   </file>
   <file src="src/Writer/Extension/Slash/Renderer/Entry.php">
-    <MixedAssignment occurrences="1">
+    <MixedAssignment>
       <code>$count</code>
     </MixedAssignment>
-    <MixedMethodCall occurrences="1">
+    <MixedMethodCall>
       <code>getCommentCount</code>
     </MixedMethodCall>
   </file>
   <file src="src/Writer/Extension/Threading/Renderer/Entry.php">
-    <MixedArgument occurrences="4">
+    <MixedArgument>
       <code>$count</code>
       <code>$count</code>
       <code>$link</code>
       <code>$link['uri']</code>
     </MixedArgument>
-    <MixedArrayAccess occurrences="2">
+    <MixedArrayAccess>
       <code>$link['type']</code>
       <code>$link['uri']</code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="5">
+    <MixedAssignment>
       <code>$count</code>
       <code>$count</code>
       <code>$link</code>
       <code>$link</code>
       <code>$links</code>
     </MixedAssignment>
-    <MixedMethodCall occurrences="5">
+    <MixedMethodCall>
       <code>getCommentCount</code>
       <code>getCommentCount</code>
       <code>getCommentCount</code>
       <code>getCommentFeedLinks</code>
       <code>getCommentLink</code>
     </MixedMethodCall>
-    <MixedOperand occurrences="1">
+    <MixedOperand>
       <code>$link['type']</code>
     </MixedOperand>
-    <TypeDoesNotContainType occurrences="1">
+    <TypeDoesNotContainType>
       <code>empty($links)</code>
     </TypeDoesNotContainType>
   </file>
   <file src="src/Writer/Extension/WellFormedWeb/Renderer/Entry.php">
-    <MixedArrayAccess occurrences="2">
+    <MixedArrayAccess>
       <code>$link['type']</code>
       <code>$link['uri']</code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="2">
+    <MixedAssignment>
       <code>$link</code>
       <code>$links</code>
     </MixedAssignment>
-    <MixedMethodCall occurrences="1">
+    <MixedMethodCall>
       <code>getCommentFeedLinks</code>
     </MixedMethodCall>
-    <TypeDoesNotContainType occurrences="1">
+    <TypeDoesNotContainType>
       <code>empty($links)</code>
     </TypeDoesNotContainType>
   </file>
   <file src="src/Writer/ExtensionManager.php">
-    <DeprecatedInterface occurrences="3">
+    <DeprecatedInterface>
       <code>?ExtensionManagerInterface</code>
       <code>ExtensionManager</code>
       <code>ExtensionManagerInterface</code>
     </DeprecatedInterface>
-    <MixedInferredReturnType occurrences="1">
+    <MixedInferredReturnType>
       <code>Extension\AbstractRenderer</code>
     </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="1">
-      <code>$this-&gt;pluginManager-&gt;get($extension)</code>
+    <MixedReturnStatement>
+      <code><![CDATA[$this->pluginManager->get($extension)]]></code>
     </MixedReturnStatement>
   </file>
   <file src="src/Writer/ExtensionPluginManager.php">
-    <DeprecatedInterface occurrences="1">
+    <DeprecatedInterface>
       <code>ExtensionPluginManager</code>
     </DeprecatedInterface>
   </file>
   <file src="src/Writer/Feed.php">
-    <InvalidMethodCall occurrences="2">
+    <InvalidMethodCall>
       <code>getTimestamp</code>
       <code>getTimestamp</code>
     </InvalidMethodCall>
-    <InvalidPropertyAssignmentValue occurrences="1">
-      <code>$this-&gt;entries</code>
+    <InvalidPropertyAssignmentValue>
+      <code><![CDATA[$this->entries]]></code>
     </InvalidPropertyAssignmentValue>
-    <InvalidStringClass occurrences="1">
+    <InvalidStringClass>
       <code>new $renderClass($this)</code>
     </InvalidStringClass>
-    <MixedInferredReturnType occurrences="1">
+    <MixedInferredReturnType>
       <code>string</code>
     </MixedInferredReturnType>
-    <MixedMethodCall occurrences="3">
+    <MixedMethodCall>
       <code>ignoreExceptions</code>
       <code>render</code>
       <code>saveXml</code>
     </MixedMethodCall>
-    <MixedReturnStatement occurrences="1">
-      <code>$renderer-&gt;render()-&gt;saveXml()</code>
+    <MixedReturnStatement>
+      <code><![CDATA[$renderer->render()->saveXml()]]></code>
     </MixedReturnStatement>
-    <PossiblyNullArgument occurrences="1">
-      <code>$this-&gt;getEncoding()</code>
+    <PossiblyNullArgument>
+      <code><![CDATA[$this->getEncoding()]]></code>
     </PossiblyNullArgument>
-    <PropertyNotSetInConstructor occurrences="2">
+    <PropertyNotSetInConstructor>
       <code>Feed</code>
       <code>Feed</code>
     </PropertyNotSetInConstructor>
   </file>
   <file src="src/Writer/FeedFactory.php">
-    <DocblockTypeContradiction occurrences="2">
-      <code>! is_array($data) &amp;&amp; ! $data instanceof Traversable</code>
-      <code>! is_array($entries) &amp;&amp; ! $entries instanceof Traversable</code>
+    <DocblockTypeContradiction>
+      <code><![CDATA[! is_array($data) && ! $data instanceof Traversable]]></code>
+      <code><![CDATA[! is_array($entries) && ! $entries instanceof Traversable]]></code>
     </DocblockTypeContradiction>
-    <MixedArgument occurrences="4">
+    <MixedArgument>
       <code>$key</code>
       <code>$value</code>
       <code>$value['link']</code>
       <code>$value['type']</code>
     </MixedArgument>
-    <MixedArgumentTypeCoercion occurrences="1">
+    <MixedArgumentTypeCoercion>
       <code>$key</code>
     </MixedArgumentTypeCoercion>
-    <MixedAssignment occurrences="2">
+    <MixedAssignment>
       <code>$key</code>
       <code>$value</code>
     </MixedAssignment>
   </file>
   <file src="src/Writer/Renderer/AbstractRenderer.php">
-    <DocblockTypeContradiction occurrences="1">
+    <DocblockTypeContradiction>
       <code>is_bool($bool)</code>
     </DocblockTypeContradiction>
-    <MixedArgument occurrences="1">
+    <MixedArgument>
       <code>$extension</code>
     </MixedArgument>
-    <MixedArrayOffset occurrences="1">
-      <code>$this-&gt;extensions[$extension]</code>
+    <MixedArrayOffset>
+      <code><![CDATA[$this->extensions[$extension]]]></code>
     </MixedArrayOffset>
-    <MixedAssignment occurrences="3">
+    <MixedAssignment>
       <code>$extension</code>
       <code>$exts</code>
       <code>$plugin</code>
     </MixedAssignment>
-    <MixedMethodCall occurrences="2">
+    <MixedMethodCall>
       <code>setDataContainer</code>
       <code>setEncoding</code>
     </MixedMethodCall>
-    <PropertyNotSetInConstructor occurrences="2">
+    <PropertyNotSetInConstructor>
       <code>$dom</code>
       <code>$rootElement</code>
     </PropertyNotSetInConstructor>
   </file>
   <file src="src/Writer/Renderer/Entry/Atom.php">
-    <ImplementedReturnTypeMismatch occurrences="1">
+    <ImplementedReturnTypeMismatch>
       <code>$this</code>
     </ImplementedReturnTypeMismatch>
-    <InvalidArgument occurrences="1">
+    <InvalidArgument>
       <code>$container</code>
     </InvalidArgument>
-    <InvalidCast occurrences="1">
+    <InvalidCast>
       <code>$tidy</code>
     </InvalidCast>
-    <InvalidIterator occurrences="1">
+    <InvalidIterator>
       <code>$categories</code>
     </InvalidIterator>
-    <InvalidMethodCall occurrences="2">
+    <InvalidMethodCall>
       <code>format</code>
       <code>format</code>
     </InvalidMethodCall>
-    <MixedArgument occurrences="12">
+    <MixedArgument>
       <code>$cat['label']</code>
       <code>$cat['scheme']</code>
       <code>$cat['term']</code>
@@ -2890,10 +2989,10 @@
       <code>$data['type']</code>
       <code>$data['uri']</code>
       <code>$source</code>
-      <code>$this-&gt;getDataContainer()-&gt;getDateCreated()-&gt;format(DateTime::ATOM)</code>
-      <code>$this-&gt;getDataContainer()-&gt;getDateModified()-&gt;format(DateTime::ATOM)</code>
+      <code><![CDATA[$this->getDataContainer()->getDateCreated()->format(DateTime::ATOM)]]></code>
+      <code><![CDATA[$this->getDataContainer()->getDateModified()->format(DateTime::ATOM)]]></code>
     </MixedArgument>
-    <MixedArrayAccess occurrences="8">
+    <MixedArrayAccess>
       <code>$cat['label']</code>
       <code>$cat['scheme']</code>
       <code>$cat['term']</code>
@@ -2903,7 +3002,7 @@
       <code>$data['type']</code>
       <code>$data['uri']</code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="6">
+    <MixedAssignment>
       <code>$cat</code>
       <code>$content</code>
       <code>$data</code>
@@ -2911,122 +3010,122 @@
       <code>$ext</code>
       <code>$source</code>
     </MixedAssignment>
-    <MixedMethodCall occurrences="4">
+    <MixedMethodCall>
       <code>render</code>
       <code>setDomDocument</code>
       <code>setRootElement</code>
       <code>setType</code>
     </MixedMethodCall>
-    <PossiblyNullArgument occurrences="8">
-      <code>$this-&gt;container-&gt;getEncoding()</code>
-      <code>$this-&gt;getDataContainer()-&gt;getDescription()</code>
-      <code>$this-&gt;getDataContainer()-&gt;getId()</code>
-      <code>$this-&gt;getDataContainer()-&gt;getId()</code>
-      <code>$this-&gt;getDataContainer()-&gt;getId()</code>
-      <code>$this-&gt;getDataContainer()-&gt;getLink()</code>
-      <code>$this-&gt;getDataContainer()-&gt;getLink()</code>
-      <code>$this-&gt;getDataContainer()-&gt;getTitle()</code>
+    <PossiblyNullArgument>
+      <code><![CDATA[$this->container->getEncoding()]]></code>
+      <code><![CDATA[$this->getDataContainer()->getDescription()]]></code>
+      <code><![CDATA[$this->getDataContainer()->getId()]]></code>
+      <code><![CDATA[$this->getDataContainer()->getId()]]></code>
+      <code><![CDATA[$this->getDataContainer()->getId()]]></code>
+      <code><![CDATA[$this->getDataContainer()->getLink()]]></code>
+      <code><![CDATA[$this->getDataContainer()->getLink()]]></code>
+      <code><![CDATA[$this->getDataContainer()->getTitle()]]></code>
     </PossiblyNullArgument>
-    <PossiblyNullReference occurrences="2">
+    <PossiblyNullReference>
       <code>format</code>
       <code>format</code>
     </PossiblyNullReference>
-    <PropertyNotSetInConstructor occurrences="2">
+    <PropertyNotSetInConstructor>
       <code>Atom</code>
       <code>Atom</code>
     </PropertyNotSetInConstructor>
-    <TypeDoesNotContainType occurrences="1">
+    <TypeDoesNotContainType>
       <code>empty($data)</code>
     </TypeDoesNotContainType>
   </file>
   <file src="src/Writer/Renderer/Entry/Atom/Deleted.php">
-    <ImplementedReturnTypeMismatch occurrences="1">
+    <ImplementedReturnTypeMismatch>
       <code>$this</code>
     </ImplementedReturnTypeMismatch>
-    <InvalidArgument occurrences="1">
+    <InvalidArgument>
       <code>$container</code>
     </InvalidArgument>
-    <MixedArgument occurrences="4">
+    <MixedArgument>
       <code>$data</code>
-      <code>$this-&gt;container-&gt;getReference()</code>
-      <code>$this-&gt;container-&gt;getWhen()-&gt;format(DateTime::ATOM)</code>
-      <code>$this-&gt;getDataContainer()-&gt;getComment()</code>
+      <code><![CDATA[$this->container->getReference()]]></code>
+      <code><![CDATA[$this->container->getWhen()->format(DateTime::ATOM)]]></code>
+      <code><![CDATA[$this->getDataContainer()->getComment()]]></code>
     </MixedArgument>
-    <MixedArrayAccess occurrences="1">
+    <MixedArrayAccess>
       <code>$data['name']</code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="1">
+    <MixedAssignment>
       <code>$data</code>
     </MixedAssignment>
-    <MixedMethodCall occurrences="1">
+    <MixedMethodCall>
       <code>format</code>
     </MixedMethodCall>
-    <PossiblyNullArgument occurrences="1">
-      <code>$this-&gt;container-&gt;getEncoding()</code>
+    <PossiblyNullArgument>
+      <code><![CDATA[$this->container->getEncoding()]]></code>
     </PossiblyNullArgument>
-    <PropertyNotSetInConstructor occurrences="2">
+    <PropertyNotSetInConstructor>
       <code>Deleted</code>
       <code>Deleted</code>
     </PropertyNotSetInConstructor>
-    <TypeDoesNotContainType occurrences="1">
+    <TypeDoesNotContainType>
       <code>empty($data)</code>
     </TypeDoesNotContainType>
   </file>
   <file src="src/Writer/Renderer/Entry/AtomDeleted.php">
-    <ImplementedReturnTypeMismatch occurrences="1">
+    <ImplementedReturnTypeMismatch>
       <code>$this</code>
     </ImplementedReturnTypeMismatch>
-    <InvalidArgument occurrences="1">
+    <InvalidArgument>
       <code>$container</code>
     </InvalidArgument>
-    <MixedArgument occurrences="4">
+    <MixedArgument>
       <code>$data</code>
-      <code>$this-&gt;container-&gt;getReference()</code>
-      <code>$this-&gt;container-&gt;getWhen()-&gt;format(DateTime::ATOM)</code>
-      <code>$this-&gt;getDataContainer()-&gt;getComment()</code>
+      <code><![CDATA[$this->container->getReference()]]></code>
+      <code><![CDATA[$this->container->getWhen()->format(DateTime::ATOM)]]></code>
+      <code><![CDATA[$this->getDataContainer()->getComment()]]></code>
     </MixedArgument>
-    <MixedArrayAccess occurrences="1">
+    <MixedArrayAccess>
       <code>$data['name']</code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="1">
+    <MixedAssignment>
       <code>$data</code>
     </MixedAssignment>
-    <MixedMethodCall occurrences="1">
+    <MixedMethodCall>
       <code>format</code>
     </MixedMethodCall>
-    <PossiblyNullArgument occurrences="1">
-      <code>$this-&gt;container-&gt;getEncoding()</code>
+    <PossiblyNullArgument>
+      <code><![CDATA[$this->container->getEncoding()]]></code>
     </PossiblyNullArgument>
-    <PropertyNotSetInConstructor occurrences="2">
+    <PropertyNotSetInConstructor>
       <code>AtomDeleted</code>
       <code>AtomDeleted</code>
     </PropertyNotSetInConstructor>
-    <TypeDoesNotContainType occurrences="1">
+    <TypeDoesNotContainType>
       <code>empty($data)</code>
     </TypeDoesNotContainType>
   </file>
   <file src="src/Writer/Renderer/Entry/Rss.php">
-    <ImplementedReturnTypeMismatch occurrences="1">
+    <ImplementedReturnTypeMismatch>
       <code>$this</code>
     </ImplementedReturnTypeMismatch>
-    <InvalidArgument occurrences="1">
+    <InvalidArgument>
       <code>$container</code>
     </InvalidArgument>
-    <InvalidIterator occurrences="1">
+    <InvalidIterator>
       <code>$categories</code>
     </InvalidIterator>
-    <InvalidMethodCall occurrences="1">
+    <InvalidMethodCall>
       <code>format</code>
     </InvalidMethodCall>
-    <MixedArgument occurrences="6">
+    <MixedArgument>
       <code>$cat['scheme']</code>
       <code>$cat['term']</code>
       <code>$data</code>
       <code>$data['type']</code>
       <code>$data['uri']</code>
-      <code>$this-&gt;getDataContainer()-&gt;getDateModified()-&gt;format(DateTime::RSS)</code>
+      <code><![CDATA[$this->getDataContainer()->getDateModified()->format(DateTime::RSS)]]></code>
     </MixedArgument>
-    <MixedArrayAccess occurrences="8">
+    <MixedArrayAccess>
       <code>$cat['scheme']</code>
       <code>$cat['term']</code>
       <code>$data['length']</code>
@@ -3036,7 +3135,7 @@
       <code>$data['type']</code>
       <code>$data['uri']</code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="6">
+    <MixedAssignment>
       <code>$cat</code>
       <code>$data</code>
       <code>$data</code>
@@ -3044,51 +3143,51 @@
       <code>$link</code>
       <code>$name</code>
     </MixedAssignment>
-    <MixedMethodCall occurrences="4">
+    <MixedMethodCall>
       <code>render</code>
       <code>setDomDocument</code>
       <code>setRootElement</code>
       <code>setType</code>
     </MixedMethodCall>
-    <MixedOperand occurrences="2">
+    <MixedOperand>
       <code>$data['email']</code>
       <code>$data['name']</code>
     </MixedOperand>
-    <PossiblyNullArgument occurrences="4">
-      <code>$this-&gt;container-&gt;getEncoding()</code>
-      <code>$this-&gt;getDataContainer()-&gt;getDescription()</code>
-      <code>$this-&gt;getDataContainer()-&gt;getId()</code>
-      <code>$this-&gt;getDataContainer()-&gt;getLink()</code>
+    <PossiblyNullArgument>
+      <code><![CDATA[$this->container->getEncoding()]]></code>
+      <code><![CDATA[$this->getDataContainer()->getDescription()]]></code>
+      <code><![CDATA[$this->getDataContainer()->getId()]]></code>
+      <code><![CDATA[$this->getDataContainer()->getLink()]]></code>
     </PossiblyNullArgument>
-    <PossiblyNullReference occurrences="1">
+    <PossiblyNullReference>
       <code>format</code>
     </PossiblyNullReference>
-    <PropertyNotSetInConstructor occurrences="2">
+    <PropertyNotSetInConstructor>
       <code>Rss</code>
       <code>Rss</code>
     </PropertyNotSetInConstructor>
-    <TypeDoesNotContainType occurrences="1">
+    <TypeDoesNotContainType>
       <code>empty($data)</code>
     </TypeDoesNotContainType>
   </file>
   <file src="src/Writer/Renderer/Feed/AbstractAtom.php">
-    <InvalidArgument occurrences="3">
+    <InvalidArgument>
       <code>$flinks</code>
       <code>$gdata</code>
       <code>$gdata</code>
     </InvalidArgument>
-    <InvalidArrayOffset occurrences="1">
+    <InvalidArrayOffset>
       <code>$gdata['name']</code>
     </InvalidArrayOffset>
-    <InvalidIterator occurrences="3">
+    <InvalidIterator>
       <code>$categories</code>
       <code>$flinks</code>
       <code>$hubs</code>
     </InvalidIterator>
-    <InvalidMethodCall occurrences="1">
+    <InvalidMethodCall>
       <code>format</code>
     </InvalidMethodCall>
-    <MixedArgument occurrences="9">
+    <MixedArgument>
       <code>$cat['label']</code>
       <code>$cat['scheme']</code>
       <code>$cat['term']</code>
@@ -3096,88 +3195,88 @@
       <code>$data</code>
       <code>$href</code>
       <code>$hubUrl</code>
-      <code>$this-&gt;getDataContainer()-&gt;getDateModified()-&gt;format(DateTime::ATOM)</code>
+      <code><![CDATA[$this->getDataContainer()->getDateModified()->format(DateTime::ATOM)]]></code>
       <code>$type</code>
     </MixedArgument>
-    <MixedArrayAccess occurrences="5">
+    <MixedArrayAccess>
       <code>$cat['label']</code>
       <code>$cat['scheme']</code>
       <code>$cat['term']</code>
       <code>$cat['term']</code>
       <code>$data['name']</code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="5">
+    <MixedAssignment>
       <code>$cat</code>
       <code>$data</code>
       <code>$href</code>
       <code>$hubUrl</code>
       <code>$type</code>
     </MixedAssignment>
-    <PossiblyNullArgument occurrences="5">
+    <PossiblyNullArgument>
       <code>$gdata['uri']</code>
       <code>$gdata['version']</code>
-      <code>$this-&gt;getDataContainer()-&gt;getLanguage()</code>
-      <code>$this-&gt;getDataContainer()-&gt;getLink()</code>
-      <code>$this-&gt;getDataContainer()-&gt;getLink()</code>
+      <code><![CDATA[$this->getDataContainer()->getLanguage()]]></code>
+      <code><![CDATA[$this->getDataContainer()->getLink()]]></code>
+      <code><![CDATA[$this->getDataContainer()->getLink()]]></code>
     </PossiblyNullArgument>
-    <PossiblyNullArrayAccess occurrences="1">
+    <PossiblyNullArrayAccess>
       <code>$gdata['name']</code>
     </PossiblyNullArrayAccess>
-    <PossiblyNullReference occurrences="1">
+    <PossiblyNullReference>
       <code>format</code>
     </PossiblyNullReference>
-    <PropertyNotSetInConstructor occurrences="2">
+    <PropertyNotSetInConstructor>
       <code>AbstractAtom</code>
       <code>AbstractAtom</code>
     </PropertyNotSetInConstructor>
   </file>
   <file src="src/Writer/Renderer/Feed/Atom.php">
-    <ImplementedReturnTypeMismatch occurrences="1">
+    <ImplementedReturnTypeMismatch>
       <code>$this</code>
     </ImplementedReturnTypeMismatch>
-    <MixedArgument occurrences="1">
+    <MixedArgument>
       <code>$entry</code>
     </MixedArgument>
-    <MixedAssignment occurrences="2">
+    <MixedAssignment>
       <code>$entry</code>
       <code>$ext</code>
     </MixedAssignment>
-    <MixedMethodCall occurrences="5">
+    <MixedMethodCall>
       <code>render</code>
       <code>setDomDocument</code>
       <code>setEncoding</code>
       <code>setRootElement</code>
       <code>setType</code>
     </MixedMethodCall>
-    <PossiblyNullArgument occurrences="1">
-      <code>$this-&gt;container-&gt;getEncoding()</code>
+    <PossiblyNullArgument>
+      <code><![CDATA[$this->container->getEncoding()]]></code>
     </PossiblyNullArgument>
-    <PropertyNotSetInConstructor occurrences="2">
+    <PropertyNotSetInConstructor>
       <code>Atom</code>
       <code>Atom</code>
     </PropertyNotSetInConstructor>
-    <RawObjectIteration occurrences="1">
-      <code>$this-&gt;container</code>
+    <RawObjectIteration>
+      <code><![CDATA[$this->container]]></code>
     </RawObjectIteration>
   </file>
   <file src="src/Writer/Renderer/Feed/Atom/AbstractAtom.php">
-    <InvalidArgument occurrences="3">
+    <InvalidArgument>
       <code>$flinks</code>
       <code>$gdata</code>
       <code>$gdata</code>
     </InvalidArgument>
-    <InvalidArrayOffset occurrences="1">
+    <InvalidArrayOffset>
       <code>$gdata['name']</code>
     </InvalidArrayOffset>
-    <InvalidIterator occurrences="3">
+    <InvalidIterator>
       <code>$categories</code>
       <code>$flinks</code>
       <code>$hubs</code>
     </InvalidIterator>
-    <InvalidMethodCall occurrences="1">
+    <InvalidMethodCall>
       <code>format</code>
     </InvalidMethodCall>
-    <MixedArgument occurrences="9">
+    <MixedArgument>
       <code>$cat['label']</code>
       <code>$cat['scheme']</code>
       <code>$cat['term']</code>
@@ -3185,138 +3284,138 @@
       <code>$data</code>
       <code>$href</code>
       <code>$hubUrl</code>
-      <code>$this-&gt;getDataContainer()-&gt;getDateModified()-&gt;format(DateTime::ATOM)</code>
+      <code><![CDATA[$this->getDataContainer()->getDateModified()->format(DateTime::ATOM)]]></code>
       <code>$type</code>
     </MixedArgument>
-    <MixedArrayAccess occurrences="5">
+    <MixedArrayAccess>
       <code>$cat['label']</code>
       <code>$cat['scheme']</code>
       <code>$cat['term']</code>
       <code>$cat['term']</code>
       <code>$data['name']</code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="5">
+    <MixedAssignment>
       <code>$cat</code>
       <code>$data</code>
       <code>$href</code>
       <code>$hubUrl</code>
       <code>$type</code>
     </MixedAssignment>
-    <PossiblyNullArgument occurrences="5">
+    <PossiblyNullArgument>
       <code>$gdata['uri']</code>
       <code>$gdata['version']</code>
-      <code>$this-&gt;getDataContainer()-&gt;getLanguage()</code>
-      <code>$this-&gt;getDataContainer()-&gt;getLink()</code>
-      <code>$this-&gt;getDataContainer()-&gt;getLink()</code>
+      <code><![CDATA[$this->getDataContainer()->getLanguage()]]></code>
+      <code><![CDATA[$this->getDataContainer()->getLink()]]></code>
+      <code><![CDATA[$this->getDataContainer()->getLink()]]></code>
     </PossiblyNullArgument>
-    <PossiblyNullArrayAccess occurrences="1">
+    <PossiblyNullArrayAccess>
       <code>$gdata['name']</code>
     </PossiblyNullArrayAccess>
-    <PossiblyNullReference occurrences="1">
+    <PossiblyNullReference>
       <code>format</code>
     </PossiblyNullReference>
-    <PropertyNotSetInConstructor occurrences="2">
+    <PropertyNotSetInConstructor>
       <code>AbstractAtom</code>
       <code>AbstractAtom</code>
     </PropertyNotSetInConstructor>
   </file>
   <file src="src/Writer/Renderer/Feed/Atom/Source.php">
-    <ImplementedReturnTypeMismatch occurrences="1">
+    <ImplementedReturnTypeMismatch>
       <code>$this</code>
     </ImplementedReturnTypeMismatch>
-    <InvalidArgument occurrences="3">
+    <InvalidArgument>
       <code>$container</code>
       <code>$gdata</code>
       <code>$gdata</code>
     </InvalidArgument>
-    <InvalidArrayOffset occurrences="1">
+    <InvalidArrayOffset>
       <code>$gdata['name']</code>
     </InvalidArrayOffset>
-    <MixedAssignment occurrences="1">
+    <MixedAssignment>
       <code>$ext</code>
     </MixedAssignment>
-    <MixedMethodCall occurrences="4">
+    <MixedMethodCall>
       <code>render</code>
       <code>setDomDocument</code>
       <code>setRootElement</code>
       <code>setType</code>
     </MixedMethodCall>
-    <PossiblyNullArgument occurrences="3">
+    <PossiblyNullArgument>
       <code>$gdata['uri']</code>
       <code>$gdata['version']</code>
-      <code>$this-&gt;container-&gt;getEncoding()</code>
+      <code><![CDATA[$this->container->getEncoding()]]></code>
     </PossiblyNullArgument>
-    <PossiblyNullArrayAccess occurrences="1">
+    <PossiblyNullArrayAccess>
       <code>$gdata['name']</code>
     </PossiblyNullArrayAccess>
-    <PropertyNotSetInConstructor occurrences="2">
+    <PropertyNotSetInConstructor>
       <code>Source</code>
       <code>Source</code>
     </PropertyNotSetInConstructor>
   </file>
   <file src="src/Writer/Renderer/Feed/AtomSource.php">
-    <ImplementedReturnTypeMismatch occurrences="1">
+    <ImplementedReturnTypeMismatch>
       <code>$this</code>
     </ImplementedReturnTypeMismatch>
-    <InvalidArgument occurrences="2">
+    <InvalidArgument>
       <code>$gdata</code>
       <code>$gdata</code>
     </InvalidArgument>
-    <InvalidArrayOffset occurrences="1">
+    <InvalidArrayOffset>
       <code>$gdata['name']</code>
     </InvalidArrayOffset>
-    <MixedAssignment occurrences="1">
+    <MixedAssignment>
       <code>$ext</code>
     </MixedAssignment>
-    <MixedMethodCall occurrences="4">
+    <MixedMethodCall>
       <code>render</code>
       <code>setDomDocument</code>
       <code>setRootElement</code>
       <code>setType</code>
     </MixedMethodCall>
-    <PossiblyNullArgument occurrences="3">
+    <PossiblyNullArgument>
       <code>$gdata['uri']</code>
       <code>$gdata['version']</code>
-      <code>$this-&gt;container-&gt;getEncoding()</code>
+      <code><![CDATA[$this->container->getEncoding()]]></code>
     </PossiblyNullArgument>
-    <PossiblyNullArrayAccess occurrences="1">
+    <PossiblyNullArrayAccess>
       <code>$gdata['name']</code>
     </PossiblyNullArrayAccess>
-    <PropertyNotSetInConstructor occurrences="2">
+    <PropertyNotSetInConstructor>
       <code>AtomSource</code>
       <code>AtomSource</code>
     </PropertyNotSetInConstructor>
   </file>
   <file src="src/Writer/Renderer/Feed/Rss.php">
-    <ImplementedReturnTypeMismatch occurrences="1">
+    <ImplementedReturnTypeMismatch>
       <code>$this</code>
     </ImplementedReturnTypeMismatch>
-    <InvalidArgument occurrences="2">
+    <InvalidArgument>
       <code>$gdata</code>
       <code>$gdata</code>
     </InvalidArgument>
-    <InvalidArrayOffset occurrences="1">
+    <InvalidArrayOffset>
       <code>$gdata['name']</code>
     </InvalidArrayOffset>
-    <InvalidIterator occurrences="1">
+    <InvalidIterator>
       <code>$categories</code>
     </InvalidIterator>
-    <InvalidMethodCall occurrences="2">
+    <InvalidMethodCall>
       <code>format</code>
       <code>format</code>
     </InvalidMethodCall>
-    <MixedArgument occurrences="4">
+    <MixedArgument>
       <code>$cat['scheme']</code>
       <code>$data</code>
-      <code>$this-&gt;getDataContainer()-&gt;getDateModified()-&gt;format(DateTime::RSS)</code>
-      <code>$this-&gt;getDataContainer()-&gt;getLastBuildDate()-&gt;format(DateTime::RSS)</code>
+      <code><![CDATA[$this->getDataContainer()->getDateModified()->format(DateTime::RSS)]]></code>
+      <code><![CDATA[$this->getDataContainer()->getLastBuildDate()->format(DateTime::RSS)]]></code>
     </MixedArgument>
-    <MixedArrayAccess occurrences="3">
+    <MixedArrayAccess>
       <code>$cat['scheme']</code>
       <code>$cat['term']</code>
       <code>$data['name']</code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="6">
+    <MixedAssignment>
       <code>$cat</code>
       <code>$data</code>
       <code>$entry</code>
@@ -3324,88 +3423,91 @@
       <code>$name</code>
       <code>$name</code>
     </MixedAssignment>
-    <MixedMethodCall occurrences="5">
+    <MixedMethodCall>
       <code>render</code>
       <code>setDomDocument</code>
       <code>setEncoding</code>
       <code>setRootElement</code>
       <code>setType</code>
     </MixedMethodCall>
-    <MixedOperand occurrences="4">
+    <MixedOperand>
       <code>$data['email']</code>
       <code>$data['name']</code>
       <code>$name</code>
       <code>$name</code>
     </MixedOperand>
-    <PossiblyNullArgument occurrences="1">
-      <code>$this-&gt;container-&gt;getEncoding()</code>
+    <PossiblyNullArgument>
+      <code><![CDATA[$this->container->getEncoding()]]></code>
     </PossiblyNullArgument>
-    <PossiblyNullArrayAccess occurrences="1">
+    <PossiblyNullArrayAccess>
       <code>$gdata['name']</code>
     </PossiblyNullArrayAccess>
-    <PossiblyNullOperand occurrences="2">
+    <PossiblyNullOperand>
       <code>$gdata['uri']</code>
       <code>$gdata['version']</code>
     </PossiblyNullOperand>
-    <PossiblyNullReference occurrences="2">
+    <PossiblyNullReference>
       <code>format</code>
       <code>format</code>
     </PossiblyNullReference>
-    <PropertyNotSetInConstructor occurrences="2">
+    <PropertyNotSetInConstructor>
       <code>Rss</code>
       <code>Rss</code>
     </PropertyNotSetInConstructor>
-    <RawObjectIteration occurrences="1">
-      <code>$this-&gt;container</code>
+    <RawObjectIteration>
+      <code><![CDATA[$this->container]]></code>
     </RawObjectIteration>
   </file>
   <file src="src/Writer/Renderer/RendererInterface.php">
-    <MissingReturnType occurrences="2">
+    <MissingReturnType>
       <code>setRootElement</code>
       <code>setType</code>
     </MissingReturnType>
   </file>
   <file src="src/Writer/Source.php">
-    <PropertyNotSetInConstructor occurrences="2">
+    <PropertyNotSetInConstructor>
       <code>Source</code>
       <code>Source</code>
     </PropertyNotSetInConstructor>
   </file>
   <file src="src/Writer/StandaloneExtensionManager.php">
-    <DeprecatedInterface occurrences="1">
+    <DeprecatedInterface>
       <code>StandaloneExtensionManager</code>
     </DeprecatedInterface>
-    <MixedMethodCall occurrences="1">
+    <MixedArgument>
+      <code>$class</code>
+    </MixedArgument>
+    <MixedMethodCall>
       <code>new $class()</code>
     </MixedMethodCall>
-    <RedundantConditionGivenDocblockType occurrences="1">
+    <RedundantConditionGivenDocblockType>
       <code>is_string($class)</code>
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="src/Writer/Writer.php">
-    <DeprecatedInterface occurrences="3">
+    <DeprecatedInterface>
       <code>ExtensionManagerInterface</code>
       <code>ExtensionManagerInterface</code>
       <code>ExtensionManagerInterface</code>
     </DeprecatedInterface>
-    <MixedArgument occurrences="4">
+    <MixedArgument>
       <code>static::$extensions['entry']</code>
       <code>static::$extensions['entryRenderer']</code>
       <code>static::$extensions['feed']</code>
       <code>static::$extensions['feedRenderer']</code>
     </MixedArgument>
-    <MixedArrayAssignment occurrences="4">
+    <MixedArrayAssignment>
       <code>static::$extensions['entry'][]</code>
       <code>static::$extensions['entryRenderer'][]</code>
       <code>static::$extensions['feed'][]</code>
       <code>static::$extensions['feedRenderer'][]</code>
     </MixedArrayAssignment>
-    <RedundantPropertyInitializationCheck occurrences="1">
+    <RedundantPropertyInitializationCheck>
       <code>isset(static::$extensionManager)</code>
     </RedundantPropertyInitializationCheck>
   </file>
   <file src="test/PubSubHubbub/ClientNotReset.php">
-    <PropertyNotSetInConstructor occurrences="6">
+    <PropertyNotSetInConstructor>
       <code>ClientNotReset</code>
       <code>ClientNotReset</code>
       <code>ClientNotReset</code>
@@ -3415,90 +3517,100 @@
     </PropertyNotSetInConstructor>
   </file>
   <file src="test/PubSubHubbub/Model/SubscriptionTest.php">
-    <MissingReturnType occurrences="1">
+    <MissingReturnType>
       <code>createTable</code>
     </MissingReturnType>
-    <PossiblyUndefinedMethod occurrences="1">
+    <PossiblyUndefinedMethod>
       <code>execute</code>
     </PossiblyUndefinedMethod>
-    <RedundantConditionGivenDocblockType occurrences="1">
+    <RedundantConditionGivenDocblockType>
       <code>assertIsArray</code>
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="test/PubSubHubbub/PubSubHubbubTest.php">
-    <ArgumentTypeCoercion occurrences="1">
+    <ArgumentTypeCoercion>
       <code>$feed</code>
     </ArgumentTypeCoercion>
   </file>
   <file src="test/PubSubHubbub/PublisherTest.php">
-    <InvalidArgument occurrences="2">
+    <InvalidArgument>
       <code>123</code>
       <code>123</code>
     </InvalidArgument>
   </file>
   <file src="test/PubSubHubbub/Subscriber/CallbackTest.php">
-    <ArgumentTypeCoercion occurrences="4">
+    <ArgumentTypeCoercion>
       <code>$className</code>
       <code>$className</code>
       <code>'Result'</code>
       <code>'Result'</code>
     </ArgumentTypeCoercion>
-    <DeprecatedMethod occurrences="3">
+    <DeprecatedMethod>
       <code>setMethods</code>
       <code>setMethods</code>
       <code>setMethods</code>
     </DeprecatedMethod>
-    <InvalidArgument occurrences="3">
-      <code>$this-&gt;tableGateway</code>
+    <InvalidArgument>
+      <code><![CDATA[$this->tableGateway]]></code>
       <code>''</code>
       <code>new stdClass()</code>
     </InvalidArgument>
-    <InvalidPropertyAssignmentValue occurrences="3"/>
-    <MissingReturnType occurrences="1">
+    <InvalidPropertyAssignmentValue>
+      <code><![CDATA[$this->getCleanMock(
+            Adapter::class
+        )]]></code>
+      <code><![CDATA[$this->getCleanMock(
+            ResultSet::class
+        )]]></code>
+      <code><![CDATA[$this->getCleanMock(
+            TableGateway::class
+        )]]></code>
+    </InvalidPropertyAssignmentValue>
+    <MissingReturnType>
       <code>mockInputStream</code>
     </MissingReturnType>
-    <PossiblyUndefinedMethod occurrences="1">
+    <PossiblyUndefinedMethod>
       <code>getHeader</code>
     </PossiblyUndefinedMethod>
-    <UndefinedClass occurrences="2">
+    <UndefinedClass>
       <code>'Result'</code>
       <code>'Result'</code>
     </UndefinedClass>
-    <UnevaluatedCode occurrences="1">
-      <code>$this-&gt;assertFalse($this-&gt;callback-&gt;isValidHubVerification($this-&gt;get));</code>
+    <UnevaluatedCode>
+      <code><![CDATA[$this->assertFalse($this->callback->isValidHubVerification($this->get));]]></code>
     </UnevaluatedCode>
   </file>
   <file src="test/PubSubHubbub/SubscriberHttpTest.php">
-    <ArgumentTypeCoercion occurrences="2">
+    <ArgumentTypeCoercion>
       <code>$className</code>
       <code>$className</code>
     </ArgumentTypeCoercion>
-    <DeprecatedMethod occurrences="1">
+    <DeprecatedMethod>
       <code>setMethods</code>
     </DeprecatedMethod>
-    <InternalMethod occurrences="1">
+    <InternalMethod>
       <code>getName</code>
     </InternalMethod>
-    <InvalidArgument occurrences="1">
-      <code>$this-&gt;storage</code>
+    <InvalidArgument>
+      <code><![CDATA[$this->storage]]></code>
     </InvalidArgument>
-    <PossiblyFalsePropertyAssignmentValue occurrences="1">
+    <PossiblyFalsePropertyAssignmentValue>
       <code>getenv('TESTS_LAMINAS_FEED_PUBSUBHUBBUB_BASEURI')</code>
     </PossiblyFalsePropertyAssignmentValue>
-    <TooFewArguments occurrences="2">
+    <TooFewArguments>
       <code>getSubscription</code>
       <code>getSubscription</code>
     </TooFewArguments>
   </file>
   <file src="test/PubSubHubbub/SubscriberTest.php">
-    <ArgumentTypeCoercion occurrences="2">
+    <ArgumentTypeCoercion>
       <code>$className</code>
       <code>$className</code>
     </ArgumentTypeCoercion>
-    <DeprecatedMethod occurrences="1">
+    <DeprecatedMethod>
       <code>setMethods</code>
     </DeprecatedMethod>
-    <InvalidArgument occurrences="5">
+    <InvalidArgument>
       <code>'0aa'</code>
       <code>'10000'</code>
       <code>123</code>
@@ -3507,19 +3619,19 @@
     </InvalidArgument>
   </file>
   <file src="test/PubSubHubbub/TestAsset/Callback.php">
-    <MissingParamType occurrences="1">
+    <MissingParamType>
       <code>$sendResponseNow</code>
     </MissingParamType>
-    <PropertyNotSetInConstructor occurrences="2">
+    <PropertyNotSetInConstructor>
       <code>Callback</code>
       <code>Callback</code>
     </PropertyNotSetInConstructor>
   </file>
   <file src="test/Reader/Entry/AtomStandaloneEntryTest.php">
-    <RedundantCastGivenDocblockType occurrences="1">
-      <code>(array) $entry-&gt;getAuthors()</code>
+    <RedundantCastGivenDocblockType>
+      <code><![CDATA[(array) $entry->getAuthors()]]></code>
     </RedundantCastGivenDocblockType>
-    <UndefinedInterfaceMethod occurrences="6">
+    <UndefinedInterfaceMethod>
       <code>getCommentLink</code>
       <code>getContent</code>
       <code>getContent</code>
@@ -3529,16 +3641,16 @@
     </UndefinedInterfaceMethod>
   </file>
   <file src="test/Reader/Entry/AtomTest.php">
-    <PossiblyUndefinedMethod occurrences="2">
+    <PossiblyUndefinedMethod>
       <code>getBaseUrl</code>
       <code>getBaseUrl</code>
     </PossiblyUndefinedMethod>
   </file>
   <file src="test/Reader/Entry/CommonTest.php">
-    <MixedArgument occurrences="1">
-      <code>$entry-&gt;getElement()-&gt;tagName</code>
+    <MixedArgument>
+      <code><![CDATA[$entry->getElement()->tagName]]></code>
     </MixedArgument>
-    <PossiblyUndefinedMethod occurrences="12">
+    <PossiblyUndefinedMethod>
       <code>getDomDocument</code>
       <code>getElement</code>
       <code>getElement</code>
@@ -3554,10 +3666,10 @@
     </PossiblyUndefinedMethod>
   </file>
   <file src="test/Reader/Entry/RssTest.php">
-    <InvalidDocblock occurrences="1">
+    <InvalidDocblock>
       <code>public function dateModifiedProvider(): array</code>
     </InvalidDocblock>
-    <InvalidMethodCall occurrences="15">
+    <InvalidMethodCall>
       <code>getValues</code>
       <code>getValues</code>
       <code>getValues</code>
@@ -3574,10 +3686,10 @@
       <code>getValues</code>
       <code>getValues</code>
     </InvalidMethodCall>
-    <MixedInferredReturnType occurrences="1">
-      <code>array&lt;int,&lt;array{0:string,1:DateTimeInterface|null}&gt;&gt;</code>
+    <MixedInferredReturnType>
+      <code><![CDATA[array<int,<array{0:string,1:DateTimeInterface|null}>>]]></code>
     </MixedInferredReturnType>
-    <PossiblyNullReference occurrences="15">
+    <PossiblyNullReference>
       <code>getValues</code>
       <code>getValues</code>
       <code>getValues</code>
@@ -3596,15 +3708,15 @@
     </PossiblyNullReference>
   </file>
   <file src="test/Reader/ExtensionPluginManagerCompatibilityTest.php">
-    <InvalidReturnType occurrences="1">
+    <InvalidReturnType>
       <code>getInstanceOf</code>
     </InvalidReturnType>
   </file>
   <file src="test/Reader/Feed/AtomSourceTest.php">
-    <MixedArgument occurrences="1">
-      <code>$source-&gt;getCategories()-&gt;getValues()</code>
+    <MixedArgument>
+      <code><![CDATA[$source->getCategories()->getValues()]]></code>
     </MixedArgument>
-    <MixedAssignment occurrences="13">
+    <MixedAssignment>
       <code>$source</code>
       <code>$source</code>
       <code>$source</code>
@@ -3619,7 +3731,7 @@
       <code>$source</code>
       <code>$source</code>
     </MixedAssignment>
-    <MixedMethodCall occurrences="15">
+    <MixedMethodCall>
       <code>getAuthors</code>
       <code>getCategories</code>
       <code>getCategories</code>
@@ -3636,7 +3748,7 @@
       <code>getTitle</code>
       <code>getValues</code>
     </MixedMethodCall>
-    <PossiblyUndefinedMethod occurrences="15">
+    <PossiblyUndefinedMethod>
       <code>getSource</code>
       <code>getSource</code>
       <code>getSource</code>
@@ -3655,11 +3767,11 @@
     </PossiblyUndefinedMethod>
   </file>
   <file src="test/Reader/Feed/AtomTest.php">
-    <RedundantCastGivenDocblockType occurrences="2">
-      <code>(array) $feed-&gt;getAuthors()</code>
-      <code>(array) $feed-&gt;getAuthors()</code>
+    <RedundantCastGivenDocblockType>
+      <code><![CDATA[(array) $feed->getAuthors()]]></code>
+      <code><![CDATA[(array) $feed->getAuthors()]]></code>
     </RedundantCastGivenDocblockType>
-    <UndefinedInterfaceMethod occurrences="9">
+    <UndefinedInterfaceMethod>
       <code>getBaseUrl</code>
       <code>getHubs</code>
       <code>getHubs</code>
@@ -3672,7 +3784,7 @@
     </UndefinedInterfaceMethod>
   </file>
   <file src="test/Reader/Feed/CommonTest.php">
-    <UndefinedInterfaceMethod occurrences="9">
+    <UndefinedInterfaceMethod>
       <code>getDomDocument</code>
       <code>getElement</code>
       <code>getEncoding</code>
@@ -3685,7 +3797,7 @@
     </UndefinedInterfaceMethod>
   </file>
   <file src="test/Reader/Feed/RssTest.php">
-    <InvalidMethodCall occurrences="28">
+    <InvalidMethodCall>
       <code>getValues</code>
       <code>getValues</code>
       <code>getValues</code>
@@ -3715,37 +3827,37 @@
       <code>getValues</code>
       <code>getValues</code>
     </InvalidMethodCall>
-    <RedundantCastGivenDocblockType occurrences="28">
-      <code>(array) $feed-&gt;getAuthors()</code>
-      <code>(array) $feed-&gt;getAuthors()</code>
-      <code>(array) $feed-&gt;getAuthors()</code>
-      <code>(array) $feed-&gt;getAuthors()</code>
-      <code>(array) $feed-&gt;getAuthors()</code>
-      <code>(array) $feed-&gt;getAuthors()</code>
-      <code>(array) $feed-&gt;getAuthors()</code>
-      <code>(array) $feed-&gt;getAuthors()</code>
-      <code>(array) $feed-&gt;getAuthors()</code>
-      <code>(array) $feed-&gt;getAuthors()</code>
-      <code>(array) $feed-&gt;getAuthors()</code>
-      <code>(array) $feed-&gt;getAuthors()</code>
-      <code>(array) $feed-&gt;getAuthors()</code>
-      <code>(array) $feed-&gt;getAuthors()</code>
-      <code>(array) $feed-&gt;getAuthors()</code>
-      <code>(array) $feed-&gt;getAuthors()</code>
-      <code>(array) $feed-&gt;getAuthors()</code>
-      <code>(array) $feed-&gt;getAuthors()</code>
-      <code>(array) $feed-&gt;getAuthors()</code>
-      <code>(array) $feed-&gt;getAuthors()</code>
-      <code>(array) $feed-&gt;getAuthors()</code>
-      <code>(array) $feed-&gt;getAuthors()</code>
-      <code>(array) $feed-&gt;getAuthors()</code>
-      <code>(array) $feed-&gt;getAuthors()</code>
-      <code>(array) $feed-&gt;getAuthors()</code>
-      <code>(array) $feed-&gt;getAuthors()</code>
-      <code>(array) $feed-&gt;getAuthors()</code>
-      <code>(array) $feed-&gt;getAuthors()</code>
+    <RedundantCastGivenDocblockType>
+      <code><![CDATA[(array) $feed->getAuthors()]]></code>
+      <code><![CDATA[(array) $feed->getAuthors()]]></code>
+      <code><![CDATA[(array) $feed->getAuthors()]]></code>
+      <code><![CDATA[(array) $feed->getAuthors()]]></code>
+      <code><![CDATA[(array) $feed->getAuthors()]]></code>
+      <code><![CDATA[(array) $feed->getAuthors()]]></code>
+      <code><![CDATA[(array) $feed->getAuthors()]]></code>
+      <code><![CDATA[(array) $feed->getAuthors()]]></code>
+      <code><![CDATA[(array) $feed->getAuthors()]]></code>
+      <code><![CDATA[(array) $feed->getAuthors()]]></code>
+      <code><![CDATA[(array) $feed->getAuthors()]]></code>
+      <code><![CDATA[(array) $feed->getAuthors()]]></code>
+      <code><![CDATA[(array) $feed->getAuthors()]]></code>
+      <code><![CDATA[(array) $feed->getAuthors()]]></code>
+      <code><![CDATA[(array) $feed->getAuthors()]]></code>
+      <code><![CDATA[(array) $feed->getAuthors()]]></code>
+      <code><![CDATA[(array) $feed->getAuthors()]]></code>
+      <code><![CDATA[(array) $feed->getAuthors()]]></code>
+      <code><![CDATA[(array) $feed->getAuthors()]]></code>
+      <code><![CDATA[(array) $feed->getAuthors()]]></code>
+      <code><![CDATA[(array) $feed->getAuthors()]]></code>
+      <code><![CDATA[(array) $feed->getAuthors()]]></code>
+      <code><![CDATA[(array) $feed->getAuthors()]]></code>
+      <code><![CDATA[(array) $feed->getAuthors()]]></code>
+      <code><![CDATA[(array) $feed->getAuthors()]]></code>
+      <code><![CDATA[(array) $feed->getAuthors()]]></code>
+      <code><![CDATA[(array) $feed->getAuthors()]]></code>
+      <code><![CDATA[(array) $feed->getAuthors()]]></code>
     </RedundantCastGivenDocblockType>
-    <UndefinedInterfaceMethod occurrences="29">
+    <UndefinedInterfaceMethod>
       <code>getHubs</code>
       <code>getHubs</code>
       <code>getHubs</code>
@@ -3778,22 +3890,22 @@
     </UndefinedInterfaceMethod>
   </file>
   <file src="test/Reader/Http/LaminasHttpClientDecoratorTest.php">
-    <InvalidArgument occurrences="2">
+    <InvalidArgument>
       <code>$headers</code>
       <code>$responseHeaders</code>
     </InvalidArgument>
-    <MismatchingDocblockReturnType occurrences="1">
-      <code>MockObject&lt;Headers&gt;</code>
+    <MismatchingDocblockReturnType>
+      <code><![CDATA[MockObject<Headers>]]></code>
     </MismatchingDocblockReturnType>
-    <MixedArgument occurrences="3">
-      <code>$this-&gt;client</code>
-      <code>$this-&gt;client</code>
-      <code>$this-&gt;client</code>
+    <MixedArgument>
+      <code><![CDATA[$this->client]]></code>
+      <code><![CDATA[$this->client]]></code>
+      <code><![CDATA[$this->client]]></code>
     </MixedArgument>
-    <MixedInferredReturnType occurrences="1">
-      <code>MockObject&lt;Headers&gt;</code>
+    <MixedInferredReturnType>
+      <code><![CDATA[MockObject<Headers>]]></code>
     </MixedInferredReturnType>
-    <MixedMethodCall occurrences="31">
+    <MixedMethodCall>
       <code>expects</code>
       <code>expects</code>
       <code>expects</code>
@@ -3826,7 +3938,7 @@
       <code>with</code>
       <code>with</code>
     </MixedMethodCall>
-    <PossiblyUndefinedMethod occurrences="11">
+    <PossiblyUndefinedMethod>
       <code>expects</code>
       <code>expects</code>
       <code>expects</code>
@@ -3839,24 +3951,24 @@
       <code>expects</code>
       <code>expects</code>
     </PossiblyUndefinedMethod>
-    <TooManyTemplateParams occurrences="2">
-      <code>MockObject&lt;Headers&gt;</code>
-      <code>MockObject&lt;HttpResponse&gt;</code>
+    <TooManyTemplateParams>
+      <code><![CDATA[MockObject<Headers>]]></code>
+      <code><![CDATA[MockObject<HttpResponse>]]></code>
     </TooManyTemplateParams>
   </file>
   <file src="test/Reader/Http/ResponseTest.php">
-    <MissingReturnType occurrences="3">
+    <MissingReturnType>
       <code>testConstructorRaisesExceptionForInvalidBody</code>
       <code>testConstructorRaisesExceptionForInvalidHeaderStructures</code>
       <code>testConstructorRaisesExceptionForInvalidStatusCode</code>
     </MissingReturnType>
-    <MixedArgument occurrences="2">
+    <MixedArgument>
       <code>$body</code>
       <code>$statusCode</code>
     </MixedArgument>
   </file>
   <file src="test/Reader/Integration/GooglePlayPodcastRss2Test.php">
-    <PossiblyUndefinedMethod occurrences="17">
+    <PossiblyUndefinedMethod>
       <code>getCastAuthor</code>
       <code>getDuration</code>
       <code>getEncoding</code>
@@ -3875,7 +3987,7 @@
       <code>isClosedCaptioned</code>
       <code>isClosedCaptioned</code>
     </PossiblyUndefinedMethod>
-    <UndefinedInterfaceMethod occurrences="14">
+    <UndefinedInterfaceMethod>
       <code>getEncoding</code>
       <code>getNewFeedUrl</code>
       <code>getOwner</code>
@@ -3893,32 +4005,32 @@
     </UndefinedInterfaceMethod>
   </file>
   <file src="test/Reader/Integration/HOnlineComAtom10Test.php">
-    <PossiblyUndefinedMethod occurrences="1">
+    <PossiblyUndefinedMethod>
       <code>getEncoding</code>
     </PossiblyUndefinedMethod>
-    <RedundantCastGivenDocblockType occurrences="1">
-      <code>(array) $feed-&gt;getAuthors()</code>
+    <RedundantCastGivenDocblockType>
+      <code><![CDATA[(array) $feed->getAuthors()]]></code>
     </RedundantCastGivenDocblockType>
-    <UndefinedInterfaceMethod occurrences="1">
+    <UndefinedInterfaceMethod>
       <code>getEncoding</code>
     </UndefinedInterfaceMethod>
   </file>
   <file src="test/Reader/Integration/LautDeRdfTest.php">
-    <PossiblyUndefinedMethod occurrences="1">
+    <PossiblyUndefinedMethod>
       <code>getEncoding</code>
     </PossiblyUndefinedMethod>
-    <RedundantCastGivenDocblockType occurrences="1">
-      <code>(array) $feed-&gt;getAuthors()</code>
+    <RedundantCastGivenDocblockType>
+      <code><![CDATA[(array) $feed->getAuthors()]]></code>
     </RedundantCastGivenDocblockType>
-    <UndefinedInterfaceMethod occurrences="1">
+    <UndefinedInterfaceMethod>
       <code>getEncoding</code>
     </UndefinedInterfaceMethod>
   </file>
   <file src="test/Reader/Integration/PodcastRss2Test.php">
-    <MixedAssignment occurrences="1">
+    <MixedAssignment>
       <code>$keywords</code>
     </MixedAssignment>
-    <PossiblyUndefinedMethod occurrences="18">
+    <PossiblyUndefinedMethod>
       <code>getBlock</code>
       <code>getCastAuthor</code>
       <code>getDuration</code>
@@ -3938,7 +4050,7 @@
       <code>isClosedCaptioned</code>
       <code>isClosedCaptioned</code>
     </PossiblyUndefinedMethod>
-    <UndefinedInterfaceMethod occurrences="13">
+    <UndefinedInterfaceMethod>
       <code>getBlock</code>
       <code>getCastAuthor</code>
       <code>getEncoding</code>
@@ -3955,29 +4067,29 @@
     </UndefinedInterfaceMethod>
   </file>
   <file src="test/Reader/Integration/WordpressAtom10Test.php">
-    <PossiblyUndefinedMethod occurrences="1">
+    <PossiblyUndefinedMethod>
       <code>getEncoding</code>
     </PossiblyUndefinedMethod>
-    <RedundantCastGivenDocblockType occurrences="1">
-      <code>(array) $feed-&gt;getAuthors()</code>
+    <RedundantCastGivenDocblockType>
+      <code><![CDATA[(array) $feed->getAuthors()]]></code>
     </RedundantCastGivenDocblockType>
-    <UndefinedInterfaceMethod occurrences="1">
+    <UndefinedInterfaceMethod>
       <code>getEncoding</code>
     </UndefinedInterfaceMethod>
   </file>
   <file src="test/Reader/Integration/WordpressRss2DcAtomTest.php">
-    <PossiblyUndefinedMethod occurrences="1">
+    <PossiblyUndefinedMethod>
       <code>getEncoding</code>
     </PossiblyUndefinedMethod>
-    <RedundantCastGivenDocblockType occurrences="1">
-      <code>(array) $feed-&gt;getAuthors()</code>
+    <RedundantCastGivenDocblockType>
+      <code><![CDATA[(array) $feed->getAuthors()]]></code>
     </RedundantCastGivenDocblockType>
-    <UndefinedInterfaceMethod occurrences="1">
+    <UndefinedInterfaceMethod>
       <code>getEncoding</code>
     </UndefinedInterfaceMethod>
   </file>
   <file src="test/Reader/ReaderTest.php">
-    <ArgumentTypeCoercion occurrences="10">
+    <ArgumentTypeCoercion>
       <code>$feed</code>
       <code>$feed</code>
       <code>$feed</code>
@@ -3989,99 +4101,120 @@
       <code>$feed</code>
       <code>$feed</code>
     </ArgumentTypeCoercion>
-    <DeprecatedMethod occurrences="2">
+    <DeprecatedMethod>
       <code>setMethods</code>
       <code>setMethods</code>
     </DeprecatedMethod>
-    <InvalidArgument occurrences="2">
+    <InvalidArgument>
       <code>new stdClass()</code>
+      <code><![CDATA[static function (int $errno, string $errstr) use ($notices): void {
+            $notices->messages[] = $errstr;
+        }]]></code>
     </InvalidArgument>
-    <InvalidArrayOffset occurrences="1">
+    <InvalidArrayOffset>
       <code>$link['feed']</code>
     </InvalidArrayOffset>
-    <MixedArgument occurrences="1">
+    <MixedArgument>
       <code>$message</code>
     </MixedArgument>
-    <PossiblyUndefinedMethod occurrences="2">
+    <PossiblyUndefinedMethod>
       <code>$link</code>
       <code>getEncoding</code>
     </PossiblyUndefinedMethod>
-    <UndefinedInterfaceMethod occurrences="1">
+    <UndefinedInterfaceMethod>
       <code>getEncoding</code>
     </UndefinedInterfaceMethod>
   </file>
   <file src="test/Reader/TestAsset/CustomExtensionManager.php">
-    <DeprecatedInterface occurrences="1">
+    <DeprecatedInterface>
       <code>CustomExtensionManager</code>
     </DeprecatedInterface>
-    <LessSpecificReturnStatement occurrences="1">
+    <LessSpecificReturnStatement>
       <code>new $class()</code>
     </LessSpecificReturnStatement>
-    <MixedMethodCall occurrences="1">
+    <MixedMethodCall>
       <code>new $class()</code>
     </MixedMethodCall>
-    <MoreSpecificReturnType occurrences="1">
+    <MoreSpecificReturnType>
       <code>Extension\AbstractEntry|Extension\AbstractFeed</code>
     </MoreSpecificReturnType>
   </file>
   <file src="test/Reader/_files/My/Extension/JungleBooks/Entry.php">
-    <MixedAssignment occurrences="1">
+    <MixedAssignment>
       <code>$isbn</code>
     </MixedAssignment>
   </file>
   <file src="test/Reader/_files/My/Extension/JungleBooks/Feed.php">
-    <MixedAssignment occurrences="1">
+    <MixedAssignment>
       <code>$dayPopular</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="1">
+    <MixedInferredReturnType>
       <code>null|string</code>
     </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="1">
-      <code>$this-&gt;data['dayPopular']</code>
+    <MixedReturnStatement>
+      <code><![CDATA[$this->data['dayPopular']]]></code>
     </MixedReturnStatement>
   </file>
   <file src="test/Writer/DeletedTest.php">
-    <DocblockTypeContradiction occurrences="1">
+    <DocblockTypeContradiction>
       <code>assertNull</code>
     </DocblockTypeContradiction>
-    <InvalidArgument occurrences="1">
+    <InvalidArgument>
       <code>'abc'</code>
     </InvalidArgument>
-    <UnevaluatedCode occurrences="3">
+    <UnevaluatedCode>
       <code>$entry = new Writer\Deleted();</code>
-      <code>$entry-&gt;setBy(['name' =&gt; 'Joe', 'uri' =&gt; 'notauri']);</code>
-      <code>$this-&gt;expectException(Writer\Exception\ExceptionInterface::class);</code>
+      <code><![CDATA[$entry->setBy(['name' => 'Joe', 'uri' => 'notauri']);]]></code>
+      <code><![CDATA[$this->expectException(Writer\Exception\ExceptionInterface::class);]]></code>
     </UnevaluatedCode>
   </file>
   <file src="test/Writer/EntryTest.php">
-    <InvalidArgument occurrences="3">
+    <InvalidArgument>
       <code>'abc'</code>
       <code>'abc'</code>
+      <code><![CDATA[static function (int $_errno, string $errstr) use ($notices): ?bool {
+            $notices->messages[] = $errstr;
+
+            return null;
+        }]]></code>
     </InvalidArgument>
-    <MixedArgument occurrences="2">
+    <MixedArgument>
       <code>$count</code>
       <code>$message</code>
     </MixedArgument>
-    <NullArgument occurrences="1">
+    <NullArgument>
       <code>null</code>
     </NullArgument>
-    <UnevaluatedCode occurrences="9">
+    <UnevaluatedCode>
       <code>$entry = new Writer\Entry();</code>
       <code>$entry = new Writer\Entry();</code>
       <code>$entry = new Writer\Entry();</code>
-      <code>$this-&gt;expectException(ExceptionInterface::class);</code>
-      <code>$this-&gt;expectException(ExceptionInterface::class);</code>
-      <code>$this-&gt;expectException(ExceptionInterface::class);</code>
+      <code><![CDATA[$entry->setCommentFeedLink([
+            'uri'  => '',
+            'type' => 'rdf',
+        ]);]]></code>
+      <code><![CDATA[$entry->setEnclosure([
+            'type'   => 'audio/mpeg',
+            'length' => '1337',
+        ]);]]></code>
+      <code><![CDATA[$entry->setEnclosure([
+            'type'   => 'audio/mpeg',
+            'uri'    => 'http://',
+            'length' => '1337',
+        ]);]]></code>
+      <code><![CDATA[$this->expectException(ExceptionInterface::class);]]></code>
+      <code><![CDATA[$this->expectException(ExceptionInterface::class);]]></code>
+      <code><![CDATA[$this->expectException(ExceptionInterface::class);]]></code>
     </UnevaluatedCode>
   </file>
   <file src="test/Writer/Extension/GooglePlayPodcast/FeedTest.php">
-    <MissingReturnType occurrences="2">
+    <MissingReturnType>
       <code>testSetPlayPodcastImageRaisesExceptionForInvalidUrl</code>
       <code>testSetPlayPodcastImageSetsInternalDataWithValidUrl</code>
     </MissingReturnType>
   </file>
   <file src="test/Writer/Extension/ITunes/EntryTest.php">
-    <MissingReturnType occurrences="8">
+    <MissingReturnType>
       <code>testEpisodeTypeMaybeMutatedWithAcceptedValues</code>
       <code>testSetEpisodeRaisesExceptionForNonNumericEpisodeNumbers</code>
       <code>testSetEpisodeTypeRaisesExceptionForInvalidTypes</code>
@@ -4093,7 +4226,7 @@
     </MissingReturnType>
   </file>
   <file src="test/Writer/Extension/ITunes/FeedTest.php">
-    <MissingReturnType occurrences="6">
+    <MissingReturnType>
       <code>testSetExplicit</code>
       <code>testSetItunesCompleteRaisesExceptionForInvalidStatus</code>
       <code>testSetItunesImageRaisesExceptionForInvalidUrl</code>
@@ -4103,98 +4236,122 @@
     </MissingReturnType>
   </file>
   <file src="test/Writer/FeedFactoryTest.php">
-    <InvalidArgument occurrences="1">
+    <InvalidArgument>
       <code>'string'</code>
     </InvalidArgument>
-    <InvalidMethodCall occurrences="1">
+    <InvalidMethodCall>
       <code>format</code>
     </InvalidMethodCall>
-    <PossiblyNullReference occurrences="1">
+    <PossiblyNullReference>
       <code>format</code>
     </PossiblyNullReference>
   </file>
   <file src="test/Writer/FeedTest.php">
-    <InvalidArgument occurrences="1"/>
-    <InvalidMethodCall occurrences="4">
+    <InvalidArgument>
+      <code><![CDATA[static function (int $errno, string $errstr) use ($notices): void {
+            $notices->messages[] = $errstr;
+        }]]></code>
+    </InvalidArgument>
+    <InvalidMethodCall>
       <code>getTimestamp</code>
       <code>getTimestamp</code>
       <code>getTimestamp</code>
       <code>getTimestamp</code>
     </InvalidMethodCall>
-    <MixedArgument occurrences="1">
+    <MixedArgument>
       <code>$message</code>
     </MixedArgument>
-    <UnevaluatedCode occurrences="9">
-      <code>$this-&gt;expectException(ExceptionInterface::class);</code>
-      <code>$this-&gt;expectException(ExceptionInterface::class);</code>
-      <code>$this-&gt;expectException(Writer\Exception\InvalidArgumentException::class);</code>
+    <UnevaluatedCode>
+      <code><![CDATA[$this->expectException(ExceptionInterface::class);]]></code>
+      <code><![CDATA[$this->expectException(ExceptionInterface::class);]]></code>
+      <code><![CDATA[$this->expectException(Writer\Exception\InvalidArgumentException::class);]]></code>
       <code>$writer = new Writer\Feed();</code>
       <code>$writer = new Writer\Feed();</code>
       <code>$writer = new Writer\Feed();</code>
-      <code>$writer-&gt;setGenerator('LaminasW', null, 'notauri');</code>
+      <code><![CDATA[$writer->addAuthor([
+            'name' => 'Joe',
+            'uri'  => 'notauri',
+        ]);]]></code>
+      <code><![CDATA[$writer->setGenerator('LaminasW', null, 'notauri');]]></code>
+      <code><![CDATA[$writer->setGenerator([
+            'name' => 'LaminasW',
+            'uri'  => 'notauri',
+        ]);]]></code>
     </UnevaluatedCode>
   </file>
   <file src="test/Writer/Renderer/Entry/AtomTest.php">
-    <InvalidArgument occurrences="1"/>
-    <MixedArgument occurrences="1">
+    <InvalidArgument>
+      <code><![CDATA[static function (int $errno, string $errstr) use ($notices): void {
+            $notices->messages[] = $errstr;
+        }]]></code>
+    </InvalidArgument>
+    <MixedArgument>
       <code>$message</code>
     </MixedArgument>
-    <PossiblyNullPropertyFetch occurrences="3">
-      <code>$enc-&gt;length</code>
-      <code>$enc-&gt;type</code>
-      <code>$enc-&gt;url</code>
+    <PossiblyNullPropertyFetch>
+      <code><![CDATA[$enc->length]]></code>
+      <code><![CDATA[$enc->type]]></code>
+      <code><![CDATA[$enc->url]]></code>
     </PossiblyNullPropertyFetch>
-    <PossiblyNullReference occurrences="2">
+    <PossiblyNullReference>
       <code>getTimestamp</code>
       <code>getTimestamp</code>
     </PossiblyNullReference>
-    <PossiblyUndefinedMethod occurrences="2">
+    <PossiblyUndefinedMethod>
       <code>getEncoding</code>
       <code>getEncoding</code>
     </PossiblyUndefinedMethod>
-    <TooManyArguments occurrences="1">
+    <TooManyArguments>
       <code>getCommentFeedLink</code>
     </TooManyArguments>
-    <UnevaluatedCode occurrences="6">
-      <code>$atomFeed = new Renderer\Feed\Atom($this-&gt;validWriter);</code>
-      <code>$atomFeed-&gt;render();</code>
-      <code>$this-&gt;expectException(ExceptionInterface::class);</code>
-      <code>$this-&gt;validEntry-&gt;remove('id');</code>
-      <code>$this-&gt;validEntry-&gt;remove('link');</code>
-      <code>$this-&gt;validEntry-&gt;setId('not-a-uri');</code>
+    <UnevaluatedCode>
+      <code><![CDATA[$atomFeed = new Renderer\Feed\Atom($this->validWriter);]]></code>
+      <code><![CDATA[$atomFeed->render();]]></code>
+      <code><![CDATA[$this->expectException(ExceptionInterface::class);]]></code>
+      <code><![CDATA[$this->validEntry->remove('id');]]></code>
+      <code><![CDATA[$this->validEntry->remove('link');]]></code>
+      <code><![CDATA[$this->validEntry->setId('not-a-uri');]]></code>
     </UnevaluatedCode>
   </file>
   <file src="test/Writer/Renderer/Entry/RssTest.php">
-    <InvalidArgument occurrences="1"/>
-    <MixedArgument occurrences="1">
+    <InvalidArgument>
+      <code><![CDATA[static function (int $errno, string $errstr) use ($notices): void {
+            $notices->messages[] = $errstr;
+        }]]></code>
+    </InvalidArgument>
+    <MixedArgument>
       <code>$message</code>
     </MixedArgument>
-    <PossiblyNullPropertyFetch occurrences="3">
-      <code>$enc-&gt;length</code>
-      <code>$enc-&gt;type</code>
-      <code>$enc-&gt;url</code>
+    <PossiblyNullPropertyFetch>
+      <code><![CDATA[$enc->length]]></code>
+      <code><![CDATA[$enc->type]]></code>
+      <code><![CDATA[$enc->url]]></code>
     </PossiblyNullPropertyFetch>
-    <PossiblyNullReference occurrences="2">
+    <PossiblyNullReference>
       <code>getTimestamp</code>
       <code>getTimestamp</code>
     </PossiblyNullReference>
-    <PossiblyUndefinedMethod occurrences="2">
+    <PossiblyUndefinedMethod>
       <code>getEncoding</code>
       <code>getEncoding</code>
     </PossiblyUndefinedMethod>
-    <TooManyArguments occurrences="1">
+    <TooManyArguments>
       <code>getCommentFeedLink</code>
     </TooManyArguments>
   </file>
   <file src="test/Writer/Renderer/Feed/AtomTest.php">
-    <InvalidArgument occurrences="1"/>
-    <MixedArgument occurrences="1">
+    <InvalidArgument>
+      <code><![CDATA[static function (int $errno, string $errstr) use ($notices): void {
+            $notices->messages[] = $errstr;
+        }]]></code>
+    </InvalidArgument>
+    <MixedArgument>
       <code>$message</code>
     </MixedArgument>
-    <PossiblyNullReference occurrences="1">
+    <PossiblyNullReference>
       <code>getTimestamp</code>
     </PossiblyNullReference>
-    <UndefinedInterfaceMethod occurrences="5">
+    <UndefinedInterfaceMethod>
       <code>getBaseUrl</code>
       <code>getEncoding</code>
       <code>getEncoding</code>
@@ -4203,21 +4360,25 @@
     </UndefinedInterfaceMethod>
   </file>
   <file src="test/Writer/Renderer/Feed/RssTest.php">
-    <InvalidArgument occurrences="1"/>
-    <MixedArgument occurrences="2">
-      <code>$feed-&gt;getDomDocument()</code>
+    <InvalidArgument>
+      <code><![CDATA[static function (int $errno, string $errstr) use ($notices): void {
+            $notices->messages[] = $errstr;
+        }]]></code>
+    </InvalidArgument>
+    <MixedArgument>
+      <code><![CDATA[$feed->getDomDocument()]]></code>
       <code>$message</code>
     </MixedArgument>
-    <MixedMethodCall occurrences="1">
+    <MixedMethodCall>
       <code>getTimestamp</code>
     </MixedMethodCall>
-    <MixedPropertyFetch occurrences="1">
-      <code>$xpath-&gt;evaluate('/rss/channel/atom:link[@rel="self"]')-&gt;length</code>
+    <MixedPropertyFetch>
+      <code><![CDATA[$xpath->evaluate('/rss/channel/atom:link[@rel="self"]')->length]]></code>
     </MixedPropertyFetch>
-    <PossiblyNullReference occurrences="1">
+    <PossiblyNullReference>
       <code>getTimestamp</code>
     </PossiblyNullReference>
-    <UndefinedInterfaceMethod occurrences="8">
+    <UndefinedInterfaceMethod>
       <code>getBaseUrl</code>
       <code>getDomDocument</code>
       <code>getEncoding</code>
@@ -4229,17 +4390,17 @@
     </UndefinedInterfaceMethod>
   </file>
   <file src="test/Writer/StandaloneExtensionManagerTest.php">
-    <MixedAssignment occurrences="3">
+    <MixedAssignment>
       <code>$extension</code>
       <code>$extension</code>
       <code>$test</code>
     </MixedAssignment>
   </file>
   <file src="test/Writer/TestAsset/CustomExtensionManager.php">
-    <DeprecatedInterface occurrences="1">
+    <DeprecatedInterface>
       <code>CustomExtensionManager</code>
     </DeprecatedInterface>
-    <MixedMethodCall occurrences="1">
+    <MixedMethodCall>
       <code>new $class()</code>
     </MixedMethodCall>
   </file>

--- a/src/Reader/ExtensionPluginManager.php
+++ b/src/Reader/ExtensionPluginManager.php
@@ -7,7 +7,6 @@ namespace Laminas\Feed\Reader;
 use Laminas\Feed\Reader\Extension\AbstractEntry;
 use Laminas\Feed\Reader\Extension\AbstractFeed;
 use Laminas\ServiceManager\AbstractPluginManager;
-use Laminas\ServiceManager\ConfigInterface;
 use Laminas\ServiceManager\Exception\InvalidServiceException;
 use Laminas\ServiceManager\Factory\InvokableFactory;
 
@@ -22,7 +21,6 @@ use function sprintf;
  * Validation checks that we have an Extension\AbstractEntry or
  * Extension\AbstractFeed.
  *
- * @psalm-import-type FactoriesConfigurationType from ConfigInterface
  * @final this class wasn't designed to be inherited from, but we can't assume that consumers haven't already
  *        extended it, therefore we cannot add the final marker without a new major release.
  * @template InstanceType of AbstractEntry|AbstractFeed
@@ -33,7 +31,7 @@ class ExtensionPluginManager extends AbstractPluginManager implements ExtensionM
     /**
      * Aliases for default set of extension classes
      *
-     * @var array<array-key, string>
+     * @inheritDoc
      */
     protected $aliases = [
         'atomentry'               => Extension\Atom\Entry::class,
@@ -143,8 +141,7 @@ class ExtensionPluginManager extends AbstractPluginManager implements ExtensionM
     /**
      * Factories for default set of extension classes
      *
-     * @var array<array-key, callable|string>
-     * @psalm-var FactoriesConfigurationType
+     * @inheritDoc
      */
     protected $factories = [
         Extension\Atom\Entry::class              => InvokableFactory::class,

--- a/src/Writer/ExtensionPluginManager.php
+++ b/src/Writer/ExtensionPluginManager.php
@@ -7,7 +7,6 @@ namespace Laminas\Feed\Writer;
 use Laminas\Feed\Writer\Extension\GooglePlayPodcast\Feed;
 use Laminas\Feed\Writer\Extension\ITunes\Entry;
 use Laminas\ServiceManager\AbstractPluginManager;
-use Laminas\ServiceManager\ConfigInterface;
 use Laminas\ServiceManager\Exception\InvalidServiceException;
 use Laminas\ServiceManager\Factory\InvokableFactory;
 
@@ -22,7 +21,6 @@ use function substr;
  *
  * Validation checks that we have an Entry, Feed, or Extension\AbstractRenderer.
  *
- * @psalm-import-type FactoriesConfigurationType from ConfigInterface
  * @template InstanceType of Extension\AbstractRenderer|Entry|Feed|Entry|\Laminas\Feed\Writer\Extension\ITunes\Feed|\Laminas\Feed\Writer\Extension\PodcastIndex\Entry|\Laminas\Feed\Writer\Extension\PodcastIndex\Feed
  * @template-extends AbstractPluginManager<InstanceType>
  */
@@ -31,7 +29,7 @@ class ExtensionPluginManager extends AbstractPluginManager implements ExtensionM
     /**
      * Aliases for default set of extension classes
      *
-     * @var array<array-key, string>
+     * @inheritDoc
      */
     protected $aliases = [
         // phpcs:disable Generic.Files.LineLength.TooLong
@@ -176,7 +174,7 @@ class ExtensionPluginManager extends AbstractPluginManager implements ExtensionM
     /**
      * Factories for default set of extension classes
      *
-     * @var FactoriesConfigurationType
+     * @inheritDoc
      */
     protected $factories = [
         Extension\Atom\Renderer\Feed::class               => InvokableFactory::class,

--- a/test/PubSubHubbub/AbstractCallbackTest.php
+++ b/test/PubSubHubbub/AbstractCallbackTest.php
@@ -23,7 +23,6 @@ class AbstractCallbackTest extends TestCase
         $callback = new TestAsset\Callback();
 
         $r = new ReflectionMethod($callback, '_detectCallbackUrl');
-        $r->setAccessible(true);
 
         $this->assertSame('/requested/path', $r->invoke($callback));
     }
@@ -38,7 +37,6 @@ class AbstractCallbackTest extends TestCase
         $callback = new TestAsset\Callback();
 
         $r = new ReflectionMethod($callback, '_detectCallbackUrl');
-        $r->setAccessible(true);
 
         $this->assertSame('/requested/path', $r->invoke($callback));
     }
@@ -52,7 +50,6 @@ class AbstractCallbackTest extends TestCase
         $callback = new TestAsset\Callback();
 
         $r = new ReflectionMethod($callback, '_detectCallbackUrl');
-        $r->setAccessible(true);
 
         $this->assertSame('/expected/path', $r->invoke($callback));
     }
@@ -66,7 +63,6 @@ class AbstractCallbackTest extends TestCase
         $callback = new TestAsset\Callback();
 
         $r = new ReflectionMethod($callback, '_detectCallbackUrl');
-        $r->setAccessible(true);
 
         $this->assertSame('/expected/path', $r->invoke($callback));
     }
@@ -76,7 +72,6 @@ class AbstractCallbackTest extends TestCase
         $callback = new TestAsset\Callback();
 
         $r = new ReflectionMethod($callback, '_detectCallbackUrl');
-        $r->setAccessible(true);
 
         $this->assertSame('', $r->invoke($callback));
     }

--- a/test/PubSubHubbub/Subscriber/CallbackTest.php
+++ b/test/PubSubHubbub/Subscriber/CallbackTest.php
@@ -103,7 +103,6 @@ class CallbackTest extends TestCase
         rewind($inputStream);
 
         $r = new ReflectionProperty($callback, 'inputStream');
-        $r->setAccessible(true);
         $r->setValue($callback, $inputStream);
     }
 

--- a/test/Reader/ExtensionPluginManagerCompatibilityTest.php
+++ b/test/Reader/ExtensionPluginManagerCompatibilityTest.php
@@ -20,7 +20,7 @@ class ExtensionPluginManagerCompatibilityTest extends TestCase
      * @psalm-suppress ImplementedReturnTypeMismatch
      * @return ExtensionPluginManager
      */
-    protected function getPluginManager()
+    protected static function getPluginManager()
     {
         return new ExtensionPluginManager(new ServiceManager());
     }

--- a/test/Reader/FeedSetTest.php
+++ b/test/Reader/FeedSetTest.php
@@ -27,7 +27,6 @@ class FeedSetTest extends TestCase
     public function testAbsolutiseUri($link, $uri, $result): void
     {
         $method = new ReflectionMethod(FeedSet::class, 'absolutiseUri');
-        $method->setAccessible(true);
 
         $this->assertEquals($result, $method->invoke($this->feedSet, $link, $uri));
     }

--- a/test/Writer/ExtensionPluginManagerCompatibilityTest.php
+++ b/test/Writer/ExtensionPluginManagerCompatibilityTest.php
@@ -20,7 +20,7 @@ class ExtensionPluginManagerCompatibilityTest extends TestCase
      * @psalm-suppress ImplementedReturnTypeMismatch
      * @return ExtensionPluginManager
      */
-    protected function getPluginManager()
+    protected static function getPluginManager()
     {
         return new ExtensionPluginManager(new ServiceManager());
     }


### PR DESCRIPTION
Further to discussion in #75, removing the hard-dependency on laminas/service-manager here allows consumers to use the component in projects that require `psr/container:2`, providing they only use the `StandaloneExtensionManager` for `Reader\` and `Writer\`