### PR TITLE
Move header value normalisation into Response

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@
 /laminas-mkdoc-theme/
 /phpunit.xml
 /vendor/
+
+.idea

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.14.1@b9d355e0829c397b9b3b47d0c0ed042a8a70284d">
+<files psalm-version="5.15.0@5c774aca4746caf3d239d9c8cadb9f882ca29352">
   <file src="src/PubSubHubbub/AbstractCallback.php">
     <DocblockTypeContradiction>
       <code><![CDATA[$this->httpResponse === null]]></code>
@@ -2217,11 +2217,7 @@
     </UnsafeInstantiation>
   </file>
   <file src="src/Reader/Http/LaminasHttpClientDecorator.php">
-    <MixedArgumentTypeCoercion>
-      <code>$value</code>
-    </MixedArgumentTypeCoercion>
     <MixedAssignment>
-      <code>$normalized[$name]</code>
       <code>$value</code>
       <code>$value</code>
     </MixedAssignment>

--- a/src/Reader/Http/LaminasHttpClientDecorator.php
+++ b/src/Reader/Http/LaminasHttpClientDecorator.php
@@ -9,7 +9,6 @@ use Laminas\Http\Client as LaminasHttpClient;
 use Laminas\Http\Headers;
 
 use function gettype;
-use function implode;
 use function is_array;
 use function is_numeric;
 use function is_object;
@@ -47,10 +46,12 @@ class LaminasHttpClientDecorator implements HeaderAwareClientInterface
         }
         $response = $this->client->send();
 
+        $headers = $response->getHeaders()->toArray();
+
         return new Response(
             $response->getStatusCode(),
             $response->getBody(),
-            $this->prepareResponseHeaders($response->getHeaders())
+            $headers
         );
     }
 
@@ -93,22 +94,5 @@ class LaminasHttpClientDecorator implements HeaderAwareClientInterface
                 $headers->addHeaderLine($name, $value);
             }
         }
-    }
-
-    /**
-     * Normalize headers to use with HeaderAwareResponseInterface.
-     *
-     * Ensures multi-value headers are represented as a single string, via
-     * comma concatenation.
-     *
-     * @return array
-     */
-    private function prepareResponseHeaders(Headers $headers)
-    {
-        $normalized = [];
-        foreach ($headers->toArray() as $name => $value) {
-            $normalized[$name] = is_array($value) ? implode(', ', $value) : $value;
-        }
-        return $normalized;
     }
 }

--- a/src/Reader/Http/Response.php
+++ b/src/Reader/Http/Response.php
@@ -144,13 +144,26 @@ class Response implements HeaderAwareResponseInterface
                 ));
             }
 
-            if (! is_string($value) && ! is_numeric($value)) {
+            if (! is_string($value) && ! is_numeric($value) && ! is_array($value)) {
                 throw new Exception\InvalidArgumentException(sprintf(
                     'Individual header values provided to %s must be a string or numeric; received %s for header %s',
                     self::class,
                     is_object($value) ? $value::class : gettype($value),
                     $name
                 ));
+            }
+
+            if (is_array($value)) {
+                foreach ($value as $key => $multiValue) {
+                    if (! is_string($multiValue) && ! is_numeric($multiValue)) {
+                        throw new Exception\InvalidArgumentException(sprintf(
+                            'Individual header values provided to %s must be a string or numeric; received %s for header %s',
+                            self::class,
+                            is_object($multiValue) ? $multiValue::class : gettype($multiValue),
+                            $name . "[$key]"
+                        ));
+                    }
+                }
             }
         }
     }

--- a/src/Reader/Http/Response.php
+++ b/src/Reader/Http/Response.php
@@ -7,7 +7,9 @@ namespace Laminas\Feed\Reader\Http;
 use Laminas\Feed\Reader\Exception;
 
 use function gettype;
+use function implode;
 use function intval;
+use function is_array;
 use function is_numeric;
 use function is_object;
 use function is_string;
@@ -155,6 +157,8 @@ class Response implements HeaderAwareResponseInterface
 
     /**
      * Normalize header names to lowercase.
+     * Also ensures multi-value headers are represented as a single string, via
+     * comma concatenation.
      *
      * @return array
      */
@@ -162,7 +166,7 @@ class Response implements HeaderAwareResponseInterface
     {
         $normalized = [];
         foreach ($headers as $name => $value) {
-            $normalized[strtolower($name)] = $value;
+            $normalized[strtolower($name)] = is_array($value) ? implode(', ', $value) : $value;
         }
         return $normalized;
     }

--- a/test/Reader/Http/LaminasHttpClientDecoratorTest.php
+++ b/test/Reader/Http/LaminasHttpClientDecoratorTest.php
@@ -234,6 +234,8 @@ class LaminasHttpClientDecoratorTest extends TestCase
         foreach ($invalidIndividualValues as $key => $value) {
             yield $key => [['X-Test' => [$value]], 'strings or numbers'];
         }
+
+        // todo: expand here with multi values.
     }
 
     /**

--- a/test/Reader/Http/ResponseTest.php
+++ b/test/Reader/Http/ResponseTest.php
@@ -43,7 +43,8 @@ class ResponseTest extends TestCase
             'Location'         => 'http://example.org/foo',
             'Content-Length'   => 1234,
             'X-Content-Length' => 1234.56,
-            'MultiValue'       => ['one', 'two']
+            'MultiValue'       => ['one', 'two'],
+            'MultiValue2'      => [1, 2],
 
         ]);
         $this->assertEquals(204, $response->getStatusCode());
@@ -170,6 +171,11 @@ class ResponseTest extends TestCase
                 ['X-Test' => [(object) ['body' => 'BODY']]],
                 'must be a string or numeric',
             ],
+            // todo: expand this with more combinations?
+            'mixed-values-in-array' => [
+                ['X-Test' => ['valid', false]],
+                'must be a string or numeric',
+            ]
         ];
     }
 

--- a/test/Reader/Http/ResponseTest.php
+++ b/test/Reader/Http/ResponseTest.php
@@ -43,6 +43,8 @@ class ResponseTest extends TestCase
             'Location'         => 'http://example.org/foo',
             'Content-Length'   => 1234,
             'X-Content-Length' => 1234.56,
+            'MultiValue'       => ['one', 'two']
+
         ]);
         $this->assertEquals(204, $response->getStatusCode());
         $this->assertEquals('', $response->getBody());
@@ -148,12 +150,24 @@ class ResponseTest extends TestCase
                 ['X-Test' => false],
                 'must be a string or numeric',
             ],
-            'array-value'  => [
-                ['X-Test' => ['BODY']],
-                'must be a string or numeric',
-            ],
             'object-value' => [
                 ['X-Test' => (object) ['body' => 'BODY']],
+                'must be a string or numeric',
+            ],
+            'null-value-in-array'   => [
+                ['X-Test' => [null]],
+                'must be a string or numeric',
+            ],
+            'true-value-in-array'   => [
+                ['X-Test' => [true]],
+                'must be a string or numeric',
+            ],
+            'false-value-in-array'  => [
+                ['X-Test' => [false]],
+                'must be a string or numeric',
+            ],
+            'object-value-in-array' => [
+                ['X-Test' => [(object) ['body' => 'BODY']]],
                 'must be a string or numeric',
             ],
         ];


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: default X.Y.z branch or the oldest support X.Y.z
  * Bugfix: default X.Y.z branch or the oldest support X.Y.z
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: default X.Y.z branch or the oldest support X.Y.z
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | yes
| QA            | yes/no

### Description

When not using laminas-http as the HTTP client the implementation of the `HeaderAwareClientInterface` one may have to reproduce the logic to normalise headers from multi value to string as it is done in [here](https://github.com/laminas/laminas-feed/blob/2.23.x/src/Reader/Http/LaminasHttpClientDecorator.php#L106). 

I am partial about whether what I am doing here is right (or desired) or wrong (will have problems), so it is more of a question, in the form of a PR for clarity.

The benefit of this change is that when implementing the interfaces needed to inject a third party client, one does not need to deal with the case of multi value headers and can reuse the Response class provided (`Laminas\Feed\Reader\Http\Response`), therefore only one implementation is needed implementing `HeaderAwareClientInterface`. 

I am relatively new to the codebase so let me know if I have missed some profound/foundational concern here. I can see a slight violation of single responsibility principle here.

On the other hand, it is a (micro?) optimisation as the loop through the headers only happens once. 

Lastly, given this is desired, maybe a unit test case should be added as well as an addition in the docs explaining the above "convenience". Ofc I am willing to do these and any other changes requested but I thought it would be nice if first it is acknowledged that the direction is desired.

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you adding documentation?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->
