### PR TITLE
Podcastindex extensions for feed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /laminas-mkdoc-theme/
 /phpunit.xml
 /vendor/
+/.idea

--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,3 @@
 /laminas-mkdoc-theme/
 /phpunit.xml
 /vendor/
-/.idea

--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
     "require": {
         "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
         "ext-dom": "*",
+        "ext-filter": "*",
         "ext-libxml": "*",
         "laminas/laminas-escaper": "^2.9",
         "laminas/laminas-stdlib": "^3.6"

--- a/docs/book/extensions/podcast-index.md
+++ b/docs/book/extensions/podcast-index.md
@@ -16,13 +16,16 @@ GET |
 `getLocation()` | Returns funding information. The output is an object with "description", "geo" and "osm" properties.
 `getImages()` | Returns information on responsive images. The output is an object with a "srcset" property.
 `getUpdateFrequency()` | Returns information on the intended release schedule. The output is an object with "description", "complete", "dtstart" and "rrule" properties.
+`getPersons()` | Returns credits for hosts and guests. The output is an array of objects with "name", "role", "group", "img" and "href" properties.
 SET |
 `setPodcastIndexLocked()` | Expects an array with the required keys "value" and "owner".
 `setPodcastIndexFunding()` | Expects an array with the required keys "title" and "url".
 `setPodcastIndexLicense()` | Expects an array with the required keys "identifier" and "url".
 `setPodcastIndexLocation()` | Expects an array with the required key "description" and the optional keys "geo" and "osm".
 `setPodcastIndexImages()` | Expects an array with the required key "srcset".
-`setPodcastIndexUpdateFrequency()` | Expects an array with the required key "description" and the optional keys "complete" (bool), "dtstart" (ISO8601 string) and "rrule" properties.
+`setPodcastIndexUpdateFrequency()` | Expects an array with the required key "description" and the optional keys "complete" (bool), "dtstart" (ISO8601 string) and "rrule".
+`addPodcastIndexPerson()` | Expects an array with the required key "name" and the optional keys "role", "group", "img" and "href".
+`setPodcastIndexPersons()` | Expects an array of objects with each the required key "name" and the optional keys "role", "group", "img" and "href".
 
 ### Episode API methods:
 

--- a/docs/book/extensions/podcast-index.md
+++ b/docs/book/extensions/podcast-index.md
@@ -9,16 +9,16 @@ single namespace.
 
 ### GET methods
 
-| Method                 | Description                                                                                                                                        |
-|------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------|
-| `isLocked()`           | Returns whether the feed is open for importing to new platforms.                                                                                   |
-| `getLockOwner()`       | Returns the email address for owner verification.                                                                                                  |
-| `getFunding()`         | Returns funding information. The output is an object with "url" and "value" properties.                                                            |
-| `getLicense()`         | Returns license information. The output is an object with "identifier" and "url" properties.                                                       |
-| `getLocation()`        | Returns funding information. The output is an object with "description", "geo" and "osm" properties.                                               |
-| `getImages()`          | Returns information on responsive images. The output is an object with a "srcset" property.                                                        |
-| `getUpdateFrequency()` | Returns information on the intended release schedule. The output is an object with "description", "complete", "dtstart" and "rrule" properties.    |
-| `getPersons()`         | Returns information on the involved people. The output is an array of objects, each with the properties "name", "role", "group", "img" and "href". |
+| Method                                        | Description                                                                                                                                        |
+|-----------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------|
+| `isLocked()`                                  | Returns whether the feed is open for importing to new platforms.                                                                                   |
+| `getLockOwner()` `getPodcastIndexLockOwner()` | Returns the email address for owner verification.                                                                                                  |
+| `getFunding()` `getPodcastIndexFunding()`     | Returns funding information. The output is an object with "url" and "value" properties.                                                            |
+| `getPodcastIndexLicense()`                    | Returns license information. The output is an object with "identifier" and "url" properties.                                                       |
+| `getPodcastIndexLocation()`                   | Returns funding information. The output is an object with "description", "geo" and "osm" properties.                                               |
+| `getPodcastIndexImages()`                     | Returns information on responsive images. The output is an object with a "srcset" property.                                                        |
+| `getPodcastIndexUpdateFrequency()`            | Returns information on the intended release schedule. The output is an object with "description", "complete", "dtstart" and "rrule" properties.    |
+| `getPodcastIndexPersons()`                    | Returns information on the involved people. The output is an array of objects, each with the properties "name", "role", "group", "img" and "href". |
 
 ### SET methods
 

--- a/docs/book/extensions/podcast-index.md
+++ b/docs/book/extensions/podcast-index.md
@@ -4,11 +4,11 @@ The Podcast Index Extension adds support for the [Podcast Index RSS namespace](h
 an open source project which consolidates new features for podcasts into a
 single namespace.
 
-### Channel API methods:
+## Channel API 
 
+### GET methods
 Method | Description
 ------ | -----------
-GET |
 `isLocked()` | Returns whether the feed is open for importing to new platforms.
 `getLockOwner()` | Returns the email address for owner verification.
 `getFunding()` | Returns funding information. The output is an object with "url" and "value" properties.
@@ -16,8 +16,10 @@ GET |
 `getLocation()` | Returns funding information. The output is an object with "description", "geo" and "osm" properties.
 `getImages()` | Returns information on responsive images. The output is an object with a "srcset" property.
 `getUpdateFrequency()` | Returns information on the intended release schedule. The output is an object with "description", "complete", "dtstart" and "rrule" properties.
-`getPersons()` | Returns credits for hosts and guests. The output is an array of objects with "name", "role", "group", "img" and "href" properties.
-SET |
+
+### SET methods
+Method | Description
+------ | -----------
 `setPodcastIndexLocked()` | Expects an array with the required keys "value" and "owner".
 `setPodcastIndexFunding()` | Expects an array with the required keys "title" and "url".
 `setPodcastIndexLicense()` | Expects an array with the required keys "identifier" and "url".
@@ -27,15 +29,18 @@ SET |
 `addPodcastIndexPerson()` | Expects an array with the required key "name" and the optional keys "role", "group", "img" and "href".
 `setPodcastIndexPersons()` | Expects an array of objects with each the required key "name" and the optional keys "role", "group", "img" and "href".
 
-### Episode API methods:
+## Episode API
 
+### GET methods
 Method | Description
 ------ | -----------
-GET |
 `getTranscript()` | Returns transcript information for the entry. The output is an object with "url", "type", "language" and "rel" properties.
 `getChapters()` | Returns chapter information for the entry. The output is an object with "url" and "type" properties.
 `getSoundbites()` | Returns soundbites for the entry. The output is an array of objects with "title", "startTime" and "duration" properties.
-SET |
+
+### SET methods
+Method | Description
+------ | -----------
 `setPodcastIndexTranscript()` | Expects an array with the required keys "url" and "type", and with the optional keys "language" and "rel".
 `setPodcastIndexChapters()` | Expects an array with the required keys "url" and "type".
 `addPodcastIndexSoundbites()` | Expects an array of soundbite entries, each itself an array with the required keys "title" and "startTime", and with the optional key "duration".

--- a/docs/book/extensions/podcast-index.md
+++ b/docs/book/extensions/podcast-index.md
@@ -18,7 +18,7 @@ single namespace.
 | `getPodcastIndexLocation()`                   | Returns funding information. The output is an object with "description", "geo" and "osm" properties.                                               |
 | `getPodcastIndexImages()`                     | Returns information on responsive images. The output is an object with a "srcset" property.                                                        |
 | `getPodcastIndexUpdateFrequency()`            | Returns information on the intended release schedule. The output is an object with "description", "complete", "dtstart" and "rrule" properties.    |
-| `getPodcastIndexPersons()`                    | Returns information on the involved people. The output is an array of objects, each with the properties "name", "role", "group", "img" and "href". |
+| `getPodcastIndexPeople()`                    | Returns information on the involved people. The output is an array of objects, each with the properties "name", "role", "group", "img" and "href". |
 
 ### SET methods
 
@@ -31,7 +31,7 @@ single namespace.
 | `setPodcastIndexImages()`          | Expects an array with the required key "srcset".                                                                                      |
 | `setPodcastIndexUpdateFrequency()` | Expects an array with the required key "description" and the optional keys "complete" (bool), "dtstart" (ISO8601 string) and "rrule". |
 | `addPodcastIndexPerson()`          | Expects an array with the required key "name" and the optional keys "role", "group", "img" and "href".                                |
-| `setPodcastIndexPersons()`         | Expects an array of objects with each the required key "name" and the optional keys "role", "group", "img" and "href".                |
+| `setPodcastIndexPeople()`         | Expects an array of objects with each the required key "name" and the optional keys "role", "group", "img" and "href".                |
 
 ## Episode API
 

--- a/docs/book/extensions/podcast-index.md
+++ b/docs/book/extensions/podcast-index.md
@@ -1,49 +1,55 @@
 # Podcast Index
 
-The Podcast Index Extension adds support for the [Podcast Index RSS namespace](https://github.com/Podcastindex-org/podcast-namespace/blob/main/docs/1.0.md),
+The Podcast Index Extension adds support for
+the [Podcast Index RSS namespace](https://github.com/Podcastindex-org/podcast-namespace/blob/main/docs/1.0.md),
 an open source project which consolidates new features for podcasts into a
 single namespace.
 
-## Channel API 
+## Channel API
 
 ### GET methods
-Method | Description
------- | -----------
-`isLocked()` | Returns whether the feed is open for importing to new platforms.
-`getLockOwner()` | Returns the email address for owner verification.
-`getFunding()` | Returns funding information. The output is an object with "url" and "value" properties.
-`getLicense()` | Returns license information. The output is an object with "identifier" and "url" properties.
-`getLocation()` | Returns funding information. The output is an object with "description", "geo" and "osm" properties.
-`getImages()` | Returns information on responsive images. The output is an object with a "srcset" property.
-`getUpdateFrequency()` | Returns information on the intended release schedule. The output is an object with "description", "complete", "dtstart" and "rrule" properties.
+
+| Method                 | Description                                                                                                                                        |
+|------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------|
+| `isLocked()`           | Returns whether the feed is open for importing to new platforms.                                                                                   |
+| `getLockOwner()`       | Returns the email address for owner verification.                                                                                                  |
+| `getFunding()`         | Returns funding information. The output is an object with "url" and "value" properties.                                                            |
+| `getLicense()`         | Returns license information. The output is an object with "identifier" and "url" properties.                                                       |
+| `getLocation()`        | Returns funding information. The output is an object with "description", "geo" and "osm" properties.                                               |
+| `getImages()`          | Returns information on responsive images. The output is an object with a "srcset" property.                                                        |
+| `getUpdateFrequency()` | Returns information on the intended release schedule. The output is an object with "description", "complete", "dtstart" and "rrule" properties.    |
+| `getPersons()`         | Returns information on the involved people. The output is an array of objects, each with the properties "name", "role", "group", "img" and "href". |
 
 ### SET methods
-Method | Description
------- | -----------
-`setPodcastIndexLocked()` | Expects an array with the required keys "value" and "owner".
-`setPodcastIndexFunding()` | Expects an array with the required keys "title" and "url".
-`setPodcastIndexLicense()` | Expects an array with the required keys "identifier" and "url".
-`setPodcastIndexLocation()` | Expects an array with the required key "description" and the optional keys "geo" and "osm".
-`setPodcastIndexImages()` | Expects an array with the required key "srcset".
-`setPodcastIndexUpdateFrequency()` | Expects an array with the required key "description" and the optional keys "complete" (bool), "dtstart" (ISO8601 string) and "rrule".
-`addPodcastIndexPerson()` | Expects an array with the required key "name" and the optional keys "role", "group", "img" and "href".
-`setPodcastIndexPersons()` | Expects an array of objects with each the required key "name" and the optional keys "role", "group", "img" and "href".
+
+| Method                             | Description                                                                                                                           |
+|------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------|
+| `setPodcastIndexLocked()`          | Expects an array with the required keys "value" and "owner".                                                                          |
+| `setPodcastIndexFunding()`         | Expects an array with the required keys "title" and "url".                                                                            |
+| `setPodcastIndexLicense()`         | Expects an array with the required keys "identifier" and "url".                                                                       |
+| `setPodcastIndexLocation()`        | Expects an array with the required key "description" and the optional keys "geo" and "osm".                                           |
+| `setPodcastIndexImages()`          | Expects an array with the required key "srcset".                                                                                      |
+| `setPodcastIndexUpdateFrequency()` | Expects an array with the required key "description" and the optional keys "complete" (bool), "dtstart" (ISO8601 string) and "rrule". |
+| `addPodcastIndexPerson()`          | Expects an array with the required key "name" and the optional keys "role", "group", "img" and "href".                                |
+| `setPodcastIndexPersons()`         | Expects an array of objects with each the required key "name" and the optional keys "role", "group", "img" and "href".                |
 
 ## Episode API
 
 ### GET methods
-Method | Description
------- | -----------
-`getTranscript()` | Returns transcript information for the entry. The output is an object with "url", "type", "language" and "rel" properties.
-`getChapters()` | Returns chapter information for the entry. The output is an object with "url" and "type" properties.
-`getSoundbites()` | Returns soundbites for the entry. The output is an array of objects with "title", "startTime" and "duration" properties.
+
+| Method            | Description                                                                                                                |
+|-------------------|----------------------------------------------------------------------------------------------------------------------------|
+| `getTranscript()` | Returns transcript information for the entry. The output is an object with "url", "type", "language" and "rel" properties. |
+| `getChapters()`   | Returns chapter information for the entry. The output is an object with "url" and "type" properties.                       |
+| `getSoundbites()` | Returns soundbites for the entry. The output is an array of objects with "title", "startTime" and "duration" properties.   |
 
 ### SET methods
-Method | Description
------- | -----------
-`setPodcastIndexTranscript()` | Expects an array with the required keys "url" and "type", and with the optional keys "language" and "rel".
-`setPodcastIndexChapters()` | Expects an array with the required keys "url" and "type".
-`addPodcastIndexSoundbites()` | Expects an array of soundbite entries, each itself an array with the required keys "title" and "startTime", and with the optional key "duration".
+
+| Method                        | Description                                                                                                                                       |
+|-------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------|
+| `setPodcastIndexTranscript()` | Expects an array with the required keys "url" and "type", and with the optional keys "language" and "rel".                                        |
+| `setPodcastIndexChapters()`   | Expects an array with the required keys "url" and "type".                                                                                         |
+| `addPodcastIndexSoundbites()` | Expects an array of soundbite entries, each itself an array with the required keys "title" and "startTime", and with the optional key "duration". |
 
 See the [Podcast Index website](https://podcastindex.org) for more information
 about the project.

--- a/docs/book/extensions/podcast-index.md
+++ b/docs/book/extensions/podcast-index.md
@@ -14,11 +14,13 @@ GET |
 `getFunding()` | Returns funding information. The output is an object with "url" and "value" properties.
 `getLicense()` | Returns license information. The output is an object with "identifier" and "url" properties.
 `getLocation()` | Returns funding information. The output is an object with "description", "geo" and "osm" properties.
+`getImages()` | Returns information on responsive images. The output is an object with a "srcset" property.
 SET |
 `setPodcastIndexLocked()` | Expects an array with the required keys "value" and "owner".
 `setPodcastIndexFunding()` | Expects an array with the required keys "title" and "url".
 `setPodcastIndexLicense()` | Expects an array with the required keys "identifier" and "url".
 `setPodcastIndexLocation()` | Expects an array with the required key "description" and the optional keys "geo" and "osm".
+`setPodcastIndexImages()` | Expects an array with the required key "srcset".
 
 ### Episode API methods:
 

--- a/docs/book/extensions/podcast-index.md
+++ b/docs/book/extensions/podcast-index.md
@@ -4,21 +4,34 @@ The Podcast Index Extension adds support for the [Podcast Index RSS namespace](h
 an open source project which consolidates new features for podcasts into a
 single namespace.
 
-Channel API methods:
+### Channel API methods:
 
 Method | Description
 ------ | -----------
+GET |
 `isLocked()` | Returns whether the feed is open for importing to new platforms.
 `getLockOwner()` | Returns the email address for owner verification.
 `getFunding()` | Returns funding information. The output is an object with "url" and "value" properties.
+`getLicense()` | Returns license information. The output is an object with "identifier" and "url" properties.
+`getLocation()` | Returns funding information. The output is an object with "description", "geo" and "osm" properties.
+SET |
+`setPodcastIndexLocked()` | Expects an array with the required keys "value" and "owner".
+`setPodcastIndexFunding()` | Expects an array with the required keys "title" and "url".
+`setPodcastIndexLicense()` | Expects an array with the required keys "identifier" and "url".
+`setPodcastIndexLocation()` | Expects an array with the required key "description" and the optional keys "geo" and "osm".
 
-Item API methods:
+### Episode API methods:
 
 Method | Description
 ------ | -----------
-`getTranscript()` | Returns transcript information for the entry. The output is an object with "url", "type", "language" and "rel" properties/
+GET |
+`getTranscript()` | Returns transcript information for the entry. The output is an object with "url", "type", "language" and "rel" properties.
 `getChapters()` | Returns chapter information for the entry. The output is an object with "url" and "type" properties.
 `getSoundbites()` | Returns soundbites for the entry. The output is an array of objects with "title", "startTime" and "duration" properties.
+SET |
+`setPodcastIndexTranscript()` | Expects an array with the required keys "url" and "type", and with the optional keys "language" and "rel".
+`setPodcastIndexChapters()` | Expects an array with the required keys "url" and "type".
+`addPodcastIndexSoundbites()` | Expects an array of soundbite entries, each itself an array with the required keys "title" and "startTime", and with the optional key "duration".
 
 See the [Podcast Index website](https://podcastindex.org) for more information
 about the project.

--- a/docs/book/extensions/podcast-index.md
+++ b/docs/book/extensions/podcast-index.md
@@ -15,12 +15,14 @@ GET |
 `getLicense()` | Returns license information. The output is an object with "identifier" and "url" properties.
 `getLocation()` | Returns funding information. The output is an object with "description", "geo" and "osm" properties.
 `getImages()` | Returns information on responsive images. The output is an object with a "srcset" property.
+`getUpdateFrequency()` | Returns information on the intended release schedule. The output is an object with "description", "complete", "dtstart" and "rrule" properties.
 SET |
 `setPodcastIndexLocked()` | Expects an array with the required keys "value" and "owner".
 `setPodcastIndexFunding()` | Expects an array with the required keys "title" and "url".
 `setPodcastIndexLicense()` | Expects an array with the required keys "identifier" and "url".
 `setPodcastIndexLocation()` | Expects an array with the required key "description" and the optional keys "geo" and "osm".
 `setPodcastIndexImages()` | Expects an array with the required key "srcset".
+`setPodcastIndexUpdateFrequency()` | Expects an array with the required key "description" and the optional keys "complete" (bool), "dtstart" (ISO8601 string) and "rrule" properties.
 
 ### Episode API methods:
 

--- a/docs/book/extensions/podcast-index.md
+++ b/docs/book/extensions/podcast-index.md
@@ -18,7 +18,7 @@ single namespace.
 | `getPodcastIndexLocation()`                   | Returns funding information. The output is an object with "description", "geo" and "osm" properties.                                               |
 | `getPodcastIndexImages()`                     | Returns information on responsive images. The output is an object with a "srcset" property.                                                        |
 | `getPodcastIndexUpdateFrequency()`            | Returns information on the intended release schedule. The output is an object with "description", "complete", "dtstart" and "rrule" properties.    |
-| `getPodcastIndexPeople()`                    | Returns information on the involved people. The output is an array of objects, each with the properties "name", "role", "group", "img" and "href". |
+| `getPodcastIndexPeople()`                     | Returns information on the involved people. The output is an array of objects, each with the properties "name", "role", "group", "img" and "href". |
 
 ### SET methods
 
@@ -31,7 +31,7 @@ single namespace.
 | `setPodcastIndexImages()`          | Expects an array with the required key "srcset".                                                                                      |
 | `setPodcastIndexUpdateFrequency()` | Expects an array with the required key "description" and the optional keys "complete" (bool), "dtstart" (ISO8601 string) and "rrule". |
 | `addPodcastIndexPerson()`          | Expects an array with the required key "name" and the optional keys "role", "group", "img" and "href".                                |
-| `setPodcastIndexPeople()`         | Expects an array of objects with each the required key "name" and the optional keys "role", "group", "img" and "href".                |
+| `setPodcastIndexPeople()`          | Expects an array of objects with each the required key "name" and the optional keys "role", "group", "img" and "href".                |
 
 ## Episode API
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -3107,6 +3107,12 @@
       <code>setEncoding</code>
       <code>setPodcastIndexFunding</code>
       <code>setPodcastIndexLocked</code>
+      <code>setPodcastIndexLicense</code>
+      <code>setPodcastIndexLocation</code>
+      <code>setPodcastIndexImages</code>
+      <code>setPodcastIndexUpdateFrequency</code>
+      <code>addPodcastIndexPerson</code>
+      <code>setPodcastIndexPersons</code>
     </PossiblyUnusedMethod>
     <PossiblyUnusedParam>
       <code>$params</code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.18.0@b113f3ed0259fd6e212d87c3df80eec95a6abf19">
+<files psalm-version="5.19.0@06b71be009a6bd6d81b9811855d6629b9fe90e1b">
   <file src="src/PubSubHubbub/AbstractCallback.php">
     <DocblockTypeContradiction>
       <code><![CDATA[$this->httpResponse === null]]></code>
@@ -3096,18 +3096,34 @@
     </PossiblyUnusedProperty>
   </file>
   <file src="src/Writer/Extension/PodcastIndex/Feed.php">
+    <DocblockTypeContradiction>
+      <code><![CDATA[! is_string($value['url'])]]></code>
+      <code><![CDATA[is_string($value['description'])]]></code>
+      <code><![CDATA[is_string($value['description'])]]></code>
+      <code><![CDATA[is_string($value['identifier'])]]></code>
+      <code><![CDATA[is_string($value['name'])]]></code>
+      <code><![CDATA[is_string($value['srcset'])]]></code>
+      <code><![CDATA[isset($value['complete']) && ! is_bool($value['complete'])]]></code>
+      <code><![CDATA[isset($value['dtstart']) && ! is_string($value['dtstart'])]]></code>
+      <code><![CDATA[isset($value['geo']) && ! is_string($value['geo'])]]></code>
+      <code><![CDATA[isset($value['osm']) && ! is_string($value['osm'])]]></code>
+      <code><![CDATA[isset($value['rrule']) && ! is_string($value['rrule'])]]></code>
+    </DocblockTypeContradiction>
+    <MixedArgumentTypeCoercion>
+      <code>$value</code>
+    </MixedArgumentTypeCoercion>
     <PossiblyUnusedMethod>
       <code>__call</code>
       <code>__construct</code>
       <code>getEncoding</code>
       <code>setEncoding</code>
       <code>setPodcastIndexFunding</code>
-      <code>setPodcastIndexLocked</code>
+      <code>setPodcastIndexImages</code>
       <code>setPodcastIndexLicense</code>
       <code>setPodcastIndexLocation</code>
-      <code>setPodcastIndexImages</code>
-      <code>setPodcastIndexUpdateFrequency</code>
+      <code>setPodcastIndexLocked</code>
       <code>setPodcastIndexPersons</code>
+      <code>setPodcastIndexUpdateFrequency</code>
     </PossiblyUnusedMethod>
     <PossiblyUnusedParam>
       <code>$params</code>
@@ -3132,12 +3148,12 @@
   <file src="src/Writer/Extension/PodcastIndex/Renderer/Feed.php">
     <MixedMethodCall>
       <code>getPodcastIndexFunding</code>
-      <code>getPodcastIndexLocked</code>
+      <code>getPodcastIndexImages</code>
       <code>getPodcastIndexLicense</code>
       <code>getPodcastIndexLocation</code>
-      <code>getPodcastIndexImages</code>
-      <code>getPodcastIndexUpdateFrequency</code>
+      <code>getPodcastIndexLocked</code>
       <code>getPodcastIndexPersons</code>
+      <code>getPodcastIndexUpdateFrequency</code>
     </MixedMethodCall>
     <RedundantCastGivenDocblockType>
       <code><![CDATA[(string) $funding['title']]]></code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -3122,7 +3122,7 @@
       <code>setPodcastIndexLicense</code>
       <code>setPodcastIndexLocation</code>
       <code>setPodcastIndexLocked</code>
-      <code>setPodcastIndexPersons</code>
+      <code>setPodcastIndexPeople</code>
       <code>setPodcastIndexUpdateFrequency</code>
     </PossiblyUnusedMethod>
     <PossiblyUnusedParam>
@@ -3152,7 +3152,7 @@
       <code>getPodcastIndexLicense</code>
       <code>getPodcastIndexLocation</code>
       <code>getPodcastIndexLocked</code>
-      <code>getPodcastIndexPersons</code>
+      <code>getPodcastIndexPeople</code>
       <code>getPodcastIndexUpdateFrequency</code>
     </MixedMethodCall>
     <RedundantCastGivenDocblockType>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -3106,14 +3106,11 @@
       <code><![CDATA[isset($value['complete']) && ! is_bool($value['complete'])]]></code>
       <code><![CDATA[isset($value['dtstart']) && ! is_string($value['dtstart'])]]></code>
       <code><![CDATA[isset($value['geo']) && ! is_string($value['geo'])]]></code>
-      <code><![CDATA[isset($value['osm']) && ! is_string($value['osm'])]]></code>
-      <code><![CDATA[isset($value['rrule']) && ! is_string($value['rrule'])]]></code>
-      <code><![CDATA[isset($value['role']) && ! is_string($value['role'])]]></code>
       <code><![CDATA[isset($value['group']) && ! is_string($value['group'])]]></code>
+      <code><![CDATA[isset($value['osm']) && ! is_string($value['osm'])]]></code>
+      <code><![CDATA[isset($value['role']) && ! is_string($value['role'])]]></code>
+      <code><![CDATA[isset($value['rrule']) && ! is_string($value['rrule'])]]></code>
     </DocblockTypeContradiction>
-    <MixedArgumentTypeCoercion>
-      <code>$value</code>
-    </MixedArgumentTypeCoercion>
     <PossiblyUnusedMethod>
       <code>__call</code>
       <code>__construct</code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -3104,7 +3104,6 @@
       <code><![CDATA[is_string($value['name'])]]></code>
       <code><![CDATA[is_string($value['srcset'])]]></code>
       <code><![CDATA[isset($value['complete']) && ! is_bool($value['complete'])]]></code>
-      <code><![CDATA[isset($value['dtstart']) && ! is_string($value['dtstart'])]]></code>
       <code><![CDATA[isset($value['geo']) && ! is_string($value['geo'])]]></code>
       <code><![CDATA[isset($value['group']) && ! is_string($value['group'])]]></code>
       <code><![CDATA[isset($value['osm']) && ! is_string($value['osm'])]]></code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -3144,15 +3144,6 @@
     </RedundantCastGivenDocblockType>
   </file>
   <file src="src/Writer/Extension/PodcastIndex/Renderer/Feed.php">
-    <MixedMethodCall>
-      <code>getPodcastIndexFunding</code>
-      <code>getPodcastIndexImages</code>
-      <code>getPodcastIndexLicense</code>
-      <code>getPodcastIndexLocation</code>
-      <code>getPodcastIndexLocked</code>
-      <code>getPodcastIndexPeople</code>
-      <code>getPodcastIndexUpdateFrequency</code>
-    </MixedMethodCall>
     <RedundantCastGivenDocblockType>
       <code><![CDATA[(string) $funding['title']]]></code>
       <code><![CDATA[(string) $locked['value']]]></code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1582,9 +1582,6 @@
     </MixedReturnStatement>
   </file>
   <file src="src/Reader/Extension/PodcastIndex/Feed.php">
-    <MismatchingDocblockReturnType>
-      <code>null|object{url: string, title: string}</code>
-    </MismatchingDocblockReturnType>
     <MixedAssignment>
       <code>$locked</code>
       <code>$owner</code>
@@ -1592,7 +1589,6 @@
     <MixedInferredReturnType>
       <code>?string</code>
       <code>bool</code>
-      <code>null|object{url: string, title: string}</code>
     </MixedInferredReturnType>
     <MixedReturnStatement>
       <code><![CDATA[$this->data['locked']]]></code>
@@ -3111,7 +3107,6 @@
       <code>setPodcastIndexLocation</code>
       <code>setPodcastIndexImages</code>
       <code>setPodcastIndexUpdateFrequency</code>
-      <code>addPodcastIndexPerson</code>
       <code>setPodcastIndexPersons</code>
     </PossiblyUnusedMethod>
     <PossiblyUnusedParam>
@@ -3138,6 +3133,11 @@
     <MixedMethodCall>
       <code>getPodcastIndexFunding</code>
       <code>getPodcastIndexLocked</code>
+      <code>getPodcastIndexLicense</code>
+      <code>getPodcastIndexLocation</code>
+      <code>getPodcastIndexImages</code>
+      <code>getPodcastIndexUpdateFrequency</code>
+      <code>getPodcastIndexPersons</code>
     </MixedMethodCall>
     <RedundantCastGivenDocblockType>
       <code><![CDATA[(string) $funding['title']]]></code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -3108,6 +3108,8 @@
       <code><![CDATA[isset($value['geo']) && ! is_string($value['geo'])]]></code>
       <code><![CDATA[isset($value['osm']) && ! is_string($value['osm'])]]></code>
       <code><![CDATA[isset($value['rrule']) && ! is_string($value['rrule'])]]></code>
+      <code><![CDATA[isset($value['role']) && ! is_string($value['role'])]]></code>
+      <code><![CDATA[isset($value['group']) && ! is_string($value['group'])]]></code>
     </DocblockTypeContradiction>
     <MixedArgumentTypeCoercion>
       <code>$value</code>

--- a/src/Reader/Extension/PodcastIndex/Feed.php
+++ b/src/Reader/Extension/PodcastIndex/Feed.php
@@ -107,6 +107,33 @@ class Feed extends Extension\AbstractFeed
     }
 
     /**
+     * Get the podcast location
+     *
+     * @psalm-return null|object{text: string, geo: string, osm: string}
+     */
+    public function getLocation(): ?stdClass
+    {
+        if (array_key_exists('location', $this->data)) {
+            return $this->data['location'];
+        }
+
+        $location = null;
+
+        $nodeList = $this->xpath->query($this->getXpathPrefix() . '/podcast:location');
+
+        if ($nodeList->length > 0) {
+            $location              = new stdClass();
+            $location->description = $nodeList->item(0)->nodeValue;
+            $location->geo         = $nodeList->item(0)->getAttribute('geo');
+            $location->osm         = $nodeList->item(0)->getAttribute('osm');
+        }
+
+        $this->data['location'] = $location;
+
+        return $this->data['location'];
+    }
+
+    /**
      * Register PodcastIndex namespace
      */
     protected function registerNamespaces(): void

--- a/src/Reader/Extension/PodcastIndex/Feed.php
+++ b/src/Reader/Extension/PodcastIndex/Feed.php
@@ -134,6 +134,31 @@ class Feed extends Extension\AbstractFeed
     }
 
     /**
+     * Get the podcast images
+     *
+     * @psalm-return null|object{scrset: string}
+     */
+    public function getImages(): ?stdClass
+    {
+        if (array_key_exists('images', $this->data)) {
+            return $this->data['images'];
+        }
+
+        $images = null;
+
+        $nodeList = $this->xpath->query($this->getXpathPrefix() . '/podcast:images');
+
+        if ($nodeList->length > 0) {
+            $images         = new stdClass();
+            $images->srcset = $nodeList->item(0)->getAttribute('srcset');
+        }
+
+        $this->data['images'] = $images;
+
+        return $this->data['images'];
+    }
+
+    /**
      * Register PodcastIndex namespace
      */
     protected function registerNamespaces(): void

--- a/src/Reader/Extension/PodcastIndex/Feed.php
+++ b/src/Reader/Extension/PodcastIndex/Feed.php
@@ -101,11 +101,13 @@ class Feed extends Extension\AbstractFeed
 
     /**
      * Get the podcast license
+     *
+     * @return null|object{identifier: string, url: string}
      */
-    public function getPodcastIndexLicense(): ?stdClass
+    public function getPodcastIndexLicense(): object|null
     {
         if (array_key_exists('license', $this->data)) {
-            /** @var stdClass $object */
+            /** @var null|object{identifier: string, url: string} $object */
             $object = $this->data['license'];
             return $object;
         }
@@ -129,11 +131,13 @@ class Feed extends Extension\AbstractFeed
 
     /**
      * Get the podcast location
+     *
+     * @return null|object{description: string, geo?: string|null, osm?: string|null}
      */
-    public function getPodcastIndexLocation(): ?stdClass
+    public function getPodcastIndexLocation(): object|null
     {
         if (array_key_exists('location', $this->data)) {
-            /** @var stdClass $object */
+            /** @var null|object{description: string, geo?: string|null, osm?: string|null} $object */
             $object = $this->data['location'];
             return $object;
         }
@@ -158,11 +162,13 @@ class Feed extends Extension\AbstractFeed
 
     /**
      * Get the podcast images
+     *
+     * @return null|object{srcset: string}
      */
-    public function getPodcastIndexImages(): ?stdClass
+    public function getPodcastIndexImages(): object|null
     {
         if (array_key_exists('images', $this->data)) {
-            /** @var stdClass $object */
+            /** @var null|object{srcset: string} $object */
             $object = $this->data['images'];
             return $object;
         }
@@ -185,11 +191,13 @@ class Feed extends Extension\AbstractFeed
 
     /**
      * Get the podcast update frequency
+     *
+     * @return null|object{description: string, complete?: bool|null, dtstart?: string|null, rrule?: string|null}
      */
-    public function getPodcastIndexUpdateFrequency(): ?stdClass
+    public function getPodcastIndexUpdateFrequency(): object|null
     {
         if (array_key_exists('updateFrequency', $this->data)) {
-            /** @var stdClass $object */
+            /** @var null|object{description: string, complete?: bool|null, dtstart?: string|null, rrule?: string|null} $object */
             $object = $this->data['updateFrequency'];
             return $object;
         }
@@ -214,12 +222,14 @@ class Feed extends Extension\AbstractFeed
     }
 
     /**
-     * Get the podcast person
+     * Get the podcast persons
+     *
+     * @return list<stdClass|null>
      */
     public function getPodcastIndexPersons(): array
     {
         if (array_key_exists('persons', $this->data)) {
-            /** @var array $persons */
+            /** @var list<stdClass|null> $persons */
             $persons = $this->data['updateFrequency'];
             return $persons;
         }

--- a/src/Reader/Extension/PodcastIndex/Feed.php
+++ b/src/Reader/Extension/PodcastIndex/Feed.php
@@ -12,12 +12,18 @@ use function array_key_exists;
 use function assert;
 
 /**
+ * @psalm-type UpdateFrequencyObject = object{
+ *    description: string,
+ *    complete?: bool,
+ *    dtstart?: DateTimeInterface,
+ *    rrule?: string
+ *    }
  * @psalm-type PersonObject = object{
- *     name: string,
- *     role: string|null,
- *     group: string|null,
- *     img: string|null,
- *     href: string|null
+ *        name: string,
+ *        role?: string,
+ *        group?: string,
+ *        img?: string,
+ *        href?: string
  * }
  */
 
@@ -203,12 +209,12 @@ class Feed extends Extension\AbstractFeed
     /**
      * Get the podcast update frequency
      *
-     * @return null|object{description: string, complete?: bool, dtstart?: string, rrule?: string}
+     * @psalm-return null|UpdateFrequencyObject
      */
     public function getPodcastIndexUpdateFrequency(): object|null
     {
         if (array_key_exists('updateFrequency', $this->data)) {
-            /** @var null|object{description: string, complete?: bool, dtstart?: string, rrule?: string} $object */
+            /** @var null|UpdateFrequencyObject $object */
             $object = $this->data['updateFrequency'];
             return $object;
         }

--- a/src/Reader/Extension/PodcastIndex/Feed.php
+++ b/src/Reader/Extension/PodcastIndex/Feed.php
@@ -222,16 +222,16 @@ class Feed extends Extension\AbstractFeed
     }
 
     /**
-     * Get the podcast persons
+     * Get the podcast people
      *
      * @return list<stdClass|null>
      */
-    public function getPodcastIndexPersons(): array
+    public function getPodcastIndexPeople(): array
     {
-        if (array_key_exists('persons', $this->data)) {
-            /** @var list<stdClass|null> $persons */
-            $persons = $this->data['updateFrequency'];
-            return $persons;
+        if (array_key_exists('people', $this->data)) {
+            /** @var list<stdClass|null> $people */
+            $people = $this->data['updateFrequency'];
+            return $people;
         }
 
         $nodeList = $this->xpath->query($this->getXpathPrefix() . '/podcast:person');
@@ -252,9 +252,9 @@ class Feed extends Extension\AbstractFeed
             }
         }
 
-        $this->data['persons'] = $personCollection;
+        $this->data['people'] = $personCollection;
 
-        return $this->data['persons'];
+        return $this->data['people'];
     }
 
     /**

--- a/src/Reader/Extension/PodcastIndex/Feed.php
+++ b/src/Reader/Extension/PodcastIndex/Feed.php
@@ -12,7 +12,7 @@ use function array_key_exists;
 use function assert;
 
 /**
- * @psalm-type PersonType = object{
+ * @psalm-type PersonObject = object{
  *     name: string,
  *     role: string|null,
  *     group: string|null,
@@ -235,12 +235,12 @@ class Feed extends Extension\AbstractFeed
     /**
      * Get the podcast people
      *
-     * @psalm-return list<PersonType>
+     * @psalm-return list<PersonObject>
      */
     public function getPodcastIndexPeople(): array
     {
         if (array_key_exists('people', $this->data)) {
-            /** @var list<PersonType> $people */
+            /** @var list<PersonObject> $people */
             $people = $this->data['updateFrequency'];
             return $people;
         }

--- a/src/Reader/Extension/PodcastIndex/Feed.php
+++ b/src/Reader/Extension/PodcastIndex/Feed.php
@@ -81,6 +81,32 @@ class Feed extends Extension\AbstractFeed
     }
 
     /**
+     * Get the podcast license
+     *
+     * @psalm-return null|object{identifier: string, url: string}
+     */
+    public function getLicense(): ?stdClass
+    {
+        if (array_key_exists('license', $this->data)) {
+            return $this->data['license'];
+        }
+
+        $license = null;
+
+        $nodeList = $this->xpath->query($this->getXpathPrefix() . '/podcast:license');
+
+        if ($nodeList->length > 0) {
+            $license             = new stdClass();
+            $license->identifier = $nodeList->item(0)->nodeValue;
+            $license->url        = $nodeList->item(0)->getAttribute('url');
+        }
+
+        $this->data['license'] = $license;
+
+        return $this->data['license'];
+    }
+
+    /**
      * Register PodcastIndex namespace
      */
     protected function registerNamespaces(): void

--- a/src/Reader/Extension/PodcastIndex/Feed.php
+++ b/src/Reader/Extension/PodcastIndex/Feed.php
@@ -159,6 +159,34 @@ class Feed extends Extension\AbstractFeed
     }
 
     /**
+     * Get the podcast update frequency
+     *
+     * @psalm-return null|object{description: string, complete: bool, dtstart: string, rrule: string}
+     */
+    public function getUpdateFrequency(): ?stdClass
+    {
+        if (array_key_exists('updateFrequency', $this->data)) {
+            return $this->data['updateFrequency'];
+        }
+
+        $updateFrequency = null;
+
+        $nodeList = $this->xpath->query($this->getXpathPrefix() . '/podcast:updateFrequency');
+
+        if ($nodeList->length > 0) {
+            $updateFrequency              = new stdClass();
+            $updateFrequency->description = $nodeList->item(0)->nodeValue;
+            $updateFrequency->complete    = $nodeList->item(0)->getAttribute('complete');
+            $updateFrequency->dtstart     = $nodeList->item(0)->getAttribute('dtstart');
+            $updateFrequency->rrule       = $nodeList->item(0)->getAttribute('rrule');
+        }
+
+        $this->data['updateFrequency'] = $updateFrequency;
+
+        return $this->data['updateFrequency'];
+    }
+
+    /**
      * Register PodcastIndex namespace
      */
     protected function registerNamespaces(): void

--- a/src/Reader/Extension/PodcastIndex/Feed.php
+++ b/src/Reader/Extension/PodcastIndex/Feed.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Laminas\Feed\Reader\Extension\PodcastIndex;
 
+// phpcs:disable SlevomatCodingStandard.Namespaces.UnusedUses.UnusedUse
+use DateTimeInterface;
+// phpcs:enable SlevomatCodingStandard.Namespaces.UnusedUses.UnusedUse
 use DOMElement;
 use Laminas\Feed\Reader\Extension;
 use stdClass;
@@ -12,23 +15,21 @@ use function array_key_exists;
 use function assert;
 
 /**
- * @psalm-type UpdateFrequencyObject = object{
- *    description: string,
- *    complete?: bool,
- *    dtstart?: DateTimeInterface,
- *    rrule?: string
- *    }
- * @psalm-type PersonObject = object{
- *        name: string,
- *        role?: string,
- *        group?: string,
- *        img?: string,
- *        href?: string
- * }
- */
-
-/**
  * Describes PodcastIndex data of a RSS Feed
+ *
+ * @psalm-type UpdateFrequencyObject = object{
+ *     description: string,
+ *     complete?: bool,
+ *     dtstart?: DateTimeInterface,
+ *     rrule?: string
+ *     }
+ * @psalm-type PersonObject = object{
+ *         name: string,
+ *         role?: string,
+ *         group?: string,
+ *         img?: string,
+ *         href?: string
+ *  }
  */
 class Feed extends Extension\AbstractFeed
 {

--- a/src/Reader/Extension/PodcastIndex/Feed.php
+++ b/src/Reader/Extension/PodcastIndex/Feed.php
@@ -132,12 +132,12 @@ class Feed extends Extension\AbstractFeed
     /**
      * Get the podcast location
      *
-     * @return null|object{description: string, geo?: string|null, osm?: string|null}
+     * @return null|object{description: string, geo?: string, osm?: string}
      */
     public function getPodcastIndexLocation(): object|null
     {
         if (array_key_exists('location', $this->data)) {
-            /** @var null|object{description: string, geo?: string|null, osm?: string|null} $object */
+            /** @var null|object{description: string, geo?: string, osm?: string} $object */
             $object = $this->data['location'];
             return $object;
         }
@@ -192,12 +192,12 @@ class Feed extends Extension\AbstractFeed
     /**
      * Get the podcast update frequency
      *
-     * @return null|object{description: string, complete?: bool|null, dtstart?: string|null, rrule?: string|null}
+     * @return null|object{description: string, complete?: bool, dtstart?: string, rrule?: string}
      */
     public function getPodcastIndexUpdateFrequency(): object|null
     {
         if (array_key_exists('updateFrequency', $this->data)) {
-            /** @var null|object{description: string, complete?: bool|null, dtstart?: string|null, rrule?: string|null} $object */
+            /** @var null|object{description: string, complete?: bool, dtstart?: string, rrule?: string} $object */
             $object = $this->data['updateFrequency'];
             return $object;
         }

--- a/src/Reader/Extension/PodcastIndex/Feed.php
+++ b/src/Reader/Extension/PodcastIndex/Feed.php
@@ -241,7 +241,7 @@ class Feed extends Extension\AbstractFeed
     {
         if (array_key_exists('people', $this->data)) {
             /** @var list<PersonObject> $people */
-            $people = $this->data['updateFrequency'];
+            $people = $this->data['people'];
             return $people;
         }
 

--- a/src/Reader/Extension/PodcastIndex/Feed.php
+++ b/src/Reader/Extension/PodcastIndex/Feed.php
@@ -191,7 +191,7 @@ class Feed extends Extension\AbstractFeed
      *
      * @psalm-return array<object{name: string, role: string, group: string, img: string, href: string}>|null
      */
-    public function getPersons()
+    public function getPersons(): array
     {
         if (array_key_exists('persons', $this->data)) {
             return $this->data['persons'];

--- a/src/Reader/Extension/PodcastIndex/Feed.php
+++ b/src/Reader/Extension/PodcastIndex/Feed.php
@@ -12,6 +12,16 @@ use function array_key_exists;
 use function assert;
 
 /**
+ * @psalm-type PersonType = object{
+ *     name: string,
+ *     role: string|null,
+ *     group: string|null,
+ *     img: string|null,
+ *     href: string|null
+ * }
+ */
+
+/**
  * Describes PodcastIndex data of a RSS Feed
  */
 class Feed extends Extension\AbstractFeed
@@ -225,12 +235,12 @@ class Feed extends Extension\AbstractFeed
     /**
      * Get the podcast people
      *
-     * @return list<stdClass|null>
+     * @psalm-return list<PersonType>
      */
     public function getPodcastIndexPeople(): array
     {
         if (array_key_exists('people', $this->data)) {
-            /** @var list<stdClass|null> $people */
+            /** @var list<PersonType> $people */
             $people = $this->data['updateFrequency'];
             return $people;
         }

--- a/src/Reader/Extension/PodcastIndex/Feed.php
+++ b/src/Reader/Extension/PodcastIndex/Feed.php
@@ -109,7 +109,7 @@ class Feed extends Extension\AbstractFeed
     /**
      * Get the podcast location
      *
-     * @psalm-return null|object{text: string, geo: string, osm: string}
+     * @psalm-return null|object{description: string, geo: string|null, osm: string|null}
      */
     public function getLocation(): ?stdClass
     {
@@ -161,7 +161,7 @@ class Feed extends Extension\AbstractFeed
     /**
      * Get the podcast update frequency
      *
-     * @psalm-return null|object{description: string, complete: bool, dtstart: string, rrule: string}
+     * @psalm-return null|object{description: string, complete: bool|null, dtstart: string|null, rrule: string|null}
      */
     public function getUpdateFrequency(): ?stdClass
     {
@@ -184,6 +184,39 @@ class Feed extends Extension\AbstractFeed
         $this->data['updateFrequency'] = $updateFrequency;
 
         return $this->data['updateFrequency'];
+    }
+
+    /**
+     * Get the podcast person
+     *
+     * @psalm-return array<object{name: string, role: string, group: string, img: string, href: string}>|null
+     */
+    public function getPersons()
+    {
+        if (array_key_exists('persons', $this->data)) {
+            return $this->data['persons'];
+        }
+
+        $nodeList = $this->xpath->query($this->getXpathPrefix() . '/podcast:person');
+
+        $personCollection = [];
+
+        if ($nodeList->length) {
+            foreach ($nodeList as $entry) {
+                $person        = new stdClass();
+                $person->name  = $entry->nodeValue;
+                $person->role  = $entry->getAttribute('role');
+                $person->group = $entry->getAttribute('group');
+                $person->img   = $entry->getAttribute('img');
+                $person->href  = $entry->getAttribute('href');
+
+                $personCollection[] = $person;
+            }
+        }
+
+        $this->data['persons'] = $personCollection;
+
+        return $this->data['persons'];
     }
 
     /**

--- a/src/Reader/Extension/PodcastIndex/Feed.php
+++ b/src/Reader/Extension/PodcastIndex/Feed.php
@@ -9,6 +9,7 @@ use Laminas\Feed\Reader\Extension;
 use stdClass;
 
 use function array_key_exists;
+use function assert;
 
 /**
  * Describes PodcastIndex data of a RSS Feed
@@ -87,8 +88,8 @@ class Feed extends Extension\AbstractFeed
         $nodeList = $this->xpath->query($this->getXpathPrefix() . '/podcast:funding');
 
         if ($nodeList->length > 0) {
-            /** @var DOMElement $item */
-            $item           = $nodeList->item(0);
+            $item = $nodeList->item(0);
+            assert($item instanceof DOMElement);
             $funding        = new stdClass();
             $funding->url   = $item->getAttribute('url');
             $funding->title = $item->nodeValue;
@@ -117,8 +118,8 @@ class Feed extends Extension\AbstractFeed
         $nodeList = $this->xpath->query($this->getXpathPrefix() . '/podcast:license');
 
         if ($nodeList->length > 0) {
-            /** @var DOMElement $item */
-            $item                = $nodeList->item(0);
+            $item = $nodeList->item(0);
+            assert($item instanceof DOMElement);
             $license             = new stdClass();
             $license->identifier = $item->nodeValue;
             $license->url        = $item->getAttribute('url');
@@ -147,8 +148,8 @@ class Feed extends Extension\AbstractFeed
         $nodeList = $this->xpath->query($this->getXpathPrefix() . '/podcast:location');
 
         if ($nodeList->length > 0) {
-            /** @var DOMElement $item */
-            $item                  = $nodeList->item(0);
+            $item = $nodeList->item(0);
+            assert($item instanceof DOMElement);
             $location              = new stdClass();
             $location->description = $item->nodeValue;
             $location->geo         = $item->getAttribute('geo');
@@ -178,8 +179,8 @@ class Feed extends Extension\AbstractFeed
         $nodeList = $this->xpath->query($this->getXpathPrefix() . '/podcast:images');
 
         if ($nodeList->length > 0) {
-            /** @var DOMElement $item */
-            $item           = $nodeList->item(0);
+            $item = $nodeList->item(0);
+            assert($item instanceof DOMElement);
             $images         = new stdClass();
             $images->srcset = $item->getAttribute('srcset');
         }
@@ -207,8 +208,8 @@ class Feed extends Extension\AbstractFeed
         $nodeList = $this->xpath->query($this->getXpathPrefix() . '/podcast:updateFrequency');
 
         if ($nodeList->length > 0) {
-            /** @var DOMElement $item */
-            $item                         = $nodeList->item(0);
+            $item = $nodeList->item(0);
+            assert($item instanceof DOMElement);
             $updateFrequency              = new stdClass();
             $updateFrequency->description = $item->nodeValue;
             $updateFrequency->complete    = $item->getAttribute('complete');
@@ -239,8 +240,8 @@ class Feed extends Extension\AbstractFeed
         $personCollection = [];
 
         if ($nodeList->length) {
-            /** @var DOMElement $entry */
             foreach ($nodeList as $entry) {
+                assert($entry instanceof DOMElement);
                 $person        = new stdClass();
                 $person->name  = $entry->nodeValue;
                 $person->role  = $entry->getAttribute('role');

--- a/src/Reader/Extension/PodcastIndex/Feed.php
+++ b/src/Reader/Extension/PodcastIndex/Feed.php
@@ -56,8 +56,6 @@ class Feed extends Extension\AbstractFeed
 
     /**
      * Get the entry funding link
-     *
-     * @psalm-return null|object{url: string, title: string}
      */
     public function getFunding(): ?stdClass
     {
@@ -82,8 +80,6 @@ class Feed extends Extension\AbstractFeed
 
     /**
      * Get the podcast license
-     *
-     * @psalm-return null|object{identifier: string, url: string}
      */
     public function getLicense(): ?stdClass
     {
@@ -108,8 +104,6 @@ class Feed extends Extension\AbstractFeed
 
     /**
      * Get the podcast location
-     *
-     * @psalm-return null|object{description: string, geo: string|null, osm: string|null}
      */
     public function getLocation(): ?stdClass
     {
@@ -135,8 +129,6 @@ class Feed extends Extension\AbstractFeed
 
     /**
      * Get the podcast images
-     *
-     * @psalm-return null|object{scrset: string}
      */
     public function getImages(): ?stdClass
     {
@@ -160,8 +152,6 @@ class Feed extends Extension\AbstractFeed
 
     /**
      * Get the podcast update frequency
-     *
-     * @psalm-return null|object{description: string, complete: bool|null, dtstart: string|null, rrule: string|null}
      */
     public function getUpdateFrequency(): ?stdClass
     {
@@ -188,8 +178,6 @@ class Feed extends Extension\AbstractFeed
 
     /**
      * Get the podcast person
-     *
-     * @psalm-return array<object{name: string, role: string, group: string, img: string, href: string}>|null
      */
     public function getPersons(): array
     {

--- a/src/Reader/Extension/PodcastIndex/Feed.php
+++ b/src/Reader/Extension/PodcastIndex/Feed.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Laminas\Feed\Reader\Extension\PodcastIndex;
 
+use DOMElement;
 use Laminas\Feed\Reader\Extension;
 use stdClass;
 
@@ -60,7 +61,9 @@ class Feed extends Extension\AbstractFeed
     public function getFunding(): ?stdClass
     {
         if (array_key_exists('funding', $this->data)) {
-            return $this->data['funding'];
+            /** @var stdClass $object */
+            $object = $this->data['funding'];
+            return $object;
         }
 
         $funding = null;
@@ -68,9 +71,11 @@ class Feed extends Extension\AbstractFeed
         $nodeList = $this->xpath->query($this->getXpathPrefix() . '/podcast:funding');
 
         if ($nodeList->length > 0) {
+            /** @var DOMElement $item */
+            $item           = $nodeList->item(0);
             $funding        = new stdClass();
-            $funding->url   = $nodeList->item(0)->getAttribute('url');
-            $funding->title = $nodeList->item(0)->nodeValue;
+            $funding->url   = $item->getAttribute('url');
+            $funding->title = $item->nodeValue;
         }
 
         $this->data['funding'] = $funding;
@@ -84,7 +89,9 @@ class Feed extends Extension\AbstractFeed
     public function getLicense(): ?stdClass
     {
         if (array_key_exists('license', $this->data)) {
-            return $this->data['license'];
+            /** @var stdClass $object */
+            $object = $this->data['license'];
+            return $object;
         }
 
         $license = null;
@@ -92,9 +99,11 @@ class Feed extends Extension\AbstractFeed
         $nodeList = $this->xpath->query($this->getXpathPrefix() . '/podcast:license');
 
         if ($nodeList->length > 0) {
+            /** @var DOMElement $item */
+            $item                = $nodeList->item(0);
             $license             = new stdClass();
-            $license->identifier = $nodeList->item(0)->nodeValue;
-            $license->url        = $nodeList->item(0)->getAttribute('url');
+            $license->identifier = $item->nodeValue;
+            $license->url        = $item->getAttribute('url');
         }
 
         $this->data['license'] = $license;
@@ -108,7 +117,9 @@ class Feed extends Extension\AbstractFeed
     public function getLocation(): ?stdClass
     {
         if (array_key_exists('location', $this->data)) {
-            return $this->data['location'];
+            /** @var stdClass $object */
+            $object = $this->data['location'];
+            return $object;
         }
 
         $location = null;
@@ -116,10 +127,12 @@ class Feed extends Extension\AbstractFeed
         $nodeList = $this->xpath->query($this->getXpathPrefix() . '/podcast:location');
 
         if ($nodeList->length > 0) {
+            /** @var DOMElement $item */
+            $item                  = $nodeList->item(0);
             $location              = new stdClass();
-            $location->description = $nodeList->item(0)->nodeValue;
-            $location->geo         = $nodeList->item(0)->getAttribute('geo');
-            $location->osm         = $nodeList->item(0)->getAttribute('osm');
+            $location->description = $item->nodeValue;
+            $location->geo         = $item->getAttribute('geo');
+            $location->osm         = $item->getAttribute('osm');
         }
 
         $this->data['location'] = $location;
@@ -133,7 +146,9 @@ class Feed extends Extension\AbstractFeed
     public function getImages(): ?stdClass
     {
         if (array_key_exists('images', $this->data)) {
-            return $this->data['images'];
+            /** @var stdClass $object */
+            $object = $this->data['images'];
+            return $object;
         }
 
         $images = null;
@@ -141,8 +156,10 @@ class Feed extends Extension\AbstractFeed
         $nodeList = $this->xpath->query($this->getXpathPrefix() . '/podcast:images');
 
         if ($nodeList->length > 0) {
+            /** @var DOMElement $item */
+            $item           = $nodeList->item(0);
             $images         = new stdClass();
-            $images->srcset = $nodeList->item(0)->getAttribute('srcset');
+            $images->srcset = $item->getAttribute('srcset');
         }
 
         $this->data['images'] = $images;
@@ -156,7 +173,9 @@ class Feed extends Extension\AbstractFeed
     public function getUpdateFrequency(): ?stdClass
     {
         if (array_key_exists('updateFrequency', $this->data)) {
-            return $this->data['updateFrequency'];
+            /** @var stdClass $object */
+            $object = $this->data['updateFrequency'];
+            return $object;
         }
 
         $updateFrequency = null;
@@ -164,11 +183,13 @@ class Feed extends Extension\AbstractFeed
         $nodeList = $this->xpath->query($this->getXpathPrefix() . '/podcast:updateFrequency');
 
         if ($nodeList->length > 0) {
+            /** @var DOMElement $item */
+            $item                         = $nodeList->item(0);
             $updateFrequency              = new stdClass();
-            $updateFrequency->description = $nodeList->item(0)->nodeValue;
-            $updateFrequency->complete    = $nodeList->item(0)->getAttribute('complete');
-            $updateFrequency->dtstart     = $nodeList->item(0)->getAttribute('dtstart');
-            $updateFrequency->rrule       = $nodeList->item(0)->getAttribute('rrule');
+            $updateFrequency->description = $item->nodeValue;
+            $updateFrequency->complete    = $item->getAttribute('complete');
+            $updateFrequency->dtstart     = $item->getAttribute('dtstart');
+            $updateFrequency->rrule       = $item->getAttribute('rrule');
         }
 
         $this->data['updateFrequency'] = $updateFrequency;
@@ -182,7 +203,9 @@ class Feed extends Extension\AbstractFeed
     public function getPersons(): array
     {
         if (array_key_exists('persons', $this->data)) {
-            return $this->data['persons'];
+            /** @var array $persons */
+            $persons = $this->data['updateFrequency'];
+            return $persons;
         }
 
         $nodeList = $this->xpath->query($this->getXpathPrefix() . '/podcast:person');
@@ -190,6 +213,7 @@ class Feed extends Extension\AbstractFeed
         $personCollection = [];
 
         if ($nodeList->length) {
+            /** @var DOMElement $entry */
             foreach ($nodeList as $entry) {
                 $person        = new stdClass();
                 $person->name  = $entry->nodeValue;

--- a/src/Reader/Extension/PodcastIndex/Feed.php
+++ b/src/Reader/Extension/PodcastIndex/Feed.php
@@ -40,6 +40,14 @@ class Feed extends Extension\AbstractFeed
      */
     public function getLockOwner(): ?string
     {
+        return $this->getPodcastIndexLockOwner();
+    }
+
+    /**
+     * Get the owner of the podcast (for verification)
+     */
+    public function getPodcastIndexLockOwner(): ?string
+    {
         if (isset($this->data['owner'])) {
             return $this->data['owner'];
         }
@@ -59,6 +67,14 @@ class Feed extends Extension\AbstractFeed
      * Get the entry funding link
      */
     public function getFunding(): ?stdClass
+    {
+        return $this->getPodcastIndexFunding();
+    }
+
+    /**
+     * Get the entry funding link
+     */
+    public function getPodcastIndexFunding(): ?stdClass
     {
         if (array_key_exists('funding', $this->data)) {
             /** @var stdClass $object */
@@ -86,7 +102,7 @@ class Feed extends Extension\AbstractFeed
     /**
      * Get the podcast license
      */
-    public function getLicense(): ?stdClass
+    public function getPodcastIndexLicense(): ?stdClass
     {
         if (array_key_exists('license', $this->data)) {
             /** @var stdClass $object */
@@ -114,7 +130,7 @@ class Feed extends Extension\AbstractFeed
     /**
      * Get the podcast location
      */
-    public function getLocation(): ?stdClass
+    public function getPodcastIndexLocation(): ?stdClass
     {
         if (array_key_exists('location', $this->data)) {
             /** @var stdClass $object */
@@ -143,7 +159,7 @@ class Feed extends Extension\AbstractFeed
     /**
      * Get the podcast images
      */
-    public function getImages(): ?stdClass
+    public function getPodcastIndexImages(): ?stdClass
     {
         if (array_key_exists('images', $this->data)) {
             /** @var stdClass $object */
@@ -170,7 +186,7 @@ class Feed extends Extension\AbstractFeed
     /**
      * Get the podcast update frequency
      */
-    public function getUpdateFrequency(): ?stdClass
+    public function getPodcastIndexUpdateFrequency(): ?stdClass
     {
         if (array_key_exists('updateFrequency', $this->data)) {
             /** @var stdClass $object */
@@ -200,7 +216,7 @@ class Feed extends Extension\AbstractFeed
     /**
      * Get the podcast person
      */
-    public function getPersons(): array
+    public function getPodcastIndexPersons(): array
     {
         if (array_key_exists('persons', $this->data)) {
             /** @var array $persons */

--- a/src/Writer/Extension/PodcastIndex/Feed.php
+++ b/src/Writer/Extension/PodcastIndex/Feed.php
@@ -119,9 +119,19 @@ class Feed
      */
     public function setPodcastIndexLicense(array $value)
     {
-        if (empty($value['identifier']) || empty($value['url'])) {
+        if (! isset($value['identifier'], $value['url'])) {
             throw new Writer\Exception\InvalidArgumentException(
                 'invalid parameter: "license" must be an array containing the keys "identifier" (node value) and "url"'
+            );
+        }
+        if (! is_string($value['identifier'])) {
+            throw new Writer\Exception\InvalidArgumentException(
+                'invalid parameter: "identifier" of "license" must be of type string.'
+            );
+        }
+        if (! is_string($value['url']) || ! filter_var($value['url'], FILTER_VALIDATE_URL)) {
+            throw new Writer\Exception\InvalidArgumentException(
+                'invalid parameter: "url" of "license": must be a url starting with "http://" or "https://"'
             );
         }
         $this->data['license'] = $value;
@@ -137,9 +147,24 @@ class Feed
      */
     public function setPodcastIndexLocation(array $value)
     {
-        if (empty($value['description'])) {
+        if (! isset($value['description'])) {
             throw new Writer\Exception\InvalidArgumentException(
                 'invalid parameter: "location" must be an array containing at least the key "description" (node value)'
+            );
+        }
+        if (! is_string($value['description'])) {
+            throw new Writer\Exception\InvalidArgumentException(
+                'invalid parameter: key "description" of "location" must be of type string.'
+            );
+        }
+        if (isset($value['geo']) && ! is_string($value['geo'])) {
+            throw new Writer\Exception\InvalidArgumentException(
+                'invalid parameter: key "geo" of "location" must be of type string. example: "geo:-27.86159,153.3169"'
+            );
+        }
+        if (isset($value['osm']) && ! is_string($value['osm'])) {
+            throw new Writer\Exception\InvalidArgumentException(
+                'invalid parameter: key "osm" of "location" must be of type string. example: "W43678282"'
             );
         }
         $this->data['location'] = $value;
@@ -155,14 +180,14 @@ class Feed
      */
     public function setPodcastIndexImages(array $value)
     {
-        if (empty($value['srcset'])) {
+        if (! isset($value['srcset'])) {
             throw new Writer\Exception\InvalidArgumentException(
                 'invalid parameter: "images" must be an array containing the key "srcset"'
             );
         }
         if (! is_string($value['srcset'])) {
             throw new Writer\Exception\InvalidArgumentException(
-                'invalid parameter: "srcset" must be of type string, containing comma-seperated urls'
+                'invalid parameter: key "srcset" of "images" must be of type string containing comma-seperated urls'
             );
         }
         $this->data['images'] = $value;
@@ -178,24 +203,29 @@ class Feed
      */
     public function setPodcastIndexUpdateFrequency(array $value)
     {
-        if (empty($value['description'])) {
+        if (! isset($value['description'])) {
             throw new Writer\Exception\InvalidArgumentException(
                 'invalid parameter: "updateFrequency" must be an array containing the key "description" (node value)'
             );
         }
-        if (! empty($value['complete']) && ! is_bool($value['complete'])) {
+        if (! is_string($value['description'])) {
             throw new Writer\Exception\InvalidArgumentException(
-                'invalid parameter for "updateFrequency": key "complete" must be of type boolean'
+                'invalid parameter: key "description" of "updateFrequency" must be of type string'
             );
         }
-        if (! empty($value['dtstart']) && ! is_string($value['dtstart'])) {
+        if (isset($value['complete']) && ! is_bool($value['complete'])) {
             throw new Writer\Exception\InvalidArgumentException(
-                'invalid parameter for "updateFrequency": key "dtstart" must be an ISO8601-formatted string'
+                'invalid parameter: key "complete" of "updateFrequency": must be of type boolean'
             );
         }
-        if (! empty($value['rrule']) && ! is_string($value['rrule'])) {
+        if (isset($value['dtstart']) && ! is_string($value['dtstart'])) {
             throw new Writer\Exception\InvalidArgumentException(
-                'invalid parameter for "updateFrequency": key "rrule" must be of type string'
+                'invalid parameter: key "dtstart" of "updateFrequency" must be an ISO8601-formatted string'
+            );
+        }
+        if (isset($value['rrule']) && ! is_string($value['rrule'])) {
+            throw new Writer\Exception\InvalidArgumentException(
+                'invalid parameter: key "rrule" of "updateFrequency" must be of type string'
             );
         }
         $this->data['updateFrequency'] = $value;
@@ -211,17 +241,22 @@ class Feed
      */
     public function addPodcastIndexPerson(array $value)
     {
-        if (empty($value['name'])) {
+        if (! isset($value['name'])) {
             throw new Writer\Exception\InvalidArgumentException(
                 'invalid parameter: "person" must be an array containing at least the key "name"'
             );
         }
-        if (! empty($value['img']) && ! filter_var($value['img'], FILTER_VALIDATE_URL)) {
+        if (! is_string($value['name'])) {
+            throw new Writer\Exception\InvalidArgumentException(
+                'invalid parameter: key "name" of "person" must be of type string'
+            );
+        }
+        if (isset($value['img']) && ! filter_var($value['img'], FILTER_VALIDATE_URL)) {
             throw new Writer\Exception\InvalidArgumentException(
                 'invalid parameter for "person": "img" must be a url, starting with "http://" or "https://"'
             );
         }
-        if (! empty($value['href']) && ! filter_var($value['href'], FILTER_VALIDATE_URL)) {
+        if (isset($value['href']) && ! filter_var($value['href'], FILTER_VALIDATE_URL)) {
             throw new Writer\Exception\InvalidArgumentException(
                 'invalid parameter for "person": "href" must be a url, starting with "http://" or "https://"'
             );
@@ -237,7 +272,7 @@ class Feed
      * Set a new array of persons.
      * If no argument is passed, it will just remove all existing persons.
      *
-     * @param array $value [name: string, role: string|null, group: string|null, img: url|null, href: url|null]
+     * @param null|array $values
      * @return $this
      * @throws Writer\Exception\InvalidArgumentException
      */

--- a/src/Writer/Extension/PodcastIndex/Feed.php
+++ b/src/Writer/Extension/PodcastIndex/Feed.php
@@ -235,7 +235,7 @@ class Feed
     /**
      * Add feed person
      *
-     * @param array $value [name: string, role: string|null, group: string|null, img: url|null, href: url|null]
+     * @param array<string,mixed> $value [name: str, role: str|null, group: str|null, img: url|null, href: url|null]
      * @return $this
      * @throws Writer\Exception\InvalidArgumentException
      */
@@ -253,17 +253,19 @@ class Feed
         }
         if (isset($value['img']) && ! filter_var($value['img'], FILTER_VALIDATE_URL)) {
             throw new Writer\Exception\InvalidArgumentException(
-                'invalid parameter for "person": "img" must be a url, starting with "http://" or "https://"'
+                'invalid parameter: key "img" of "person" must be a url, starting with "http://" or "https://"'
             );
         }
         if (isset($value['href']) && ! filter_var($value['href'], FILTER_VALIDATE_URL)) {
             throw new Writer\Exception\InvalidArgumentException(
-                'invalid parameter for "person": "href" must be a url, starting with "http://" or "https://"'
+                'invalid parameter: key "href" of "person" must be a url, starting with "http://" or "https://"'
             );
         }
         if (! isset($this->data['persons'])) {
             $this->data['persons'] = [];
         }
+
+        /** @var array<array<string, mixed>> $this->data['persons'] */
         $this->data['persons'][] = $value;
         return $this;
     }
@@ -272,7 +274,7 @@ class Feed
      * Set a new array of persons.
      * If no argument is passed, it will just remove all existing persons.
      *
-     * @param null|array $values
+     * @param null|array<array> $values
      * @return $this
      * @throws Writer\Exception\InvalidArgumentException
      */
@@ -284,20 +286,11 @@ class Feed
             return $this;
         }
 
+        /** @var array<string,string> $value */
         foreach ($values as $value) {
             $this->addPodcastIndexPerson($value);
         }
         return $this;
-    }
-
-    /**
-     * Get feed persons
-     *
-     * @return array|null
-     */
-    public function getPodcastIndexPersons()
-    {
-        return $this->data['persons'] ?? null;
     }
 
     /**

--- a/src/Writer/Extension/PodcastIndex/Feed.php
+++ b/src/Writer/Extension/PodcastIndex/Feed.php
@@ -113,7 +113,7 @@ class Feed
     /**
      * Set feed license
      *
-     * @param array $value [identifier: string, url: string]
+     * @param array{identifier: string, url: string} $value
      * @return $this
      * @throws Writer\Exception\InvalidArgumentException
      */
@@ -141,7 +141,7 @@ class Feed
     /**
      * Set feed location
      *
-     * @param array $value [description: string, geo: string|null, osm: string|null]
+     * @param array{description: string, geo?: string|null, osm?: string|null} $value
      * @return $this
      * @throws Writer\Exception\InvalidArgumentException
      */
@@ -174,7 +174,7 @@ class Feed
     /**
      * Set feed images
      *
-     * @param array $value [scrset: string]
+     * @param array{srcset: string} $value
      * @return $this
      * @throws Writer\Exception\InvalidArgumentException
      */
@@ -197,7 +197,7 @@ class Feed
     /**
      * Set feed update frequency
      *
-     * @param array $value [description: string, complete: bool|null, dtstart: string|null, rrule: string|null]
+     * @param array{description: string, complete?: bool|null, dtstart?: string|null, rrule?: string|null} $value
      * @return $this
      * @throws Writer\Exception\InvalidArgumentException
      */
@@ -235,7 +235,7 @@ class Feed
     /**
      * Add feed person
      *
-     * @param array<string,mixed> $value [name: str, role: str|null, group: str|null, img: url|null, href: url|null]
+     * @param array{name: string, role?: string, group?: string, img?: string, href?: string} $value
      * @return $this
      * @throws Writer\Exception\InvalidArgumentException
      */
@@ -286,7 +286,6 @@ class Feed
             return $this;
         }
 
-        /** @var array<string,string> $value */
         foreach ($values as $value) {
             $this->addPodcastIndexPerson($value);
         }

--- a/src/Writer/Extension/PodcastIndex/Feed.php
+++ b/src/Writer/Extension/PodcastIndex/Feed.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Laminas\Feed\Writer\Extension\PodcastIndex;
 
+use DateTime;
+use DateTimeInterface;
 use Laminas\Feed\Writer;
 use Laminas\Stdlib\StringUtils;
 use Laminas\Stdlib\StringWrapper\StringWrapperInterface;
@@ -207,7 +209,7 @@ class Feed
     /**
      * Set feed update frequency
      *
-     * @param array{description: string, complete?: bool, dtstart?: string, rrule?: string} $value
+     * @param array{description: string, complete?: bool, dtstart?: DateTime, rrule?: string} $value
      * @return $this
      * @throws Writer\Exception\InvalidArgumentException
      */
@@ -228,10 +230,14 @@ class Feed
                 'invalid parameter: key "complete" of "updateFrequency": must be of type boolean'
             );
         }
-        if (isset($value['dtstart']) && ! is_string($value['dtstart'])) {
-            throw new Writer\Exception\InvalidArgumentException(
-                'invalid parameter: key "dtstart" of "updateFrequency" must be an ISO8601-formatted string'
-            );
+        if (isset($value['dtstart'])) {
+            if (! $value['dtstart'] instanceof DateTime) {
+                throw new Writer\Exception\InvalidArgumentException(
+                    'invalid parameter: key "dtstart" of "updateFrequency" must be of type DateTime'
+                );
+            }
+            // cast to ISO8601 string
+            $value['dtstart'] = $value['dtstart']->format(DateTimeInterface::ATOM);
         }
         if (isset($value['rrule']) && ! is_string($value['rrule'])) {
             throw new Writer\Exception\InvalidArgumentException(

--- a/src/Writer/Extension/PodcastIndex/Feed.php
+++ b/src/Writer/Extension/PodcastIndex/Feed.php
@@ -261,27 +261,27 @@ class Feed
                 'invalid parameter: key "href" of "person" must be a url, starting with "http://" or "https://"'
             );
         }
-        if (! isset($this->data['persons'])) {
-            $this->data['persons'] = [];
+        if (! isset($this->data['people'])) {
+            $this->data['people'] = [];
         }
 
-        /** @var array<array<string, mixed>> $this->data['persons'] */
-        $this->data['persons'][] = $value;
+        /** @var array<array<string, mixed>> $this->data['people'] */
+        $this->data['people'][] = $value;
         return $this;
     }
 
     /**
-     * Set a new array of persons.
-     * If no argument is passed, it will just remove all existing persons.
+     * Set a new array of people.
+     * If no argument is passed, it will just remove all existing people.
      *
      * @param array<array> $values
      * @return $this
      * @throws Writer\Exception\InvalidArgumentException
      */
-    public function setPodcastIndexPersons(array $values = []): self
+    public function setPodcastIndexPeople(array $values = []): self
     {
-        // delete existing persons before setting new ones
-        $this->data['persons'] = [];
+        // delete existing people before setting new ones
+        $this->data['people'] = [];
 
         foreach ($values as $value) {
             $this->addPodcastIndexPerson($value);

--- a/src/Writer/Extension/PodcastIndex/Feed.php
+++ b/src/Writer/Extension/PodcastIndex/Feed.php
@@ -143,6 +143,24 @@ class Feed
     }
 
     /**
+     * Set feed images
+     *
+     * @param array $value
+     * @return $this
+     * @throws Writer\Exception\InvalidArgumentException
+     */
+    public function setPodcastIndexImages(array $value)
+    {
+        if (empty($value['srcset'])) {
+            throw new Writer\Exception\InvalidArgumentException(
+                'invalid parameter: "images" must be an array containing the key "srcset"'
+            );
+        }
+        $this->data['srcset'] = $value;
+        return $this;
+    }
+
+    /**
      * Overloading: proxy to internal setters
      *
      * @return mixed

--- a/src/Writer/Extension/PodcastIndex/Feed.php
+++ b/src/Writer/Extension/PodcastIndex/Feed.php
@@ -10,6 +10,7 @@ use Laminas\Stdlib\StringWrapper\StringWrapperInterface;
 
 use function array_key_exists;
 use function ctype_alpha;
+use function is_bool;
 use function is_string;
 use function lcfirst;
 use function method_exists;
@@ -157,6 +158,39 @@ class Feed
             );
         }
         $this->data['images'] = $value;
+        return $this;
+    }
+
+    /**
+     * Set feed update frequency
+     *
+     * @param array $value
+     * @return $this
+     * @throws Writer\Exception\InvalidArgumentException
+     */
+    public function setPodcastIndexUpdateFrequency(array $value)
+    {
+        if (empty($value['description'])) {
+            throw new Writer\Exception\InvalidArgumentException(
+                'invalid parameter: "updateFrequency" must be an array containing the key "description" (node value)'
+            );
+        }
+        if (! empty($value['complete']) && ! is_bool($value['complete'])) {
+            throw new Writer\Exception\InvalidArgumentException(
+                'invalid parameter for "updateFrequency": key "complete" must be of type boolean'
+            );
+        }
+        if (! empty($value['dtstart']) && ! is_string($value['dtstart'])) {
+            throw new Writer\Exception\InvalidArgumentException(
+                'invalid parameter for "updateFrequency": key "dtstart" must be an ISO8601-formatted string'
+            );
+        }
+        if (! empty($value['rrule']) && ! is_string($value['rrule'])) {
+            throw new Writer\Exception\InvalidArgumentException(
+                'invalid parameter for "updateFrequency": key "rrule" must be of type string'
+            );
+        }
+        $this->data['updateFrequency'] = $value;
         return $this;
     }
 

--- a/src/Writer/Extension/PodcastIndex/Feed.php
+++ b/src/Writer/Extension/PodcastIndex/Feed.php
@@ -117,7 +117,7 @@ class Feed
      * @return $this
      * @throws Writer\Exception\InvalidArgumentException
      */
-    public function setPodcastIndexLicense(array $value)
+    public function setPodcastIndexLicense(array $value): self
     {
         if (! isset($value['identifier'], $value['url'])) {
             throw new Writer\Exception\InvalidArgumentException(
@@ -141,11 +141,11 @@ class Feed
     /**
      * Set feed location
      *
-     * @param array{description: string, geo?: string|null, osm?: string|null} $value
+     * @param array{description: string, geo?: string, osm?: string} $value
      * @return $this
      * @throws Writer\Exception\InvalidArgumentException
      */
-    public function setPodcastIndexLocation(array $value)
+    public function setPodcastIndexLocation(array $value): self
     {
         if (! isset($value['description'])) {
             throw new Writer\Exception\InvalidArgumentException(
@@ -178,7 +178,7 @@ class Feed
      * @return $this
      * @throws Writer\Exception\InvalidArgumentException
      */
-    public function setPodcastIndexImages(array $value)
+    public function setPodcastIndexImages(array $value): self
     {
         if (! isset($value['srcset'])) {
             throw new Writer\Exception\InvalidArgumentException(
@@ -197,11 +197,11 @@ class Feed
     /**
      * Set feed update frequency
      *
-     * @param array{description: string, complete?: bool|null, dtstart?: string|null, rrule?: string|null} $value
+     * @param array{description: string, complete?: bool, dtstart?: string, rrule?: string} $value
      * @return $this
      * @throws Writer\Exception\InvalidArgumentException
      */
-    public function setPodcastIndexUpdateFrequency(array $value)
+    public function setPodcastIndexUpdateFrequency(array $value): self
     {
         if (! isset($value['description'])) {
             throw new Writer\Exception\InvalidArgumentException(
@@ -239,7 +239,7 @@ class Feed
      * @return $this
      * @throws Writer\Exception\InvalidArgumentException
      */
-    public function addPodcastIndexPerson(array $value)
+    public function addPodcastIndexPerson(array $value): self
     {
         if (! isset($value['name'])) {
             throw new Writer\Exception\InvalidArgumentException(
@@ -274,17 +274,14 @@ class Feed
      * Set a new array of persons.
      * If no argument is passed, it will just remove all existing persons.
      *
-     * @param null|array<array> $values
+     * @param array<array> $values
      * @return $this
      * @throws Writer\Exception\InvalidArgumentException
      */
-    public function setPodcastIndexPersons(?array $values = null)
+    public function setPodcastIndexPersons(array $values = []): self
     {
         // delete existing persons before setting new ones
-        $this->data['persons'] = null;
-        if (null === $values) {
-            return $this;
-        }
+        $this->data['persons'] = [];
 
         foreach ($values as $value) {
             $this->addPodcastIndexPerson($value);

--- a/src/Writer/Extension/PodcastIndex/Feed.php
+++ b/src/Writer/Extension/PodcastIndex/Feed.php
@@ -290,7 +290,7 @@ class Feed
             $this->data['people'] = [];
         }
 
-        /** @var PersonArray $this->data['people'] */
+        /** @var list<PersonArray> $this->data['people'] */
         $this->data['people'][] = $value;
         return $this;
     }
@@ -299,13 +299,12 @@ class Feed
      * Set a new array of people.
      * If no argument is passed, it will just remove all existing people.
      *
-     * @psalm-param array<PersonArray> $values
+     * @psalm-param list<PersonArray> $values
      * @return $this
      * @throws Writer\Exception\InvalidArgumentException
      */
     public function setPodcastIndexPeople(array $values = []): self
     {
-        // delete existing people before setting new ones
         $this->data['people'] = [];
 
         foreach ($values as $value) {

--- a/src/Writer/Extension/PodcastIndex/Feed.php
+++ b/src/Writer/Extension/PodcastIndex/Feed.php
@@ -10,6 +10,7 @@ use Laminas\Stdlib\StringWrapper\StringWrapperInterface;
 
 use function array_key_exists;
 use function ctype_alpha;
+use function filter_var;
 use function is_bool;
 use function is_string;
 use function lcfirst;
@@ -17,6 +18,8 @@ use function method_exists;
 use function strlen;
 use function substr;
 use function ucfirst;
+
+use const FILTER_VALIDATE_URL;
 
 /**
  * Describes PodcastIndex data of a RSS Feed
@@ -110,7 +113,7 @@ class Feed
     /**
      * Set feed license
      *
-     * @param array $value
+     * @param array $value [identifier: string, url: string]
      * @return $this
      * @throws Writer\Exception\InvalidArgumentException
      */
@@ -128,7 +131,7 @@ class Feed
     /**
      * Set feed location
      *
-     * @param array $value
+     * @param array $value [description: string, geo: string|null, osm: string|null]
      * @return $this
      * @throws Writer\Exception\InvalidArgumentException
      */
@@ -146,7 +149,7 @@ class Feed
     /**
      * Set feed images
      *
-     * @param array $value
+     * @param array $value [scrset: string]
      * @return $this
      * @throws Writer\Exception\InvalidArgumentException
      */
@@ -164,7 +167,7 @@ class Feed
     /**
      * Set feed update frequency
      *
-     * @param array $value
+     * @param array $value [description: string, complete: bool|null, dtstart: string|null, rrule: string|null]
      * @return $this
      * @throws Writer\Exception\InvalidArgumentException
      */
@@ -192,6 +195,69 @@ class Feed
         }
         $this->data['updateFrequency'] = $value;
         return $this;
+    }
+
+    /**
+     * Add feed person
+     *
+     * @param array $value [name: string, role: string|null, group: string|null, img: url|null, href: url|null]
+     * @return $this
+     * @throws Writer\Exception\InvalidArgumentException
+     */
+    public function addPodcastIndexPerson(array $value)
+    {
+        if (empty($value['name'])) {
+            throw new Writer\Exception\InvalidArgumentException(
+                'invalid parameter: "person" must be an array containing at least the key "name"'
+            );
+        }
+        if (! empty($value['img']) && ! filter_var($value['img'], FILTER_VALIDATE_URL)) {
+            throw new Writer\Exception\InvalidArgumentException(
+                'invalid parameter for "person": "img" must be a url, starting with "http://" or "https://"'
+            );
+        }
+        if (! empty($value['href']) && ! filter_var($value['href'], FILTER_VALIDATE_URL)) {
+            throw new Writer\Exception\InvalidArgumentException(
+                'invalid parameter for "person": "href" must be a url, starting with "http://" or "https://"'
+            );
+        }
+        if (! isset($this->data['persons'])) {
+            $this->data['persons'] = [];
+        }
+        $this->data['persons'][] = $value;
+        return $this;
+    }
+
+    /**
+     * Set a new array of persons.
+     * If no argument is passed, it will just remove all existing persons.
+     *
+     * @param array $value [name: string, role: string|null, group: string|null, img: url|null, href: url|null]
+     * @return $this
+     * @throws Writer\Exception\InvalidArgumentException
+     */
+    public function setPodcastIndexPersons(?array $values = null)
+    {
+        // delete existing persons before setting new ones
+        $this->data['persons'] = null;
+        if (null === $values) {
+            return $this;
+        }
+
+        foreach ($values as $value) {
+            $this->addPodcastIndexPerson($value);
+        }
+        return $this;
+    }
+
+    /**
+     * Get feed persons
+     *
+     * @return array|null
+     */
+    public function getPodcastIndexPersons()
+    {
+        return $this->data['persons'] ?? null;
     }
 
     /**

--- a/src/Writer/Extension/PodcastIndex/Feed.php
+++ b/src/Writer/Extension/PodcastIndex/Feed.php
@@ -115,12 +115,30 @@ class Feed
      */
     public function setPodcastIndexLicense(array $value)
     {
-        if (! isset($value['identifier']) || ! isset($value['url'])) {
+        if (empty($value['identifier']) || empty($value['url'])) {
             throw new Writer\Exception\InvalidArgumentException(
-                'invalid parameter: "license" must be an array containing keys "identifier" and "url"'
+                'invalid parameter: "license" must be an array containing the keys "identifier" (node value) and "url"'
             );
         }
         $this->data['license'] = $value;
+        return $this;
+    }
+
+    /**
+     * Set feed location
+     *
+     * @param array $value
+     * @return $this
+     * @throws Writer\Exception\InvalidArgumentException
+     */
+    public function setPodcastIndexLocation(array $value)
+    {
+        if (empty($value['description'])) {
+            throw new Writer\Exception\InvalidArgumentException(
+                'invalid parameter: "location" must be an array containing at least the key "description" (node value)'
+            );
+        }
+        $this->data['location'] = $value;
         return $this;
     }
 

--- a/src/Writer/Extension/PodcastIndex/Feed.php
+++ b/src/Writer/Extension/PodcastIndex/Feed.php
@@ -160,6 +160,11 @@ class Feed
                 'invalid parameter: "images" must be an array containing the key "srcset"'
             );
         }
+        if (! is_string($value['srcset'])) {
+            throw new Writer\Exception\InvalidArgumentException(
+                'invalid parameter: "srcset" must be of type string, containing comma-seperated urls'
+            );
+        }
         $this->data['images'] = $value;
         return $this;
     }

--- a/src/Writer/Extension/PodcastIndex/Feed.php
+++ b/src/Writer/Extension/PodcastIndex/Feed.php
@@ -107,6 +107,24 @@ class Feed
     }
 
     /**
+     * Set feed license
+     *
+     * @param array $value
+     * @return $this
+     * @throws Writer\Exception\InvalidArgumentException
+     */
+    public function setPodcastIndexLicense(array $value)
+    {
+        if (! isset($value['identifier']) || ! isset($value['url'])) {
+            throw new Writer\Exception\InvalidArgumentException(
+                'invalid parameter: "license" must be an array containing keys "identifier" and "url"'
+            );
+        }
+        $this->data['license'] = $value;
+        return $this;
+    }
+
+    /**
      * Overloading: proxy to internal setters
      *
      * @return mixed

--- a/src/Writer/Extension/PodcastIndex/Feed.php
+++ b/src/Writer/Extension/PodcastIndex/Feed.php
@@ -22,6 +22,16 @@ use function ucfirst;
 use const FILTER_VALIDATE_URL;
 
 /**
+ * @psalm-type PersonArray = array{
+ *     name: string,
+ *     role?: string,
+ *     group?: string,
+ *     img?: string,
+ *     href?: string
+ * }
+ */
+
+/**
  * Describes PodcastIndex data of a RSS Feed
  */
 class Feed
@@ -235,7 +245,7 @@ class Feed
     /**
      * Add feed person
      *
-     * @param array{name: string, role?: string, group?: string, img?: string, href?: string} $value
+     * @psalm-param PersonArray $value
      * @return $this
      * @throws Writer\Exception\InvalidArgumentException
      */
@@ -275,7 +285,7 @@ class Feed
             $this->data['people'] = [];
         }
 
-        /** @var array<array<string, mixed>> $this->data['people'] */
+        /** @var PersonArray $this->data['people'] */
         $this->data['people'][] = $value;
         return $this;
     }
@@ -284,7 +294,7 @@ class Feed
      * Set a new array of people.
      * If no argument is passed, it will just remove all existing people.
      *
-     * @param array<array> $values
+     * @psalm-param array<PersonArray> $values
      * @return $this
      * @throws Writer\Exception\InvalidArgumentException
      */

--- a/src/Writer/Extension/PodcastIndex/Feed.php
+++ b/src/Writer/Extension/PodcastIndex/Feed.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Laminas\Feed\Writer\Extension\PodcastIndex;
 
-use DateTime;
 use DateTimeInterface;
 use Laminas\Feed\Writer;
 use Laminas\Stdlib\StringUtils;
@@ -24,17 +23,21 @@ use function ucfirst;
 use const FILTER_VALIDATE_URL;
 
 /**
- * @psalm-type PersonArray = array{
- *     name: string,
- *     role?: string,
- *     group?: string,
- *     img?: string,
- *     href?: string
- * }
- */
-
-/**
  * Describes PodcastIndex data of a RSS Feed
+ *
+ * @psalm-type UpdateFrequencyArray = array{
+ *   description: string,
+ *   complete?: bool,
+ *   dtstart?: DateTimeInterface,
+ *   rrule?: string
+ *   }
+ * @psalm-type PersonArray = array{
+ *       name: string,
+ *       role?: string,
+ *       group?: string,
+ *       img?: string,
+ *       href?: string
+ *   }
  */
 class Feed
 {
@@ -209,7 +212,7 @@ class Feed
     /**
      * Set feed update frequency
      *
-     * @param array{description: string, complete?: bool, dtstart?: DateTime, rrule?: string} $value
+     * @param UpdateFrequencyArray $value
      * @return $this
      * @throws Writer\Exception\InvalidArgumentException
      */
@@ -230,14 +233,10 @@ class Feed
                 'invalid parameter: key "complete" of "updateFrequency": must be of type boolean'
             );
         }
-        if (isset($value['dtstart'])) {
-            if (! $value['dtstart'] instanceof DateTime) {
-                throw new Writer\Exception\InvalidArgumentException(
-                    'invalid parameter: key "dtstart" of "updateFrequency" must be of type DateTime'
-                );
-            }
-            // cast to ISO8601 string
-            $value['dtstart'] = $value['dtstart']->format(DateTimeInterface::ATOM);
+        if (isset($value['dtstart']) && ! $value['dtstart'] instanceof DateTimeInterface) {
+            throw new Writer\Exception\InvalidArgumentException(
+                'invalid parameter: key "dtstart" of "updateFrequency" must be of type DateTimeInterface'
+            );
         }
         if (isset($value['rrule']) && ! is_string($value['rrule'])) {
             throw new Writer\Exception\InvalidArgumentException(

--- a/src/Writer/Extension/PodcastIndex/Feed.php
+++ b/src/Writer/Extension/PodcastIndex/Feed.php
@@ -205,7 +205,7 @@ class Feed
     {
         if (! isset($value['description'])) {
             throw new Writer\Exception\InvalidArgumentException(
-                'invalid parameter: "updateFrequency" must be an array containing the key "description" (node value)'
+                'invalid parameter: "updateFrequency" must be an array containing at least the key "description"'
             );
         }
         if (! is_string($value['description'])) {
@@ -249,6 +249,16 @@ class Feed
         if (! is_string($value['name'])) {
             throw new Writer\Exception\InvalidArgumentException(
                 'invalid parameter: key "name" of "person" must be of type string'
+            );
+        }
+        if (isset($value['role']) && ! is_string($value['role'])) {
+            throw new Writer\Exception\InvalidArgumentException(
+                'invalid parameter: key "role" of "person" must be of type string'
+            );
+        }
+        if (isset($value['group']) && ! is_string($value['group'])) {
+            throw new Writer\Exception\InvalidArgumentException(
+                'invalid parameter: key "group" of "person" must be of type string'
             );
         }
         if (isset($value['img']) && ! filter_var($value['img'], FILTER_VALIDATE_URL)) {

--- a/src/Writer/Extension/PodcastIndex/Feed.php
+++ b/src/Writer/Extension/PodcastIndex/Feed.php
@@ -156,7 +156,7 @@ class Feed
                 'invalid parameter: "images" must be an array containing the key "srcset"'
             );
         }
-        $this->data['srcset'] = $value;
+        $this->data['images'] = $value;
         return $this;
     }
 

--- a/src/Writer/Extension/PodcastIndex/Renderer/Feed.php
+++ b/src/Writer/Extension/PodcastIndex/Renderer/Feed.php
@@ -4,12 +4,16 @@ declare(strict_types=1);
 
 namespace Laminas\Feed\Writer\Extension\PodcastIndex\Renderer;
 
+use DateTimeInterface;
 use DOMDocument;
 use DOMElement;
 use Laminas\Feed\Writer\Extension;
 
 /**
  * Renders PodcastIndex data of a RSS Feed
+ *
+ * @psalm-import-type PersonArray from \Laminas\Feed\Writer\Extension\PodcastIndex\Feed
+ * @psalm-import-type UpdateFrequencyArray from \Laminas\Feed\Writer\Extension\PodcastIndex\Feed
  */
 class Feed extends Extension\AbstractRenderer
 {
@@ -150,22 +154,22 @@ class Feed extends Extension\AbstractRenderer
      */
     private function setUpdateFrequency(DOMDocument $dom, DOMElement $root): void
     {
-        /** @psalm-var null|array<string, mixed> $updateFrequency */
+        /** @psalm-var null|UpdateFrequencyArray $updateFrequency */
         $updateFrequency = $this->getDataContainer()->getPodcastIndexUpdateFrequency();
         if ($updateFrequency === null) {
             return;
         }
         $el   = $dom->createElement('podcast:updateFrequency');
-        $text = $dom->createTextNode((string) $updateFrequency['description']);
+        $text = $dom->createTextNode($updateFrequency['description']);
         $el->appendChild($text);
         if (! empty($updateFrequency['complete'])) {
             $el->setAttribute('complete', (string) $updateFrequency['complete']);
         }
         if (! empty($updateFrequency['dtstart'])) {
-            $el->setAttribute('dtstart', (string) $updateFrequency['dtstart']);
+            $el->setAttribute('dtstart', $updateFrequency['dtstart']->format(DateTimeInterface::ATOM));
         }
         if (! empty($updateFrequency['rrule'])) {
-            $el->setAttribute('rrule', (string) $updateFrequency['rrule']);
+            $el->setAttribute('rrule', $updateFrequency['rrule']);
         }
         $root->appendChild($el);
         $this->called = true;
@@ -176,27 +180,27 @@ class Feed extends Extension\AbstractRenderer
      */
     private function addPerson(DOMDocument $dom, DOMElement $root): void
     {
-        /** @psalm-var array<array> $people */
+        /** @psalm-var list<PersonArray|> $people */
         $people = $this->getDataContainer()->getPodcastIndexPeople();
         if (empty($people)) {
             return;
         }
         foreach ($people as $person) {
             $el   = $dom->createElement('podcast:person');
-            $text = $dom->createTextNode((string) $person['name']);
+            $text = $dom->createTextNode($person['name']);
             $el->appendChild($text);
 
             if (! empty($person['role'])) {
-                $el->setAttribute('role', (string) $person['role']);
+                $el->setAttribute('role', $person['role']);
             }
             if (! empty($person['group'])) {
-                $el->setAttribute('group', (string) $person['group']);
+                $el->setAttribute('group', $person['group']);
             }
             if (! empty($person['img'])) {
-                $el->setAttribute('img', (string) $person['img']);
+                $el->setAttribute('img', $person['img']);
             }
             if (! empty($person['href'])) {
-                $el->setAttribute('href', (string) $person['href']);
+                $el->setAttribute('href', $person['href']);
             }
             $root->appendChild($el);
         }

--- a/src/Writer/Extension/PodcastIndex/Renderer/Feed.php
+++ b/src/Writer/Extension/PodcastIndex/Renderer/Feed.php
@@ -30,6 +30,7 @@ class Feed extends Extension\AbstractRenderer
         $this->setLocked($this->dom, $this->base);
         $this->setFunding($this->dom, $this->base);
         $this->setLicense($this->dom, $this->base);
+        $this->setLocation($this->dom, $this->base);
         if ($this->called) {
             $this->_appendNamespaces();
         }
@@ -97,6 +98,29 @@ class Feed extends Extension\AbstractRenderer
         $text = $dom->createTextNode((string) $license['identifier']);
         $el->appendChild($text);
         $el->setAttribute('url', $license['url']);
+        $root->appendChild($el);
+        $this->called = true;
+    }
+
+    /**
+     * Set feed location
+     */
+    protected function setLocation(DOMDocument $dom, DOMElement $root): void
+    {
+        /** @psalm-var null|array<string, string> $location */
+        $location = $this->getDataContainer()->getPodcastIndexLocation();
+        if ($location === null) {
+            return;
+        }
+        $el   = $dom->createElement('podcast:location');
+        $text = $dom->createTextNode((string) $location['description']);
+        $el->appendChild($text);
+        if (! empty($location['geo'])) {
+            $el->setAttribute('geo', $location['geo']);
+        }
+        if (! empty($location['osm'])) {
+            $el->setAttribute('osm', $location['osm']);
+        }
         $root->appendChild($el);
         $this->called = true;
     }

--- a/src/Writer/Extension/PodcastIndex/Renderer/Feed.php
+++ b/src/Writer/Extension/PodcastIndex/Renderer/Feed.php
@@ -33,6 +33,8 @@ class Feed extends Extension\AbstractRenderer
         $this->setLocation($this->dom, $this->base);
         $this->setImages($this->dom, $this->base);
         $this->setUpdateFrequency($this->dom, $this->base);
+        $this->addPerson($this->dom, $this->base);
+        $this->setPersons($this->dom, $this->base);
         if ($this->called) {
             $this->_appendNamespaces();
         }
@@ -167,5 +169,42 @@ class Feed extends Extension\AbstractRenderer
         }
         $root->appendChild($el);
         $this->called = true;
+    }
+
+    /**
+     * Add feed person
+     */
+    protected function addPerson(DOMDocument $dom, DOMElement $root): void
+    {
+        /** @psalm-var null|array<string, mixed> $person */
+        $persons = $this->getDataContainer()->getPodcastIndexPersons();
+        if ($persons === null) {
+            return;
+        }
+        foreach ($persons as $person) {
+            $el   = $dom->createElement('podcast:person');
+            $text = $dom->createTextNode((string) $person['name']);
+            $el->appendChild($text);
+
+            if (! empty($person['role'])) {
+                $el->setAttribute('role', $person['role']);
+            }
+            if (! empty($person['group'])) {
+                $el->setAttribute('group', $person['group']);
+            }
+            if (! empty($person['img'])) {
+                $el->setAttribute('img', $person['img']);
+            }
+            if (! empty($person['href'])) {
+                $el->setAttribute('href', $person['href']);
+            }
+            $root->appendChild($el);
+        }
+        $this->called = true;
+    }
+
+    protected function setPersons(DOMDocument $dom, DOMElement $root): void
+    {
+        $this->addPerson($dom, $root);
     }
 }

--- a/src/Writer/Extension/PodcastIndex/Renderer/Feed.php
+++ b/src/Writer/Extension/PodcastIndex/Renderer/Feed.php
@@ -34,7 +34,7 @@ class Feed extends Extension\AbstractRenderer
         $this->setImages($this->dom, $this->base);
         $this->setUpdateFrequency($this->dom, $this->base);
         $this->addPerson($this->dom, $this->base);
-        $this->setPersons($this->dom, $this->base);
+        $this->setPeople($this->dom, $this->base);
         if ($this->called) {
             $this->_appendNamespaces();
         }
@@ -176,12 +176,12 @@ class Feed extends Extension\AbstractRenderer
      */
     protected function addPerson(DOMDocument $dom, DOMElement $root): void
     {
-        /** @psalm-var array<array> $persons */
-        $persons = $this->getDataContainer()->getPodcastIndexPersons();
-        if (empty($persons)) {
+        /** @psalm-var array<array> $people */
+        $people = $this->getDataContainer()->getPodcastIndexPeople();
+        if (empty($people)) {
             return;
         }
-        foreach ($persons as $person) {
+        foreach ($people as $person) {
             $el   = $dom->createElement('podcast:person');
             $text = $dom->createTextNode((string) $person['name']);
             $el->appendChild($text);
@@ -203,7 +203,7 @@ class Feed extends Extension\AbstractRenderer
         $this->called = true;
     }
 
-    protected function setPersons(DOMDocument $dom, DOMElement $root): void
+    protected function setPeople(DOMDocument $dom, DOMElement $root): void
     {
         $this->addPerson($dom, $root);
     }

--- a/src/Writer/Extension/PodcastIndex/Renderer/Feed.php
+++ b/src/Writer/Extension/PodcastIndex/Renderer/Feed.php
@@ -32,6 +32,7 @@ class Feed extends Extension\AbstractRenderer
         $this->setLicense($this->dom, $this->base);
         $this->setLocation($this->dom, $this->base);
         $this->setImages($this->dom, $this->base);
+        $this->setUpdateFrequency($this->dom, $this->base);
         if ($this->called) {
             $this->_appendNamespaces();
         }
@@ -138,6 +139,32 @@ class Feed extends Extension\AbstractRenderer
         }
         $el = $dom->createElement('podcast:images');
         $el->setAttribute('srcset', $images['srcset']);
+        $root->appendChild($el);
+        $this->called = true;
+    }
+
+    /**
+     * Set feed update frequency
+     */
+    protected function setUpdateFrequency(DOMDocument $dom, DOMElement $root): void
+    {
+        /** @psalm-var null|array<string, mixed> $updateFrequency */
+        $updateFrequency = $this->getDataContainer()->getPodcastIndexUpdateFrequency();
+        if ($updateFrequency === null) {
+            return;
+        }
+        $el   = $dom->createElement('podcast:updateFrequency');
+        $text = $dom->createTextNode((string) $updateFrequency['description']);
+        $el->appendChild($text);
+        if (! empty($updateFrequency['complete'])) {
+            $el->setAttribute('complete', $updateFrequency['complete']);
+        }
+        if (! empty($updateFrequency['dtstart'])) {
+            $el->setAttribute('dtstart', $updateFrequency['dtstart']);
+        }
+        if (! empty($updateFrequency['rrule'])) {
+            $el->setAttribute('rrule', $updateFrequency['rrule']);
+        }
         $root->appendChild($el);
         $this->called = true;
     }

--- a/src/Writer/Extension/PodcastIndex/Renderer/Feed.php
+++ b/src/Writer/Extension/PodcastIndex/Renderer/Feed.php
@@ -176,9 +176,9 @@ class Feed extends Extension\AbstractRenderer
      */
     protected function addPerson(DOMDocument $dom, DOMElement $root): void
     {
-        /** @psalm-var null|array<string, mixed> $person */
+        /** @psalm-var array<array> $persons */
         $persons = $this->getDataContainer()->getPodcastIndexPersons();
-        if ($persons === null) {
+        if (empty($persons)) {
             return;
         }
         foreach ($persons as $person) {

--- a/src/Writer/Extension/PodcastIndex/Renderer/Feed.php
+++ b/src/Writer/Extension/PodcastIndex/Renderer/Feed.php
@@ -37,7 +37,6 @@ class Feed extends Extension\AbstractRenderer
         $this->setLocation($this->dom, $this->base);
         $this->setImages($this->dom, $this->base);
         $this->setUpdateFrequency($this->dom, $this->base);
-        $this->addPerson($this->dom, $this->base);
         $this->setPeople($this->dom, $this->base);
         if ($this->called) {
             $this->_appendNamespaces();
@@ -59,7 +58,7 @@ class Feed extends Extension\AbstractRenderer
     /**
      * Set feed lock
      */
-    private function setLocked(DOMDocument $dom, DOMElement $root): void
+    protected function setLocked(DOMDocument $dom, DOMElement $root): void
     {
         /** @psalm-var null|array<string, string> $locked */
         $locked = $this->getDataContainer()->getPodcastIndexLocked();
@@ -77,7 +76,7 @@ class Feed extends Extension\AbstractRenderer
     /**
      * Set feed funding
      */
-    private function setFunding(DOMDocument $dom, DOMElement $root): void
+    protected function setFunding(DOMDocument $dom, DOMElement $root): void
     {
         /** @psalm-var null|array<string, string> $funding */
         $funding = $this->getDataContainer()->getPodcastIndexFunding();
@@ -123,10 +122,10 @@ class Feed extends Extension\AbstractRenderer
         $el   = $dom->createElement('podcast:location');
         $text = $dom->createTextNode($location['description']);
         $el->appendChild($text);
-        if (! empty($location['geo'])) {
+        if (isset($location['geo']) && $location['geo'] !== '') {
             $el->setAttribute('geo', $location['geo']);
         }
-        if (! empty($location['osm'])) {
+        if (isset($location['osm']) && $location['osm'] !== '') {
             $el->setAttribute('osm', $location['osm']);
         }
         $root->appendChild($el);
@@ -162,13 +161,13 @@ class Feed extends Extension\AbstractRenderer
         $el   = $dom->createElement('podcast:updateFrequency');
         $text = $dom->createTextNode($updateFrequency['description']);
         $el->appendChild($text);
-        if (! empty($updateFrequency['complete'])) {
-            $el->setAttribute('complete', (string) $updateFrequency['complete']);
+        if (($updateFrequency['complete'] ?? null) === true) {
+            $el->setAttribute('complete', 'true');
         }
-        if (! empty($updateFrequency['dtstart'])) {
+        if (isset($updateFrequency['dtstart'])) {
             $el->setAttribute('dtstart', $updateFrequency['dtstart']->format(DateTimeInterface::ATOM));
         }
-        if (! empty($updateFrequency['rrule'])) {
+        if (isset($updateFrequency['rrule']) && $updateFrequency['rrule'] !== '') {
             $el->setAttribute('rrule', $updateFrequency['rrule']);
         }
         $root->appendChild($el);
@@ -176,11 +175,11 @@ class Feed extends Extension\AbstractRenderer
     }
 
     /**
-     * Add feed person
+     * Set feed people
      */
-    private function addPerson(DOMDocument $dom, DOMElement $root): void
+    private function setPeople(DOMDocument $dom, DOMElement $root): void
     {
-        /** @psalm-var list<PersonArray|> $people */
+        /** @psalm-var list<PersonArray> $people */
         $people = $this->getDataContainer()->getPodcastIndexPeople();
         if (empty($people)) {
             return;
@@ -190,25 +189,20 @@ class Feed extends Extension\AbstractRenderer
             $text = $dom->createTextNode($person['name']);
             $el->appendChild($text);
 
-            if (! empty($person['role'])) {
+            if (isset($person['role']) && $person['role'] !== '') {
                 $el->setAttribute('role', $person['role']);
             }
-            if (! empty($person['group'])) {
+            if (isset($person['group']) && $person['group'] !== '') {
                 $el->setAttribute('group', $person['group']);
             }
-            if (! empty($person['img'])) {
+            if (isset($person['img']) && $person['img'] !== '') {
                 $el->setAttribute('img', $person['img']);
             }
-            if (! empty($person['href'])) {
+            if (isset($person['href']) && $person['href'] !== '') {
                 $el->setAttribute('href', $person['href']);
             }
             $root->appendChild($el);
         }
         $this->called = true;
-    }
-
-    private function setPeople(DOMDocument $dom, DOMElement $root): void
-    {
-        $this->addPerson($dom, $root);
     }
 }

--- a/src/Writer/Extension/PodcastIndex/Renderer/Feed.php
+++ b/src/Writer/Extension/PodcastIndex/Renderer/Feed.php
@@ -55,7 +55,7 @@ class Feed extends Extension\AbstractRenderer
     /**
      * Set feed lock
      */
-    protected function setLocked(DOMDocument $dom, DOMElement $root): void
+    private function setLocked(DOMDocument $dom, DOMElement $root): void
     {
         /** @psalm-var null|array<string, string> $locked */
         $locked = $this->getDataContainer()->getPodcastIndexLocked();
@@ -73,7 +73,7 @@ class Feed extends Extension\AbstractRenderer
     /**
      * Set feed funding
      */
-    protected function setFunding(DOMDocument $dom, DOMElement $root): void
+    private function setFunding(DOMDocument $dom, DOMElement $root): void
     {
         /** @psalm-var null|array<string, string> $funding */
         $funding = $this->getDataContainer()->getPodcastIndexFunding();
@@ -91,7 +91,7 @@ class Feed extends Extension\AbstractRenderer
     /**
      * Set feed license
      */
-    protected function setLicense(DOMDocument $dom, DOMElement $root): void
+    private function setLicense(DOMDocument $dom, DOMElement $root): void
     {
         /** @psalm-var null|array<string,string> $license */
         $license = $this->getDataContainer()->getPodcastIndexLicense();
@@ -109,7 +109,7 @@ class Feed extends Extension\AbstractRenderer
     /**
      * Set feed location
      */
-    protected function setLocation(DOMDocument $dom, DOMElement $root): void
+    private function setLocation(DOMDocument $dom, DOMElement $root): void
     {
         /** @psalm-var null|array<string,string> $location */
         $location = $this->getDataContainer()->getPodcastIndexLocation();
@@ -132,7 +132,7 @@ class Feed extends Extension\AbstractRenderer
     /**
      * Set feed images
      */
-    protected function setImages(DOMDocument $dom, DOMElement $root): void
+    private function setImages(DOMDocument $dom, DOMElement $root): void
     {
         /** @psalm-var null|array<string, string> $images */
         $images = $this->getDataContainer()->getPodcastIndexImages();
@@ -148,7 +148,7 @@ class Feed extends Extension\AbstractRenderer
     /**
      * Set feed update frequency
      */
-    protected function setUpdateFrequency(DOMDocument $dom, DOMElement $root): void
+    private function setUpdateFrequency(DOMDocument $dom, DOMElement $root): void
     {
         /** @psalm-var null|array<string, mixed> $updateFrequency */
         $updateFrequency = $this->getDataContainer()->getPodcastIndexUpdateFrequency();
@@ -174,7 +174,7 @@ class Feed extends Extension\AbstractRenderer
     /**
      * Add feed person
      */
-    protected function addPerson(DOMDocument $dom, DOMElement $root): void
+    private function addPerson(DOMDocument $dom, DOMElement $root): void
     {
         /** @psalm-var array<array> $people */
         $people = $this->getDataContainer()->getPodcastIndexPeople();
@@ -203,7 +203,7 @@ class Feed extends Extension\AbstractRenderer
         $this->called = true;
     }
 
-    protected function setPeople(DOMDocument $dom, DOMElement $root): void
+    private function setPeople(DOMDocument $dom, DOMElement $root): void
     {
         $this->addPerson($dom, $root);
     }

--- a/src/Writer/Extension/PodcastIndex/Renderer/Feed.php
+++ b/src/Writer/Extension/PodcastIndex/Renderer/Feed.php
@@ -8,6 +8,7 @@ use DateTimeInterface;
 use DOMDocument;
 use DOMElement;
 use Laminas\Feed\Writer\Extension;
+use Laminas\Feed\Writer\Feed as FeedWriter;
 
 /**
  * Renders PodcastIndex data of a RSS Feed
@@ -60,8 +61,11 @@ class Feed extends Extension\AbstractRenderer
      */
     protected function setLocked(DOMDocument $dom, DOMElement $root): void
     {
+        /** @psalm-var FeedWriter $container */
+        $container = $this->getDataContainer();
+
         /** @psalm-var null|array<string, string> $locked */
-        $locked = $this->getDataContainer()->getPodcastIndexLocked();
+        $locked = $container->getPodcastIndexLocked();
         if ($locked === null) {
             return;
         }
@@ -78,8 +82,11 @@ class Feed extends Extension\AbstractRenderer
      */
     protected function setFunding(DOMDocument $dom, DOMElement $root): void
     {
+        /** @psalm-var FeedWriter $container */
+        $container = $this->getDataContainer();
+
         /** @psalm-var null|array<string, string> $funding */
-        $funding = $this->getDataContainer()->getPodcastIndexFunding();
+        $funding = $container->getPodcastIndexFunding();
         if ($funding === null) {
             return;
         }
@@ -96,8 +103,11 @@ class Feed extends Extension\AbstractRenderer
      */
     private function setLicense(DOMDocument $dom, DOMElement $root): void
     {
+        /** @psalm-var FeedWriter $container */
+        $container = $this->getDataContainer();
+
         /** @psalm-var null|array<string,string> $license */
-        $license = $this->getDataContainer()->getPodcastIndexLicense();
+        $license = $container->getPodcastIndexLicense();
         if ($license === null) {
             return;
         }
@@ -114,8 +124,11 @@ class Feed extends Extension\AbstractRenderer
      */
     private function setLocation(DOMDocument $dom, DOMElement $root): void
     {
+        /** @psalm-var FeedWriter $container */
+        $container = $this->getDataContainer();
+
         /** @psalm-var null|array<string,string> $location */
-        $location = $this->getDataContainer()->getPodcastIndexLocation();
+        $location = $container->getPodcastIndexLocation();
         if ($location === null) {
             return;
         }
@@ -137,8 +150,11 @@ class Feed extends Extension\AbstractRenderer
      */
     private function setImages(DOMDocument $dom, DOMElement $root): void
     {
+        /** @psalm-var FeedWriter $container */
+        $container = $this->getDataContainer();
+
         /** @psalm-var null|array<string, string> $images */
-        $images = $this->getDataContainer()->getPodcastIndexImages();
+        $images = $container->getPodcastIndexImages();
         if ($images === null) {
             return;
         }
@@ -153,8 +169,11 @@ class Feed extends Extension\AbstractRenderer
      */
     private function setUpdateFrequency(DOMDocument $dom, DOMElement $root): void
     {
+        /** @psalm-var FeedWriter $container */
+        $container = $this->getDataContainer();
+
         /** @psalm-var null|UpdateFrequencyArray $updateFrequency */
-        $updateFrequency = $this->getDataContainer()->getPodcastIndexUpdateFrequency();
+        $updateFrequency = $container->getPodcastIndexUpdateFrequency();
         if ($updateFrequency === null) {
             return;
         }
@@ -179,9 +198,12 @@ class Feed extends Extension\AbstractRenderer
      */
     private function setPeople(DOMDocument $dom, DOMElement $root): void
     {
-        /** @psalm-var list<PersonArray> $people */
-        $people = $this->getDataContainer()->getPodcastIndexPeople();
-        if (empty($people)) {
+        /** @psalm-var FeedWriter $container */
+        $container = $this->getDataContainer();
+
+        /** @psalm-var list<PersonArray>|null $people */
+        $people = $container->getPodcastIndexPeople();
+        if ($people === null || $people === []) {
             return;
         }
         foreach ($people as $person) {

--- a/src/Writer/Extension/PodcastIndex/Renderer/Feed.php
+++ b/src/Writer/Extension/PodcastIndex/Renderer/Feed.php
@@ -31,6 +31,7 @@ class Feed extends Extension\AbstractRenderer
         $this->setFunding($this->dom, $this->base);
         $this->setLicense($this->dom, $this->base);
         $this->setLocation($this->dom, $this->base);
+        $this->setImages($this->dom, $this->base);
         if ($this->called) {
             $this->_appendNamespaces();
         }
@@ -121,6 +122,22 @@ class Feed extends Extension\AbstractRenderer
         if (! empty($location['osm'])) {
             $el->setAttribute('osm', $location['osm']);
         }
+        $root->appendChild($el);
+        $this->called = true;
+    }
+
+    /**
+     * Set feed images
+     */
+    protected function setImages(DOMDocument $dom, DOMElement $root): void
+    {
+        /** @psalm-var null|array<string, string> $images */
+        $images = $this->getDataContainer()->getPodcastIndexImages();
+        if ($images === null) {
+            return;
+        }
+        $el = $dom->createElement('podcast:images');
+        $el->setAttribute('srcset', $images['srcset']);
         $root->appendChild($el);
         $this->called = true;
     }

--- a/src/Writer/Extension/PodcastIndex/Renderer/Feed.php
+++ b/src/Writer/Extension/PodcastIndex/Renderer/Feed.php
@@ -29,6 +29,7 @@ class Feed extends Extension\AbstractRenderer
     {
         $this->setLocked($this->dom, $this->base);
         $this->setFunding($this->dom, $this->base);
+        $this->setLicense($this->dom, $this->base);
         if ($this->called) {
             $this->_appendNamespaces();
         }
@@ -78,6 +79,24 @@ class Feed extends Extension\AbstractRenderer
         $text = $dom->createTextNode((string) $funding['title']);
         $el->appendChild($text);
         $el->setAttribute('url', $funding['url']);
+        $root->appendChild($el);
+        $this->called = true;
+    }
+
+    /**
+     * Set feed license
+     */
+    protected function setLicense(DOMDocument $dom, DOMElement $root): void
+    {
+        /** @psalm-var null|array<string, string> $license */
+        $license = $this->getDataContainer()->getPodcastIndexLicense();
+        if ($license === null) {
+            return;
+        }
+        $el   = $dom->createElement('podcast:license');
+        $text = $dom->createTextNode((string) $license['identifier']);
+        $el->appendChild($text);
+        $el->setAttribute('url', $license['url']);
         $root->appendChild($el);
         $this->called = true;
     }

--- a/src/Writer/Extension/PodcastIndex/Renderer/Feed.php
+++ b/src/Writer/Extension/PodcastIndex/Renderer/Feed.php
@@ -93,13 +93,13 @@ class Feed extends Extension\AbstractRenderer
      */
     protected function setLicense(DOMDocument $dom, DOMElement $root): void
     {
-        /** @psalm-var null|array<string, string> $license */
+        /** @psalm-var null|array<string,string> $license */
         $license = $this->getDataContainer()->getPodcastIndexLicense();
         if ($license === null) {
             return;
         }
         $el   = $dom->createElement('podcast:license');
-        $text = $dom->createTextNode((string) $license['identifier']);
+        $text = $dom->createTextNode($license['identifier']);
         $el->appendChild($text);
         $el->setAttribute('url', $license['url']);
         $root->appendChild($el);
@@ -111,13 +111,13 @@ class Feed extends Extension\AbstractRenderer
      */
     protected function setLocation(DOMDocument $dom, DOMElement $root): void
     {
-        /** @psalm-var null|array<string, string> $location */
+        /** @psalm-var null|array<string,string> $location */
         $location = $this->getDataContainer()->getPodcastIndexLocation();
         if ($location === null) {
             return;
         }
         $el   = $dom->createElement('podcast:location');
-        $text = $dom->createTextNode((string) $location['description']);
+        $text = $dom->createTextNode($location['description']);
         $el->appendChild($text);
         if (! empty($location['geo'])) {
             $el->setAttribute('geo', $location['geo']);
@@ -159,13 +159,13 @@ class Feed extends Extension\AbstractRenderer
         $text = $dom->createTextNode((string) $updateFrequency['description']);
         $el->appendChild($text);
         if (! empty($updateFrequency['complete'])) {
-            $el->setAttribute('complete', $updateFrequency['complete']);
+            $el->setAttribute('complete', (string) $updateFrequency['complete']);
         }
         if (! empty($updateFrequency['dtstart'])) {
-            $el->setAttribute('dtstart', $updateFrequency['dtstart']);
+            $el->setAttribute('dtstart', (string) $updateFrequency['dtstart']);
         }
         if (! empty($updateFrequency['rrule'])) {
-            $el->setAttribute('rrule', $updateFrequency['rrule']);
+            $el->setAttribute('rrule', (string) $updateFrequency['rrule']);
         }
         $root->appendChild($el);
         $this->called = true;
@@ -187,16 +187,16 @@ class Feed extends Extension\AbstractRenderer
             $el->appendChild($text);
 
             if (! empty($person['role'])) {
-                $el->setAttribute('role', $person['role']);
+                $el->setAttribute('role', (string) $person['role']);
             }
             if (! empty($person['group'])) {
-                $el->setAttribute('group', $person['group']);
+                $el->setAttribute('group', (string) $person['group']);
             }
             if (! empty($person['img'])) {
-                $el->setAttribute('img', $person['img']);
+                $el->setAttribute('img', (string) $person['img']);
             }
             if (! empty($person['href'])) {
-                $el->setAttribute('href', $person['href']);
+                $el->setAttribute('href', (string) $person['href']);
             }
             $root->appendChild($el);
         }

--- a/test/Reader/Integration/PodcastIndexRss2Test.php
+++ b/test/Reader/Integration/PodcastIndexRss2Test.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\TestCase;
 use stdClass;
 
 use function file_get_contents;
+use function implode;
 
 /**
  * @group Laminas_Feed
@@ -58,6 +59,89 @@ class PodcastIndexRss2Test extends TestCase
         $expected->title = 'Support the show!';
 
         $this->assertEquals($expected, $feed->getFunding());
+    }
+
+    public function testGetsLicense(): void
+    {
+        /** @var Reader\Extension\PodcastIndex\Feed $feed */
+        $feed = Reader\Reader::importString(
+            file_get_contents($this->feedSamplePath)
+        );
+
+        $expected             = new stdClass();
+        $expected->identifier = 'my-podcast-license-v1';
+        $expected->url        = 'https://example.org/mypodcastlicense/full.pdf';
+
+        $this->assertEquals($expected, $feed->getLicense());
+    }
+
+    public function testGetsLocation(): void
+    {
+        /** @var Reader\Extension\PodcastIndex\Feed $feed */
+        $feed = Reader\Reader::importString(
+            file_get_contents($this->feedSamplePath)
+        );
+
+        $expected              = new stdClass();
+        $expected->description = 'Austin';
+        $expected->geo         = 'geo:30.2711286,-97.7436995';
+        $expected->osm         = 'R113314';
+
+        $this->assertEquals($expected, $feed->getLocation());
+    }
+
+    public function testGetsImages(): void
+    {
+        /** @var Reader\Extension\PodcastIndex\Feed $feed */
+        $feed = Reader\Reader::importString(
+            file_get_contents($this->feedSamplePath)
+        );
+
+        $srcset = [
+            "https://example.com/images/ep1/pci_avatar-massive.jpg 1500w",
+            "https://example.com/images/ep1/pci_avatar-middle.jpg 600w",
+            "https://example.com/images/ep1/pci_avatar-small.jpg 300w",
+            "https://example.com/images/ep1/pci_avatar-tiny.jpg 150w",
+        ];
+
+        $expected         = new stdClass();
+        $expected->srcset = implode(', ', $srcset);
+
+        $this->assertEquals($expected, $feed->getImages());
+    }
+
+    public function testGetsUpdateFrequency(): void
+    {
+        /** @var Reader\Extension\PodcastIndex\Feed $feed */
+        $feed = Reader\Reader::importString(
+            file_get_contents($this->feedSamplePath)
+        );
+
+        $expected              = new stdClass();
+        $expected->description = 'Every other Monday';
+        $expected->complete    = 'false';
+        $expected->dtstart     = '2023-08-28T00:00:00.000Z';
+        $expected->rrule       = 'FREQ=WEEKLY';
+
+        $this->assertEquals($expected, $feed->getUpdateFrequency());
+    }
+
+    public function testGetsPersons(): void
+    {
+        /** @var Reader\Extension\PodcastIndex\Feed $feed */
+        $feed = Reader\Reader::importString(
+            file_get_contents($this->feedSamplePath)
+        );
+
+        $expected        = new stdClass();
+        $expected->name  = 'Alice Brown';
+        $expected->role  = 'guest';
+        $expected->group = 'writing';
+        $expected->img   = 'http://example.com/images/alicebrown.jpg';
+        $expected->href  = 'https://www.wikipedia/alicebrown';
+
+        $persons = $feed->getPersons();
+        $this->assertEquals($expected, $persons[0]);
     }
 
     /**

--- a/test/Reader/Integration/PodcastIndexRss2Test.php
+++ b/test/Reader/Integration/PodcastIndexRss2Test.php
@@ -45,6 +45,7 @@ class PodcastIndexRss2Test extends TestCase
             file_get_contents($this->feedSamplePath)
         );
         $this->assertEquals('john.doe@example.com', $feed->getLockOwner());
+        $this->assertEquals('john.doe@example.com', $feed->getPodcastIndexLockOwner());
     }
 
     public function testGetsFunding(): void
@@ -59,6 +60,7 @@ class PodcastIndexRss2Test extends TestCase
         $expected->title = 'Support the show!';
 
         $this->assertEquals($expected, $feed->getFunding());
+        $this->assertEquals($expected, $feed->getPodcastIndexFunding());
     }
 
     public function testGetsLicense(): void
@@ -72,7 +74,7 @@ class PodcastIndexRss2Test extends TestCase
         $expected->identifier = 'my-podcast-license-v1';
         $expected->url        = 'https://example.org/mypodcastlicense/full.pdf';
 
-        $this->assertEquals($expected, $feed->getLicense());
+        $this->assertEquals($expected, $feed->getPodcastIndexLicense());
     }
 
     public function testGetsLocation(): void
@@ -87,7 +89,7 @@ class PodcastIndexRss2Test extends TestCase
         $expected->geo         = 'geo:30.2711286,-97.7436995';
         $expected->osm         = 'R113314';
 
-        $this->assertEquals($expected, $feed->getLocation());
+        $this->assertEquals($expected, $feed->getPodcastIndexLocation());
     }
 
     public function testGetsImages(): void
@@ -107,7 +109,7 @@ class PodcastIndexRss2Test extends TestCase
         $expected         = new stdClass();
         $expected->srcset = implode(', ', $srcset);
 
-        $this->assertEquals($expected, $feed->getImages());
+        $this->assertEquals($expected, $feed->getPodcastIndexImages());
     }
 
     public function testGetsUpdateFrequency(): void
@@ -123,7 +125,7 @@ class PodcastIndexRss2Test extends TestCase
         $expected->dtstart     = '2023-08-28T00:00:00.000Z';
         $expected->rrule       = 'FREQ=WEEKLY';
 
-        $this->assertEquals($expected, $feed->getUpdateFrequency());
+        $this->assertEquals($expected, $feed->getPodcastIndexUpdateFrequency());
     }
 
     public function testGetsPersons(): void
@@ -140,7 +142,7 @@ class PodcastIndexRss2Test extends TestCase
         $expected->img   = 'http://example.com/images/alicebrown.jpg';
         $expected->href  = 'https://www.wikipedia/alicebrown';
 
-        $persons = $feed->getPersons();
+        $persons = $feed->getPodcastIndexPersons();
         $this->assertEquals($expected, $persons[0]);
     }
 

--- a/test/Reader/Integration/PodcastIndexRss2Test.php
+++ b/test/Reader/Integration/PodcastIndexRss2Test.php
@@ -128,7 +128,7 @@ class PodcastIndexRss2Test extends TestCase
         $this->assertEquals($expected, $feed->getPodcastIndexUpdateFrequency());
     }
 
-    public function testGetsPersons(): void
+    public function testGetsPeople(): void
     {
         /** @var Reader\Extension\PodcastIndex\Feed $feed */
         $feed = Reader\Reader::importString(
@@ -142,8 +142,8 @@ class PodcastIndexRss2Test extends TestCase
         $expected->img   = 'http://example.com/images/alicebrown.jpg';
         $expected->href  = 'https://www.wikipedia/alicebrown';
 
-        $persons = $feed->getPodcastIndexPersons();
-        $this->assertEquals($expected, $persons[0]);
+        $people = $feed->getPodcastIndexPeople();
+        $this->assertEquals($expected, $people[0]);
     }
 
     /**

--- a/test/Reader/Integration/_files/podcastindex.xml
+++ b/test/Reader/Integration/_files/podcastindex.xml
@@ -35,6 +35,11 @@
         <itunes:category text="TV &amp; Film" />
         <podcast:locked owner="john.doe@example.com">yes</podcast:locked>
         <podcast:funding url="http://example.com/donate">Support the show!</podcast:funding>
+        <podcast:license url="https://example.org/mypodcastlicense/full.pdf">my-podcast-license-v1</podcast:license>
+        <podcast:location geo="geo:30.2711286,-97.7436995" osm="R113314">Austin</podcast:location>
+        <podcast:images srcset="https://example.com/images/ep1/pci_avatar-massive.jpg 1500w, https://example.com/images/ep1/pci_avatar-middle.jpg 600w, https://example.com/images/ep1/pci_avatar-small.jpg 300w, https://example.com/images/ep1/pci_avatar-tiny.jpg 150w"/>
+        <podcast:updateFrequency rrule="FREQ=WEEKLY" dtstart="2023-08-28T00:00:00.000Z" complete="false">Every other Monday</podcast:updateFrequency>
+        <podcast:person group="writing" role="guest" href="https://www.wikipedia/alicebrown" img="http://example.com/images/alicebrown.jpg">Alice Brown</podcast:person>
 
         <item>
             <title>Shake Shake Shake Your Spices</title>

--- a/test/Writer/Extension/PodcastIndex/FeedTest.php
+++ b/test/Writer/Extension/PodcastIndex/FeedTest.php
@@ -7,6 +7,7 @@ namespace LaminasTest\Feed\Writer\Extension\PodcastIndex;
 use Laminas\Feed\Writer;
 use PHPUnit\Framework\TestCase;
 
+use function count;
 use function implode;
 use function in_array;
 use function time;
@@ -356,13 +357,27 @@ class FeedTest extends TestCase
         ];
         // set
         $feed->setPodcastIndexPersons($persons);
-
         /** @var array<array> $personsSaved */
         $personsSaved = $feed->getPodcastIndexPersons();
-
         foreach ($persons as $person) {
             $this->assertTrue(in_array($person, $personsSaved));
         }
+        // update
+        $newPersons = [
+            [
+                'name'  => 'Alice Brown',
+                'role'  => 'guest',
+                'group' => 'writing',
+                'img'   => 'http://example.com/images/alicebrown.jpg',
+                'href'  => 'https://www.wikipedia/alicebrown',
+            ],
+        ];
+        $feed->setPodcastIndexPersons($newPersons);
+        /** @var array<array> $updated */
+        $updated = $feed->getPodcastIndexPersons();
+        $this->assertEquals(1, count($updated));
+        $this->assertEquals($newPersons, $updated);
+
         // delete
         $feed->setPodcastIndexPersons();
         $this->assertNull($feed->getPodcastIndexPersons());

--- a/test/Writer/Extension/PodcastIndex/FeedTest.php
+++ b/test/Writer/Extension/PodcastIndex/FeedTest.php
@@ -110,4 +110,39 @@ class FeedTest extends TestCase
         $this->expectException(Writer\Exception\InvalidArgumentException::class);
         $feed->setPodcastIndexLicense($license);
     }
+
+    public function testSetLocation(): void
+    {
+        $feed = new Writer\Feed();
+
+        $location = [
+            'description' => 'London, Baker Street',
+            'geo'         => 'geo:-27.86159,153.3169',
+            'osm'         => 'W43678282',
+        ];
+        $feed->setPodcastIndexLocation($location);
+        $this->assertEquals($location, $feed->getPodcastIndexLocation());
+    }
+
+    public function testSetLocationWithOneArgument(): void
+    {
+        $feed = new Writer\Feed();
+
+        $location = [
+            'description' => 'Dreamworld (Queensland)',
+        ];
+        $feed->setPodcastIndexLocation($location);
+        $this->assertEquals($location, $feed->getPodcastIndexLocation());
+    }
+
+    public function testSetLocationThrowsExceptionOnInvalidArguments(): void
+    {
+        $feed = new Writer\Feed();
+
+        $location = [
+            'abc' => 'def',
+        ];
+        $this->expectException(Writer\Exception\InvalidArgumentException::class);
+        $feed->setPodcastIndexLocation($location);
+    }
 }

--- a/test/Writer/Extension/PodcastIndex/FeedTest.php
+++ b/test/Writer/Extension/PodcastIndex/FeedTest.php
@@ -87,4 +87,27 @@ class FeedTest extends TestCase
         $this->expectException(Writer\Exception\InvalidArgumentException::class);
         $feed->setPodcastIndexFunding($locked);
     }
+
+    public function testSetLicense(): void
+    {
+        $feed = new Writer\Feed();
+
+        $license = [
+            'identifier' => 'cc-by-4.0',
+            'url'        => 'https://spdx.org/licenses/CC-BY-4.0.html',
+        ];
+        $feed->setPodcastIndexLicense($license);
+        $this->assertEquals($license, $feed->getPodcastIndexLicense());
+    }
+
+    public function testSetLicenseThrowsExceptionOnInvalidArguments(): void
+    {
+        $feed = new Writer\Feed();
+
+        $license = [
+            'abc' => 'def',
+        ];
+        $this->expectException(Writer\Exception\InvalidArgumentException::class);
+        $feed->setPodcastIndexLicense($license);
+    }
 }

--- a/test/Writer/Extension/PodcastIndex/FeedTest.php
+++ b/test/Writer/Extension/PodcastIndex/FeedTest.php
@@ -332,16 +332,16 @@ class FeedTest extends TestCase
         ];
         $feed->addPodcastIndexPerson($person);
 
-        /** @var array<array> $persons */
-        $persons = $feed->getPodcastIndexPersons();
-        $this->assertTrue(in_array($person, $persons));
+        /** @var array<array> $people */
+        $people = $feed->getPodcastIndexPeople();
+        $this->assertTrue(in_array($person, $people));
     }
 
-    public function testSetPersons(): void
+    public function testSetPeople(): void
     {
         $feed = new Writer\Feed();
 
-        $persons = [
+        $people = [
             [
                 'name'  => 'Hercules Poirot',
                 'role'  => 'guest',
@@ -356,11 +356,11 @@ class FeedTest extends TestCase
             ],
         ];
         // set
-        $feed->setPodcastIndexPersons($persons);
-        /** @var array<array> $personsSaved */
-        $personsSaved = $feed->getPodcastIndexPersons();
-        foreach ($persons as $person) {
-            $this->assertTrue(in_array($person, $personsSaved));
+        $feed->setPodcastIndexPeople($people);
+        /** @var array<array> $peopleSaved */
+        $peopleSaved = $feed->getPodcastIndexPeople();
+        foreach ($people as $person) {
+            $this->assertTrue(in_array($person, $peopleSaved));
         }
         // update
         $newPersons = [
@@ -372,15 +372,15 @@ class FeedTest extends TestCase
                 'href'  => 'https://www.wikipedia/alicebrown',
             ],
         ];
-        $feed->setPodcastIndexPersons($newPersons);
+        $feed->setPodcastIndexPeople($newPersons);
         /** @var array<array> $updated */
-        $updated = $feed->getPodcastIndexPersons();
+        $updated = $feed->getPodcastIndexPeople();
         $this->assertEquals(1, count($updated));
         $this->assertEquals($newPersons, $updated);
 
         // delete
-        $feed->setPodcastIndexPersons();
-        $this->assertNull($feed->getPodcastIndexPersons());
+        $feed->setPodcastIndexPeople();
+        $this->assertNull($feed->getPodcastIndexPeople());
     }
 
     public function testSetPersonWithOneArgument(): void
@@ -392,9 +392,9 @@ class FeedTest extends TestCase
         ];
         $feed->addPodcastIndexPerson($person);
 
-        /** @var array<array> $persons */
-        $persons = $feed->getPodcastIndexPersons();
-        $this->assertTrue(in_array($person, $persons));
+        /** @var array<array> $people */
+        $people = $feed->getPodcastIndexPeople();
+        $this->assertTrue(in_array($person, $people));
     }
 
     public function testSetPersonThrowsExceptionOnInvalidArguments(): void

--- a/test/Writer/Extension/PodcastIndex/FeedTest.php
+++ b/test/Writer/Extension/PodcastIndex/FeedTest.php
@@ -7,6 +7,7 @@ namespace LaminasTest\Feed\Writer\Extension\PodcastIndex;
 use Laminas\Feed\Writer;
 use PHPUnit\Framework\TestCase;
 
+use function implode;
 use function in_array;
 use function time;
 
@@ -153,12 +154,16 @@ class FeedTest extends TestCase
     {
         $feed = new Writer\Feed();
 
-        $images = [
-            'srcset' => "https://example.com/images/ep1/pci_avatar-massive.jpg 1500w, 
-    https://example.com/images/ep1/pci_avatar-middle.jpg 600w, 
-    https://example.com/images/ep1/pci_avatar-small.jpg 300w, 
-    https://example.com/images/ep1/pci_avatar-tiny.jpg 150w",
+        $srcset = [
+            "https://example.com/images/ep1/pci_avatar-massive.jpg 1500w",
+            "https://example.com/images/ep1/pci_avatar-middle.jpg 600w",
+            "https://example.com/images/ep1/pci_avatar-small.jpg 300w",
+            "https://example.com/images/ep1/pci_avatar-tiny.jpg 150w",
         ];
+        $images = [
+            'srcset' => implode(", ", $srcset), // cast to string
+        ];
+
         $feed->setPodcastIndexImages($images);
         $this->assertEquals($images, $feed->getPodcastIndexImages());
     }
@@ -170,6 +175,24 @@ class FeedTest extends TestCase
         $images = [
             'abc' => 'def',
         ];
+        $this->expectException(Writer\Exception\InvalidArgumentException::class);
+        $feed->setPodcastIndexImages($images);
+    }
+
+    public function testSetImagesThrowsExceptionOnInvalidSrcsetType(): void
+    {
+        $feed = new Writer\Feed();
+
+        $srcset = [
+            "https://example.com/images/ep1/pci_avatar-massive.jpg 1500w",
+            "https://example.com/images/ep1/pci_avatar-middle.jpg 600w",
+            "https://example.com/images/ep1/pci_avatar-small.jpg 300w",
+            "https://example.com/images/ep1/pci_avatar-tiny.jpg 150w",
+        ];
+        $images = [
+            'srcset' => $srcset, // plain array, not allowed
+        ];
+
         $this->expectException(Writer\Exception\InvalidArgumentException::class);
         $feed->setPodcastIndexImages($images);
     }

--- a/test/Writer/Extension/PodcastIndex/FeedTest.php
+++ b/test/Writer/Extension/PodcastIndex/FeedTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace LaminasTest\Feed\Writer\Extension\PodcastIndex;
 
 use DateTime;
-use DateTimeInterface;
 use Laminas\Feed\Writer;
 use PHPUnit\Framework\TestCase;
 
@@ -273,13 +272,7 @@ class FeedTest extends TestCase
             'rrule'       => 'FREQ=DAILY',
         ];
         $feed->setPodcastIndexUpdateFrequency($updateFrequency);
-
-        /** @var array $response */
-        $response = $feed->getPodcastIndexUpdateFrequency();
-        $this->assertEquals($updateFrequency['description'], $response['description']);
-        $this->assertEquals($updateFrequency['complete'], $response['complete']);
-        $this->assertEquals($updateFrequency['rrule'], $response['rrule']);
-        $this->assertEquals($date->format(DateTimeInterface::ATOM), $response['dtstart']);
+        $this->assertEquals($updateFrequency, $feed->getPodcastIndexUpdateFrequency());
     }
 
     public function testSetUpdateFrequencyWithOneArgument(): void

--- a/test/Writer/Extension/PodcastIndex/FeedTest.php
+++ b/test/Writer/Extension/PodcastIndex/FeedTest.php
@@ -7,6 +7,8 @@ namespace LaminasTest\Feed\Writer\Extension\PodcastIndex;
 use Laminas\Feed\Writer;
 use PHPUnit\Framework\TestCase;
 
+use function time;
+
 class FeedTest extends TestCase
 {
     public function testSetLocked(): void
@@ -169,5 +171,65 @@ class FeedTest extends TestCase
         ];
         $this->expectException(Writer\Exception\InvalidArgumentException::class);
         $feed->setPodcastIndexImages($images);
+    }
+
+    public function testSetUpdateFrequency(): void
+    {
+        $feed = new Writer\Feed();
+
+        $updateFrequency = [
+            'description' => 'Daily',
+            'complete'    => false,
+            'dtstart'     => '2023-08-28T00:00:00.000Z',
+            'rrule'       => 'FREQ=DAILY',
+        ];
+        $feed->setPodcastIndexUpdateFrequency($updateFrequency);
+        $this->assertEquals($updateFrequency, $feed->getPodcastIndexUpdateFrequency());
+    }
+
+    public function testSetUpdateFrequencyWithOneArgument(): void
+    {
+        $feed = new Writer\Feed();
+
+        $updateFrequency = [
+            'description' => 'Daily',
+        ];
+        $feed->setPodcastIndexUpdateFrequency($updateFrequency);
+        $this->assertEquals($updateFrequency, $feed->getPodcastIndexUpdateFrequency());
+    }
+
+    public function testSetUpdateFrequencyThrowsExceptionOnInvalidArguments(): void
+    {
+        $feed = new Writer\Feed();
+
+        $updateFrequency = [
+            'abc' => 'def',
+        ];
+        $this->expectException(Writer\Exception\InvalidArgumentException::class);
+        $feed->setPodcastIndexUpdateFrequency($updateFrequency);
+    }
+
+    public function testSetUpdateFrequencyThrowsExceptionOnInvalidCompleteValue(): void
+    {
+        $feed = new Writer\Feed();
+
+        $updateFrequency = [
+            'description' => 'Daily',
+            'complete'    => 'yes',
+        ];
+        $this->expectException(Writer\Exception\InvalidArgumentException::class);
+        $feed->setPodcastIndexUpdateFrequency($updateFrequency);
+    }
+
+    public function testSetUpdateFrequencyThrowsExceptionOnInvalidDateValue(): void
+    {
+        $feed = new Writer\Feed();
+
+        $updateFrequency = [
+            'description' => 'Daily',
+            'dtstart'     => time(),
+        ];
+        $this->expectException(Writer\Exception\InvalidArgumentException::class);
+        $feed->setPodcastIndexUpdateFrequency($updateFrequency);
     }
 }

--- a/test/Writer/Extension/PodcastIndex/FeedTest.php
+++ b/test/Writer/Extension/PodcastIndex/FeedTest.php
@@ -330,7 +330,10 @@ class FeedTest extends TestCase
             'href'  => 'https://poirot.com/my-cases',
         ];
         $feed->addPodcastIndexPerson($person);
-        $this->assertTrue(in_array($person, $feed->getPodcastIndexPersons()));
+
+        /** @var array<array> $persons */
+        $persons = $feed->getPodcastIndexPersons();
+        $this->assertTrue(in_array($person, $persons));
     }
 
     public function testSetPersons(): void
@@ -353,8 +356,12 @@ class FeedTest extends TestCase
         ];
         // set
         $feed->setPodcastIndexPersons($persons);
+
+        /** @var array<array> $personsSaved */
+        $personsSaved = $feed->getPodcastIndexPersons();
+
         foreach ($persons as $person) {
-            $this->assertTrue(in_array($person, $feed->getPodcastIndexPersons()));
+            $this->assertTrue(in_array($person, $personsSaved));
         }
         // delete
         $feed->setPodcastIndexPersons();
@@ -369,7 +376,10 @@ class FeedTest extends TestCase
             'name' => 'Hercules Poirot',
         ];
         $feed->addPodcastIndexPerson($person);
-        $this->assertTrue(in_array($person, $feed->getPodcastIndexPersons()));
+
+        /** @var array<array> $persons */
+        $persons = $feed->getPodcastIndexPersons();
+        $this->assertTrue(in_array($person, $persons));
     }
 
     public function testSetPersonThrowsExceptionOnInvalidArguments(): void

--- a/test/Writer/Extension/PodcastIndex/FeedTest.php
+++ b/test/Writer/Extension/PodcastIndex/FeedTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace LaminasTest\Feed\Writer\Extension\PodcastIndex;
 
+use DateTime;
+use DateTimeInterface;
 use Laminas\Feed\Writer;
 use PHPUnit\Framework\TestCase;
 
@@ -261,16 +263,23 @@ class FeedTest extends TestCase
 
     public function testSetUpdateFrequency(): void
     {
+        $date = new DateTime();
         $feed = new Writer\Feed();
 
         $updateFrequency = [
             'description' => 'Daily',
             'complete'    => false,
-            'dtstart'     => '2023-08-28T00:00:00.000Z',
+            'dtstart'     => $date,
             'rrule'       => 'FREQ=DAILY',
         ];
         $feed->setPodcastIndexUpdateFrequency($updateFrequency);
-        $this->assertEquals($updateFrequency, $feed->getPodcastIndexUpdateFrequency());
+
+        /** @var array $response */
+        $response = $feed->getPodcastIndexUpdateFrequency();
+        $this->assertEquals($updateFrequency['description'], $response['description']);
+        $this->assertEquals($updateFrequency['complete'], $response['complete']);
+        $this->assertEquals($updateFrequency['rrule'], $response['rrule']);
+        $this->assertEquals($date->format(DateTimeInterface::ATOM), $response['dtstart']);
     }
 
     public function testSetUpdateFrequencyWithOneArgument(): void

--- a/test/Writer/Extension/PodcastIndex/FeedTest.php
+++ b/test/Writer/Extension/PodcastIndex/FeedTest.php
@@ -7,6 +7,7 @@ namespace LaminasTest\Feed\Writer\Extension\PodcastIndex;
 use Laminas\Feed\Writer;
 use PHPUnit\Framework\TestCase;
 
+use function in_array;
 use function time;
 
 class FeedTest extends TestCase
@@ -231,5 +232,83 @@ class FeedTest extends TestCase
         ];
         $this->expectException(Writer\Exception\InvalidArgumentException::class);
         $feed->setPodcastIndexUpdateFrequency($updateFrequency);
+    }
+
+    public function testAddPerson(): void
+    {
+        $feed = new Writer\Feed();
+
+        $person = [
+            'name'  => 'Hercules Poirot',
+            'role'  => 'guest',
+            'group' => 'writing',
+            'img'   => 'https://poirot.com/about/my-moustage.jpg',
+            'href'  => 'https://poirot.com/my-cases',
+        ];
+        $feed->addPodcastIndexPerson($person);
+        $this->assertTrue(in_array($person, $feed->getPodcastIndexPersons()));
+    }
+
+    public function testSetPersons(): void
+    {
+        $feed = new Writer\Feed();
+
+        $persons = [
+            [
+                'name'  => 'Hercules Poirot',
+                'role'  => 'guest',
+                'group' => 'writing',
+                'img'   => 'https://poirot.com/about/my-moustage.jpg',
+                'href'  => 'https://poirot.com/my-cases',
+            ],
+            [
+                'name' => 'Agatha Christie',
+                'role' => 'guest',
+            ],
+        ];
+        // set
+        $feed->setPodcastIndexPersons($persons);
+        foreach ($persons as $person) {
+            $this->assertTrue(in_array($person, $feed->getPodcastIndexPersons()));
+        }
+        // delete
+        $feed->setPodcastIndexPersons();
+        $this->assertNull($feed->getPodcastIndexPersons());
+    }
+
+    public function testSetPersonWithOneArgument(): void
+    {
+        $feed = new Writer\Feed();
+
+        $person = [
+            'name' => 'Hercules Poirot',
+        ];
+        $feed->addPodcastIndexPerson($person);
+        $this->assertTrue(in_array($person, $feed->getPodcastIndexPersons()));
+    }
+
+    public function testSetPersonThrowsExceptionOnInvalidArguments(): void
+    {
+        $feed = new Writer\Feed();
+
+        $person = [
+            'abc' => 'def',
+        ];
+        $this->expectException(Writer\Exception\InvalidArgumentException::class);
+        $feed->addPodcastIndexPerson($person);
+    }
+
+    public function testSetPersonThrowsExceptionOnInvalidImageUrl(): void
+    {
+        $feed = new Writer\Feed();
+
+        $person = [
+            'name'  => 'Hercules Poirot',
+            'role'  => 'guest',
+            'group' => 'writing',
+            'img'   => 'poirot.com/my-moustage.jpg',
+        ];
+        $this->expectException(Writer\Exception\InvalidArgumentException::class);
+        $feed->addPodcastIndexPerson($person);
     }
 }

--- a/test/Writer/Extension/PodcastIndex/FeedTest.php
+++ b/test/Writer/Extension/PodcastIndex/FeedTest.php
@@ -115,6 +115,41 @@ class FeedTest extends TestCase
         $feed->setPodcastIndexLicense($license);
     }
 
+    public function testSetLicenseThrowsExceptionOnInvalidIdentifier(): void
+    {
+        $feed = new Writer\Feed();
+
+        $license = [
+            'identifier' => 1234,
+            'url'        => 'https://spdx.org/licenses/CC-BY-4.0.html',
+        ];
+        $this->expectException(Writer\Exception\InvalidArgumentException::class);
+        $feed->setPodcastIndexLicense($license);
+    }
+
+    public function testSetLicenseThrowsExceptionOnInvalidUrl(): void
+    {
+        $feed = new Writer\Feed();
+
+        $license = [
+            'identifier' => 'cc-by-4.0',
+            'url'        => 'spdx.org/licenses/CC-BY-4.0.html',
+        ];
+        $this->expectException(Writer\Exception\InvalidArgumentException::class);
+        $feed->setPodcastIndexLicense($license);
+    }
+
+    public function testSetLicenseThrowsExceptionOnMissingUrl(): void
+    {
+        $feed = new Writer\Feed();
+
+        $license = [
+            'identifier' => 'cc-by-4.0',
+        ];
+        $this->expectException(Writer\Exception\InvalidArgumentException::class);
+        $feed->setPodcastIndexLicense($license);
+    }
+
     public function testSetLocation(): void
     {
         $feed = new Writer\Feed();
@@ -133,7 +168,7 @@ class FeedTest extends TestCase
         $feed = new Writer\Feed();
 
         $location = [
-            'description' => 'Dreamworld (Queensland)',
+            'description' => 'London, Baker Street',
         ];
         $feed->setPodcastIndexLocation($location);
         $this->assertEquals($location, $feed->getPodcastIndexLocation());
@@ -145,6 +180,32 @@ class FeedTest extends TestCase
 
         $location = [
             'abc' => 'def',
+        ];
+        $this->expectException(Writer\Exception\InvalidArgumentException::class);
+        $feed->setPodcastIndexLocation($location);
+    }
+
+    public function testSetLocationThrowsExceptionOnInvalidGeo(): void
+    {
+        $feed = new Writer\Feed();
+
+        $location = [
+            'description' => 'London, Baker Street',
+            'geo'         => [-27.86159, 153.3169],
+            'osm'         => 'W43678282',
+        ];
+        $this->expectException(Writer\Exception\InvalidArgumentException::class);
+        $feed->setPodcastIndexLocation($location);
+    }
+
+    public function testSetLocationThrowsExceptionOnInvalidOsm(): void
+    {
+        $feed = new Writer\Feed();
+
+        $location = [
+            'description' => 'London, Baker Street',
+            'geo'         => 'geo:-27.86159,153.3169',
+            'osm'         => false,
         ];
         $this->expectException(Writer\Exception\InvalidArgumentException::class);
         $feed->setPodcastIndexLocation($location);
@@ -264,7 +325,7 @@ class FeedTest extends TestCase
         $person = [
             'name'  => 'Hercules Poirot',
             'role'  => 'guest',
-            'group' => 'writing',
+            'group' => 'starring',
             'img'   => 'https://poirot.com/about/my-moustage.jpg',
             'href'  => 'https://poirot.com/my-cases',
         ];
@@ -280,13 +341,14 @@ class FeedTest extends TestCase
             [
                 'name'  => 'Hercules Poirot',
                 'role'  => 'guest',
-                'group' => 'writing',
+                'group' => 'starring',
                 'img'   => 'https://poirot.com/about/my-moustage.jpg',
                 'href'  => 'https://poirot.com/my-cases',
             ],
             [
-                'name' => 'Agatha Christie',
-                'role' => 'guest',
+                'name'  => 'Agatha Christie',
+                'role'  => 'guest',
+                'group' => 'writing',
             ],
         ];
         // set

--- a/test/Writer/Extension/PodcastIndex/FeedTest.php
+++ b/test/Writer/Extension/PodcastIndex/FeedTest.php
@@ -145,4 +145,29 @@ class FeedTest extends TestCase
         $this->expectException(Writer\Exception\InvalidArgumentException::class);
         $feed->setPodcastIndexLocation($location);
     }
+
+    public function testSetImages(): void
+    {
+        $feed = new Writer\Feed();
+
+        $images = [
+            'srcset' => "https://example.com/images/ep1/pci_avatar-massive.jpg 1500w, 
+    https://example.com/images/ep1/pci_avatar-middle.jpg 600w, 
+    https://example.com/images/ep1/pci_avatar-small.jpg 300w, 
+    https://example.com/images/ep1/pci_avatar-tiny.jpg 150w",
+        ];
+        $feed->setPodcastIndexImages($images);
+        $this->assertEquals($images, $feed->getPodcastIndexImages());
+    }
+
+    public function testSetImagesThrowsExceptionOnInvalidArguments(): void
+    {
+        $feed = new Writer\Feed();
+
+        $images = [
+            'abc' => 'def',
+        ];
+        $this->expectException(Writer\Exception\InvalidArgumentException::class);
+        $feed->setPodcastIndexImages($images);
+    }
 }

--- a/test/Writer/Renderer/Extension/PodcastIndex/FeedTest.php
+++ b/test/Writer/Renderer/Extension/PodcastIndex/FeedTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace LaminasTest\Feed\Writer\Renderer\Extension\PodcastIndex;
 
+use DateTime;
+use DateTimeInterface;
 use Laminas\Feed\Writer;
 use Laminas\Feed\Writer\Renderer;
 use PHPUnit\Framework\TestCase;
@@ -117,13 +119,14 @@ class FeedTest extends TestCase
 
     public function testRendersRssUpdateFrequencyTag(): void
     {
+        $date        = new DateTime();
         $description = 'Daily';
         $complete    = false;
 
         $updateFrequency = [
             'description' => $description,
             'complete'    => $complete,
-            'dtstart'     => '2023-08-28T00:00:00.000Z',
+            'dtstart'     => $date,
             'rrule'       => 'FREQ=DAILY',
         ];
 
@@ -135,8 +138,8 @@ class FeedTest extends TestCase
         $this->assertStringContainsString('<podcast:updateFrequency', $xml);
         $this->assertStringContainsString(">$description<", $xml);
         $this->assertStringContainsString((string) $complete, $xml);
-        $this->assertStringContainsString($updateFrequency['dtstart'], $xml);
         $this->assertStringContainsString($updateFrequency['rrule'], $xml);
+        $this->assertStringContainsString($date->format(DateTimeInterface::ATOM), $xml);
     }
 
     public function testRendersRssPersonTag(): void

--- a/test/Writer/Renderer/Extension/PodcastIndex/FeedTest.php
+++ b/test/Writer/Renderer/Extension/PodcastIndex/FeedTest.php
@@ -91,4 +91,18 @@ class FeedTest extends TestCase
         $this->assertStringContainsString($location['geo'], $xml);
         $this->assertStringContainsString($location['osm'], $xml);
     }
+
+    public function testRendersRssImagesTag(): void
+    {
+        $images = [
+            'srcset' => 'London, Baker Street',
+        ];
+        $this->validWriter->setPodcastIndexImages($images);
+
+        $rssFeed = new Renderer\Feed\Rss($this->validWriter);
+        $xml     = $rssFeed->render()->saveXml();
+
+        $this->assertStringContainsString('<podcast:images', $xml);
+        $this->assertStringContainsString($images['srcset'], $xml);
+    }
 }

--- a/test/Writer/Renderer/Extension/PodcastIndex/FeedTest.php
+++ b/test/Writer/Renderer/Extension/PodcastIndex/FeedTest.php
@@ -11,6 +11,7 @@ use Laminas\Feed\Writer\Renderer;
 use PHPUnit\Framework\TestCase;
 
 use function implode;
+use function substr_count;
 
 class FeedTest extends TestCase
 {
@@ -159,6 +160,7 @@ class FeedTest extends TestCase
 
         $this->assertStringContainsString('<podcast:person', $xml);
         $this->assertStringContainsString($person['name'], $xml);
+        $this->assertSame(1, substr_count($xml, $person['name']));
         $this->assertStringContainsString($person['role'], $xml);
         $this->assertStringContainsString($person['group'], $xml);
         $this->assertStringContainsString($person['img'], $xml);

--- a/test/Writer/Renderer/Extension/PodcastIndex/FeedTest.php
+++ b/test/Writer/Renderer/Extension/PodcastIndex/FeedTest.php
@@ -129,4 +129,46 @@ class FeedTest extends TestCase
         $this->assertStringContainsString($updateFrequency['dtstart'], $xml);
         $this->assertStringContainsString($updateFrequency['rrule'], $xml);
     }
+
+    public function testRendersRssPersonTag(): void
+    {
+        $person = [
+            'name'  => 'Hercules Poirot',
+            'role'  => 'guest',
+            'group' => 'writing',
+            'img'   => 'https://poirot.com/about/my-moustage.jpg',
+            'href'  => 'https://poirot.com/my-cases',
+        ];
+
+        $this->validWriter->addPodcastIndexPerson($person);
+
+        $rssFeed = new Renderer\Feed\Rss($this->validWriter);
+        $xml     = $rssFeed->render()->saveXml();
+
+        $this->assertStringContainsString('<podcast:person', $xml);
+        $this->assertStringContainsString($person['name'], $xml);
+        $this->assertStringContainsString($person['role'], $xml);
+        $this->assertStringContainsString($person['group'], $xml);
+        $this->assertStringContainsString($person['img'], $xml);
+        $this->assertStringContainsString($person['href'], $xml);
+    }
+
+    public function testRendersMultipleRssPersonTags(): void
+    {
+        $fName = 'Hercules Poirot';
+        $sName = 'Agatha Christie';
+
+        $persons = [
+            ['name' => $fName],
+            ['name' => $sName],
+        ];
+
+        $this->validWriter->setPodcastIndexPersons($persons);
+
+        $rssFeed = new Renderer\Feed\Rss($this->validWriter);
+        $xml     = $rssFeed->render()->saveXml();
+
+        $this->assertStringContainsString(">$fName</podcast:person>", $xml);
+        $this->assertStringContainsString(">$sName</podcast:person>", $xml);
+    }
 }

--- a/test/Writer/Renderer/Extension/PodcastIndex/FeedTest.php
+++ b/test/Writer/Renderer/Extension/PodcastIndex/FeedTest.php
@@ -73,4 +73,22 @@ class FeedTest extends TestCase
         $this->assertStringContainsString($url, $xml);
         $this->assertStringContainsString($identifier, $xml);
     }
+
+    public function testRendersRssLocationTag(): void
+    {
+        $location = [
+            'description' => 'London, Baker Street',
+            'geo'         => 'geo:-27.86159,153.3169',
+            'osm'         => 'W43678282',
+        ];
+        $this->validWriter->setPodcastIndexLocation($location);
+
+        $rssFeed = new Renderer\Feed\Rss($this->validWriter);
+        $xml     = $rssFeed->render()->saveXml();
+
+        $this->assertStringContainsString('<podcast:location', $xml);
+        $this->assertStringContainsString($location['description'], $xml);
+        $this->assertStringContainsString($location['geo'], $xml);
+        $this->assertStringContainsString($location['osm'], $xml);
+    }
 }

--- a/test/Writer/Renderer/Extension/PodcastIndex/FeedTest.php
+++ b/test/Writer/Renderer/Extension/PodcastIndex/FeedTest.php
@@ -167,12 +167,12 @@ class FeedTest extends TestCase
         $fName = 'Hercules Poirot';
         $sName = 'Agatha Christie';
 
-        $persons = [
+        $people = [
             ['name' => $fName],
             ['name' => $sName],
         ];
 
-        $this->validWriter->setPodcastIndexPersons($persons);
+        $this->validWriter->setPodcastIndexPeople($people);
 
         $rssFeed = new Renderer\Feed\Rss($this->validWriter);
         $xml     = $rssFeed->render()->saveXml();

--- a/test/Writer/Renderer/Extension/PodcastIndex/FeedTest.php
+++ b/test/Writer/Renderer/Extension/PodcastIndex/FeedTest.php
@@ -28,7 +28,7 @@ class FeedTest extends TestCase
         Writer\Writer::reset();
     }
 
-    public function testRendersLockedTag(): void
+    public function testRendersRssLockedTag(): void
     {
         $locked = [
             'value' => 'yes',
@@ -41,7 +41,7 @@ class FeedTest extends TestCase
         $this->assertStringContainsString('<podcast:locked', $xml);
     }
 
-    public function testRendersFundingTag(): void
+    public function testRendersRssFundingTag(): void
     {
         $funding = [
             'title' => 'Support the show!',
@@ -53,5 +53,24 @@ class FeedTest extends TestCase
         $xml     = $rssFeed->render()->saveXml();
 
         $this->assertStringContainsString('<podcast:funding', $xml);
+    }
+
+    public function testRendersRssLicenseTag(): void
+    {
+        $identifier = 'cc-by-4.0';
+        $url        = 'https://spdx.org/licenses/CC-BY-4.0.html';
+
+        $license = [
+            'identifier' => $identifier,
+            'url'        => $url,
+        ];
+        $this->validWriter->setPodcastIndexLicense($license);
+
+        $rssFeed = new Renderer\Feed\Rss($this->validWriter);
+        $xml     = $rssFeed->render()->saveXml();
+
+        $this->assertStringContainsString('<podcast:license', $xml);
+        $this->assertStringContainsString($url, $xml);
+        $this->assertStringContainsString($identifier, $xml);
     }
 }

--- a/test/Writer/Renderer/Extension/PodcastIndex/FeedTest.php
+++ b/test/Writer/Renderer/Extension/PodcastIndex/FeedTest.php
@@ -8,6 +8,8 @@ use Laminas\Feed\Writer;
 use Laminas\Feed\Writer\Renderer;
 use PHPUnit\Framework\TestCase;
 
+use function implode;
+
 class FeedTest extends TestCase
 {
     protected Writer\Feed $validWriter;
@@ -94,9 +96,16 @@ class FeedTest extends TestCase
 
     public function testRendersRssImagesTag(): void
     {
-        $images = [
-            'srcset' => 'London, Baker Street',
+        $srcset = [
+            "https://example.com/images/ep1/pci_avatar-massive.jpg 1500w",
+            "https://example.com/images/ep1/pci_avatar-middle.jpg 600w",
+            "https://example.com/images/ep1/pci_avatar-small.jpg 300w",
+            "https://example.com/images/ep1/pci_avatar-tiny.jpg 150w",
         ];
+        $images = [
+            'srcset' => implode(", ", $srcset), // cast to string
+        ];
+
         $this->validWriter->setPodcastIndexImages($images);
 
         $rssFeed = new Renderer\Feed\Rss($this->validWriter);

--- a/test/Writer/Renderer/Extension/PodcastIndex/FeedTest.php
+++ b/test/Writer/Renderer/Extension/PodcastIndex/FeedTest.php
@@ -105,4 +105,28 @@ class FeedTest extends TestCase
         $this->assertStringContainsString('<podcast:images', $xml);
         $this->assertStringContainsString($images['srcset'], $xml);
     }
+
+    public function testRendersRssUpdateFrequencyTag(): void
+    {
+        $description = 'Daily';
+        $complete    = false;
+
+        $updateFrequency = [
+            'description' => $description,
+            'complete'    => $complete,
+            'dtstart'     => '2023-08-28T00:00:00.000Z',
+            'rrule'       => 'FREQ=DAILY',
+        ];
+
+        $this->validWriter->setPodcastIndexUpdateFrequency($updateFrequency);
+
+        $rssFeed = new Renderer\Feed\Rss($this->validWriter);
+        $xml     = $rssFeed->render()->saveXml();
+
+        $this->assertStringContainsString('<podcast:updateFrequency', $xml);
+        $this->assertStringContainsString(">$description<", $xml);
+        $this->assertStringContainsString((string) $complete, $xml);
+        $this->assertStringContainsString($updateFrequency['dtstart'], $xml);
+        $this->assertStringContainsString($updateFrequency['rrule'], $xml);
+    }
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | yes

### Description

1.  Extended PodcastIndex support for additional namespaces:

- Feed License
- Feed Location
- Feed Images
- Feed UpdateFrequency
- Feed Person

2. Added test for the above namespaces
3. Added documentation for the above namespaces
4. Introduced new naming convention for PodcastIndex get methods (example: getPodcastIndexLicense() to be distinguished from getLicense())