### PR TITLE
Fix: Unable to create feed item with 'magnet' URL scheme

### DIFF
--- a/src/Uri.php
+++ b/src/Uri.php
@@ -46,6 +46,7 @@ class Uri
         'http',
         'https',
         'file',
+        'magnet',
     ];
 
     /**


### PR DESCRIPTION
Fixes #93

This is needed for [BEP 36](https://www.bittorrent.org/beps/bep_0036.html):

> For the purpose of the BEP, the term torrent link will be used to identify any kind of URL identifying a torrent. This may be either an HTTP or HTTPS URL pointing to a .torrent file or a [magnet link](https://www.bittorrent.org/beps/bep0009.html) identifying a torrent info-hash.

> The enclosure tag MUST have a type attribute set to "application/x-bittorrent" and MUST store the torrent link in a url attribute.