### PR TITLE
Fix type-safety for `ExtensionPluginManager`

### DIFF
--- a/src/Reader/ExtensionPluginManager.php
+++ b/src/Reader/ExtensionPluginManager.php
@@ -33,7 +33,7 @@ class ExtensionPluginManager extends AbstractPluginManager implements ExtensionM
      *
      * @inheritDoc
      */
-    protected $aliases = [
+    protected array $aliases = [
         'atomentry'               => Extension\Atom\Entry::class,
         'atomEntry'               => Extension\Atom\Entry::class,
         'AtomEntry'               => Extension\Atom\Entry::class,
@@ -143,7 +143,7 @@ class ExtensionPluginManager extends AbstractPluginManager implements ExtensionM
      *
      * @inheritDoc
      */
-    protected $factories = [
+    protected array $factories = [
         Extension\Atom\Entry::class              => InvokableFactory::class,
         Extension\Atom\Feed::class               => InvokableFactory::class,
         Extension\Content\Entry::class           => InvokableFactory::class,
@@ -197,10 +197,10 @@ class ExtensionPluginManager extends AbstractPluginManager implements ExtensionM
      *
      * @var bool
      */
-    protected $sharedByDefault = false;
+    protected bool $sharedByDefault = false;
 
     /** @inheritDoc */
-    public function validate(mixed $instance)
+    public function validate(mixed $instance) : void
     {
         if (
             $instance instanceof AbstractEntry


### PR DESCRIPTION
This fixes a few type definitions that were missing when defining instances within `ExtensionPluginManager`, resulting in a complete white-screen when `error_reporting(E_ALL)` is enabled.

For instance, [`PluginManagerInterface::validate`](https://github.com/laminas/laminas-servicemanager/blob/4.3.x/src/PluginManagerInterface.php#L27) expects to return `void`.

This change fixes the following...

>Got error 'PHP message: PHP Fatal error:  Declaration of Laminas\\Feed\\Reader\\ExtensionPluginManager::validate(mixed $instance) must be compatible with Laminas\\ServiceManager\\PluginManagerInterface::validate(mixed $instance): void in /var/www/html/vendor/laminas/laminas-feed/src/Reader/ExtensionPluginManager.php on line 203'

<!--
Fill in the relevant information below to help triage your issue.

Assuming the current release is 1.5.0, the next patch release is 1.5.1, the next minor is 1.6.0 and the next major is 2.0.0, The Current release branch will be `1.5.x`, the next minor branch will be `1.6.x`, and the next major branch will be `2.0.x`

Pick the target branch based on the following criteria:
  * Documentation improvement: Current release branch 1.5.x
  * Bugfix: Current release branch 1.5.x
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: Next minor 1.6.x
  * New feature, or refactor of existing code: Next minor 1.6.x
  * Backwards incompatible features and refactoring: Next major 2.0.x

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

### Description

- Are you fixing a bug or providing a failing unit test to demonstrate a bug? Yes, this fixes type safety issues in the inherited class.
  - How do you reproduce it? Use `error_reporting(E_ALL)`, and inherit from `laminas-service` 4.3
  - What did you expect to happen? For there to not be any type errors.
  - What actually happened? It reported the above error
  - TARGET THE CURRENT RELEASE BRANCH

- Are you adding documentation? No.
  - TARGET THE CURRENT RELEASE BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior? No, there is no behavior change.
  - Explain why the changes are necessary. The change is required for type-safety across the PHP classes.
  - TARGET THE NEXT MINOR BRANCH

- Are you fixing a BC Break? Unsure.
  - How do you reproduce it? Use `error_reporting(E_ALL)`
  - What was the previous behavior? Things work without the error reporting.
  - What is the current behavior? Things break when you're using error reporting.
  - TARGET THE CURRENT RELEASE BRANCH

- Are you adding something the library currently does not support? No.

- Are you refactoring code? No.
