### PR TITLE
PodcastIndex Feed: second extension

### DIFF
--- a/docs/book/extensions/podcast-index.md
+++ b/docs/book/extensions/podcast-index.md
@@ -23,6 +23,7 @@ single namespace.
 | `getPodcastIndexGuid()`                       | Returns the podcast guid. The output is an object with the property "value".                                                                       |
 | `getPodcastIndexMedium()`                     | Returns the podcast medium. The output is an object with the property "value".                                                                     |
 | `getPodcastIndexBlocks()`                     | Returns whether or which platforms are allowed to publicly display this feed. The output is an object with the properties "value" and "id".        |
+| `getPodcastIndexTxts()`                       | Returns information on topics that do not have their own tags. The output is an object with the properties "value" and "purpose".                  |
 
 ### SET methods
 
@@ -35,12 +36,14 @@ single namespace.
 | `setPodcastIndexImages()`          | Expects an array with the required key "srcset".                                                                                      |
 | `setPodcastIndexUpdateFrequency()` | Expects an array with the required key "description" and the optional keys "complete" (bool), "dtstart" (ISO8601 string) and "rrule". |
 | `addPodcastIndexPerson()`          | Expects an array with the required key "name" and the optional keys "role", "group", "img" and "href".                                |
-| `setPodcastIndexPeople()`          | Expects an array of objects with each the required key "name" and the optional keys "role", "group", "img" and "href".                |
+| `setPodcastIndexPeople()`          | Expects an array of arrays with each the required key "name" and the optional keys "role", "group", "img" and "href".                 |
 | `setPodcastIndexTrailer()`         | Expects an array with the required keys "title", "pubdate" and "url" and the optional keys "length", "type" and "season".             |
 | `setPodcastIndexGuid()`            | Expects an array with the required key "value".                                                                                       |
 | `setPodcastIndexMedium()`          | Expects an array with the required key "value".                                                                                       |
 | `addPodcastIndexBlock()`           | Expects an array with the required key "value" and the optional key "id".                                                             |
-| `setPodcastIndexBlocks()`          | Expects an array of objects with each the required key "value" and the optional key "id".                                             |
+| `setPodcastIndexBlocks()`          | Expects an array of arrays with each the required key "value" and the optional key "id".                                              |
+| `addPodcastIndexTxt()`             | Expects an array with the required key "value" and the optional key "purpose".                                                        |
+| `setPodcastIndexTxts()`            | Expects an array of arrays with each the required key "value" and the optional key "purpose".                                         |
 
 
 ## Episode API

--- a/docs/book/extensions/podcast-index.md
+++ b/docs/book/extensions/podcast-index.md
@@ -11,14 +11,15 @@ single namespace.
 
 | Method                                        | Description                                                                                                                                        |
 |-----------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------|
-| `isLocked()`                                  | Returns whether the feed is open for importing to new platforms.                                                                                   |
+| `isLocked()` `isPodcastIndexLocked()`         | Returns whether the feed is open for importing to new platforms.                                                                                   |
 | `getLockOwner()` `getPodcastIndexLockOwner()` | Returns the email address for owner verification.                                                                                                  |
 | `getFunding()` `getPodcastIndexFunding()`     | Returns funding information. The output is an object with "url" and "value" properties.                                                            |
 | `getPodcastIndexLicense()`                    | Returns license information. The output is an object with "identifier" and "url" properties.                                                       |
-| `getPodcastIndexLocation()`                   | Returns funding information. The output is an object with "description", "geo" and "osm" properties.                                               |
+| `getPodcastIndexLocation()`                   | Returns location information. The output is an object with "description", "geo" and "osm" properties.                                              |
 | `getPodcastIndexImages()`                     | Returns information on responsive images. The output is an object with a "srcset" property.                                                        |
 | `getPodcastIndexUpdateFrequency()`            | Returns information on the intended release schedule. The output is an object with "description", "complete", "dtstart" and "rrule" properties.    |
 | `getPodcastIndexPersons()`                    | Returns information on the involved people. The output is an array of objects, each with the properties "name", "role", "group", "img" and "href". |
+| `getPodcastIndexTrailer()`                    | Returns information on the podcast trailer. The output is an object with the properties "title", "pubdate", "url", "length", "type" and "season".  |
 
 ### SET methods
 
@@ -32,6 +33,7 @@ single namespace.
 | `setPodcastIndexUpdateFrequency()` | Expects an array with the required key "description" and the optional keys "complete" (bool), "dtstart" (ISO8601 string) and "rrule". |
 | `addPodcastIndexPerson()`          | Expects an array with the required key "name" and the optional keys "role", "group", "img" and "href".                                |
 | `setPodcastIndexPersons()`         | Expects an array of objects with each the required key "name" and the optional keys "role", "group", "img" and "href".                |
+| `setPodcastIndexTrailer()`         | Expects an array with the required keys "title", "pubdate" and "url" and the optional keys "length", "type" and "season".             |
 
 ## Episode API
 

--- a/docs/book/extensions/podcast-index.md
+++ b/docs/book/extensions/podcast-index.md
@@ -21,6 +21,7 @@ single namespace.
 | `getPodcastIndexPersons()`                    | Returns information on the involved people. The output is an array of objects, each with the properties "name", "role", "group", "img" and "href". |
 | `getPodcastIndexTrailer()`                    | Returns information on the podcast trailer. The output is an object with the properties "title", "pubdate", "url", "length", "type" and "season".  |
 | `getPodcastIndexGuid()`                       | Returns the podcast guid. The output is an object with the property "value".                                                                       |
+| `getPodcastIndexMedium()`                     | Returns the podcast medium. The output is an object with the property "value".                                                                     |
 
 ### SET methods
 
@@ -36,6 +37,7 @@ single namespace.
 | `setPodcastIndexPersons()`         | Expects an array of objects with each the required key "name" and the optional keys "role", "group", "img" and "href".                |
 | `setPodcastIndexTrailer()`         | Expects an array with the required keys "title", "pubdate" and "url" and the optional keys "length", "type" and "season".             |
 | `setPodcastIndexGuid()`            | Expects an array with the required key "value".                                                                                       |
+| `setPodcastIndexMedium()`          | Expects an array with the required key "value".                                                                                       |
 
 ## Episode API
 

--- a/docs/book/extensions/podcast-index.md
+++ b/docs/book/extensions/podcast-index.md
@@ -47,7 +47,6 @@ single namespace.
 | `setPodcastIndexTxts()`            | Expects an array of arrays with each the required key "value" and the optional key "purpose".                                         |
 | `setPodcastIndexPodping()`         | Expects an array with the required key "usesPodping".                                                                                 |
 
-
 ## Episode API
 
 ### GET methods

--- a/docs/book/extensions/podcast-index.md
+++ b/docs/book/extensions/podcast-index.md
@@ -22,6 +22,7 @@ single namespace.
 | `getPodcastIndexTrailer()`                    | Returns information on the podcast trailer. The output is an object with the properties "title", "pubdate", "url", "length", "type" and "season".  |
 | `getPodcastIndexGuid()`                       | Returns the podcast guid. The output is an object with the property "value".                                                                       |
 | `getPodcastIndexMedium()`                     | Returns the podcast medium. The output is an object with the property "value".                                                                     |
+| `getPodcastIndexBlocks()`                     | Returns whether or which platforms are allowed to publicly display this feed. The output is an object with the properties "value" and "id".        |
 
 ### SET methods
 
@@ -34,10 +35,13 @@ single namespace.
 | `setPodcastIndexImages()`          | Expects an array with the required key "srcset".                                                                                      |
 | `setPodcastIndexUpdateFrequency()` | Expects an array with the required key "description" and the optional keys "complete" (bool), "dtstart" (ISO8601 string) and "rrule". |
 | `addPodcastIndexPerson()`          | Expects an array with the required key "name" and the optional keys "role", "group", "img" and "href".                                |
-| `setPodcastIndexPeople()`         | Expects an array of objects with each the required key "name" and the optional keys "role", "group", "img" and "href".                |
+| `setPodcastIndexPeople()`          | Expects an array of objects with each the required key "name" and the optional keys "role", "group", "img" and "href".                |
 | `setPodcastIndexTrailer()`         | Expects an array with the required keys "title", "pubdate" and "url" and the optional keys "length", "type" and "season".             |
 | `setPodcastIndexGuid()`            | Expects an array with the required key "value".                                                                                       |
 | `setPodcastIndexMedium()`          | Expects an array with the required key "value".                                                                                       |
+| `addPodcastIndexBlock()`           | Expects an array with the required key "value" and the optional key "id".                                                             |
+| `setPodcastIndexBlocks()`          | Expects an array of objects with each the required key "value" and the optional key "id".                                             |
+
 
 ## Episode API
 

--- a/docs/book/extensions/podcast-index.md
+++ b/docs/book/extensions/podcast-index.md
@@ -24,6 +24,7 @@ single namespace.
 | `getPodcastIndexMedium()`                     | Returns the podcast medium. The output is an object with the property "value".                                                                     |
 | `getPodcastIndexBlocks()`                     | Returns whether or which platforms are allowed to publicly display this feed. The output is an object with the properties "value" and "id".        |
 | `getPodcastIndexTxts()`                       | Returns information on topics that do not have their own tags. The output is an object with the properties "value" and "purpose".                  |
+| `getPodcastIndexPodping()`                    | Returns whether the feed sends out Podping notifications when changes are made to it. The output is an object with the property "usesPodping".     |
 
 ### SET methods
 
@@ -44,6 +45,7 @@ single namespace.
 | `setPodcastIndexBlocks()`          | Expects an array of arrays with each the required key "value" and the optional key "id".                                              |
 | `addPodcastIndexTxt()`             | Expects an array with the required key "value" and the optional key "purpose".                                                        |
 | `setPodcastIndexTxts()`            | Expects an array of arrays with each the required key "value" and the optional key "purpose".                                         |
+| `setPodcastIndexPodping()`         | Expects an array with the required key "usesPodping".                                                                                 |
 
 
 ## Episode API

--- a/docs/book/extensions/podcast-index.md
+++ b/docs/book/extensions/podcast-index.md
@@ -20,6 +20,7 @@ single namespace.
 | `getPodcastIndexUpdateFrequency()`            | Returns information on the intended release schedule. The output is an object with "description", "complete", "dtstart" and "rrule" properties.    |
 | `getPodcastIndexPersons()`                    | Returns information on the involved people. The output is an array of objects, each with the properties "name", "role", "group", "img" and "href". |
 | `getPodcastIndexTrailer()`                    | Returns information on the podcast trailer. The output is an object with the properties "title", "pubdate", "url", "length", "type" and "season".  |
+| `getPodcastIndexGuid()`                       | Returns the podcast guid. The output is an object with the property "value".                                                                       |
 
 ### SET methods
 
@@ -34,6 +35,7 @@ single namespace.
 | `addPodcastIndexPerson()`          | Expects an array with the required key "name" and the optional keys "role", "group", "img" and "href".                                |
 | `setPodcastIndexPersons()`         | Expects an array of objects with each the required key "name" and the optional keys "role", "group", "img" and "href".                |
 | `setPodcastIndexTrailer()`         | Expects an array with the required keys "title", "pubdate" and "url" and the optional keys "length", "type" and "season".             |
+| `setPodcastIndexGuid()`            | Expects an array with the required key "value".                                                                                       |
 
 ## Episode API
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -3108,6 +3108,7 @@
       <code>setPodcastIndexImages</code>
       <code>setPodcastIndexUpdateFrequency</code>
       <code>setPodcastIndexPersons</code>
+      <code>setPodcastIndexTrailer</code>
     </PossiblyUnusedMethod>
     <PossiblyUnusedParam>
       <code>$params</code>
@@ -3138,6 +3139,7 @@
       <code>getPodcastIndexImages</code>
       <code>getPodcastIndexUpdateFrequency</code>
       <code>getPodcastIndexPersons</code>
+      <code>getPodcastIndexTrailer</code>
     </MixedMethodCall>
     <RedundantCastGivenDocblockType>
       <code><![CDATA[(string) $funding['title']]]></code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -3102,12 +3102,18 @@
       <code><![CDATA[is_string($value['description'])]]></code>
       <code><![CDATA[is_string($value['identifier'])]]></code>
       <code><![CDATA[is_string($value['name'])]]></code>
+      <code><![CDATA[is_string($value['pubdate'])]]></code>
       <code><![CDATA[is_string($value['srcset'])]]></code>
+      <code><![CDATA[is_string($value['title'])]]></code>
+      <code><![CDATA[is_string($value['value'])]]></code>
       <code><![CDATA[isset($value['complete']) && ! is_bool($value['complete'])]]></code>
       <code><![CDATA[isset($value['dtstart']) && ! is_string($value['dtstart'])]]></code>
       <code><![CDATA[isset($value['geo']) && ! is_string($value['geo'])]]></code>
+      <code><![CDATA[isset($value['length']) && ! is_int($value['length'])]]></code>
       <code><![CDATA[isset($value['osm']) && ! is_string($value['osm'])]]></code>
       <code><![CDATA[isset($value['rrule']) && ! is_string($value['rrule'])]]></code>
+      <code><![CDATA[isset($value['season']) && ! is_int($value['season'])]]></code>
+      <code><![CDATA[isset($value['type']) && ! is_string($value['type'])]]></code>
     </DocblockTypeContradiction>
     <MixedArgumentTypeCoercion>
       <code>$value</code>
@@ -3118,15 +3124,15 @@
       <code>getEncoding</code>
       <code>setEncoding</code>
       <code>setPodcastIndexFunding</code>
+      <code>setPodcastIndexGuid</code>
       <code>setPodcastIndexImages</code>
       <code>setPodcastIndexLicense</code>
       <code>setPodcastIndexLocation</code>
       <code>setPodcastIndexLocked</code>
-      <code>setPodcastIndexPeople</code>
-      <code>setPodcastIndexUpdateFrequency</code>
-      <code>setPodcastIndexTrailer</code>
-      <code>setPodcastIndexGuid</code>
       <code>setPodcastIndexMedium</code>
+      <code>setPodcastIndexPeople</code>
+      <code>setPodcastIndexTrailer</code>
+      <code>setPodcastIndexUpdateFrequency</code>
     </PossiblyUnusedMethod>
     <PossiblyUnusedParam>
       <code>$params</code>
@@ -3151,15 +3157,15 @@
   <file src="src/Writer/Extension/PodcastIndex/Renderer/Feed.php">
     <MixedMethodCall>
       <code>getPodcastIndexFunding</code>
+      <code>getPodcastIndexGuid</code>
       <code>getPodcastIndexImages</code>
       <code>getPodcastIndexLicense</code>
       <code>getPodcastIndexLocation</code>
       <code>getPodcastIndexLocked</code>
-      <code>getPodcastIndexPeople</code>
-      <code>getPodcastIndexUpdateFrequency</code>
-      <code>getPodcastIndexTrailer</code>
-      <code>getPodcastIndexGuid</code>
       <code>getPodcastIndexMedium</code>
+      <code>getPodcastIndexPeople</code>
+      <code>getPodcastIndexTrailer</code>
+      <code>getPodcastIndexUpdateFrequency</code>
     </MixedMethodCall>
     <RedundantCastGivenDocblockType>
       <code><![CDATA[(string) $funding['title']]]></code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -3098,6 +3098,7 @@
   <file src="src/Writer/Extension/PodcastIndex/Feed.php">
     <DocblockTypeContradiction>
       <code><![CDATA[! is_string($value['url'])]]></code>
+      <code><![CDATA[! is_string($value['value'])]]></code>
       <code><![CDATA[is_string($value['description'])]]></code>
       <code><![CDATA[is_string($value['description'])]]></code>
       <code><![CDATA[is_string($value['identifier'])]]></code>
@@ -3115,12 +3116,14 @@
       <code><![CDATA[isset($value['rrule']) && ! is_string($value['rrule'])]]></code>
       <code><![CDATA[isset($value['season']) && ! is_int($value['season'])]]></code>
       <code><![CDATA[isset($value['type']) && ! is_string($value['type'])]]></code>
+      <code><![CDATA[isset($value['id']) && ! is_string($value['id'])]]></code>
     </DocblockTypeContradiction>
     <PossiblyUnusedMethod>
       <code>__call</code>
       <code>__construct</code>
       <code>getEncoding</code>
       <code>setEncoding</code>
+      <code>setPodcastIndexBlocks</code>
       <code>setPodcastIndexFunding</code>
       <code>setPodcastIndexGuid</code>
       <code>setPodcastIndexImages</code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -3110,6 +3110,7 @@
       <code>setPodcastIndexPersons</code>
       <code>setPodcastIndexTrailer</code>
       <code>setPodcastIndexGuid</code>
+      <code>setPodcastIndexMedium</code>
     </PossiblyUnusedMethod>
     <PossiblyUnusedParam>
       <code>$params</code>
@@ -3142,6 +3143,7 @@
       <code>getPodcastIndexPersons</code>
       <code>getPodcastIndexTrailer</code>
       <code>getPodcastIndexGuid</code>
+      <code>getPodcastIndexMedium</code>
     </MixedMethodCall>
     <RedundantCastGivenDocblockType>
       <code><![CDATA[(string) $funding['title']]]></code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -3099,6 +3099,7 @@
     <DocblockTypeContradiction>
       <code><![CDATA[! is_string($value['url'])]]></code>
       <code><![CDATA[! is_string($value['value'])]]></code>
+      <code><![CDATA[is_bool($value['usesPodping'])]]></code>
       <code><![CDATA[is_string($value['description'])]]></code>
       <code><![CDATA[is_string($value['description'])]]></code>
       <code><![CDATA[is_string($value['identifier'])]]></code>
@@ -3132,6 +3133,7 @@
       <code>setPodcastIndexLocked</code>
       <code>setPodcastIndexMedium</code>
       <code>setPodcastIndexPeople</code>
+      <code>setPodcastIndexPodping</code>
       <code>setPodcastIndexTrailer</code>
       <code>setPodcastIndexTxts</code>
       <code>setPodcastIndexUpdateFrequency</code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -3110,13 +3110,13 @@
       <code><![CDATA[isset($value['complete']) && ! is_bool($value['complete'])]]></code>
       <code><![CDATA[isset($value['geo']) && ! is_string($value['geo'])]]></code>
       <code><![CDATA[isset($value['group']) && ! is_string($value['group'])]]></code>
+      <code><![CDATA[isset($value['id']) && ! is_string($value['id'])]]></code>
       <code><![CDATA[isset($value['length']) && ! is_int($value['length'])]]></code>
       <code><![CDATA[isset($value['osm']) && ! is_string($value['osm'])]]></code>
       <code><![CDATA[isset($value['role']) && ! is_string($value['role'])]]></code>
       <code><![CDATA[isset($value['rrule']) && ! is_string($value['rrule'])]]></code>
       <code><![CDATA[isset($value['season']) && ! is_int($value['season'])]]></code>
       <code><![CDATA[isset($value['type']) && ! is_string($value['type'])]]></code>
-      <code><![CDATA[isset($value['id']) && ! is_string($value['id'])]]></code>
     </DocblockTypeContradiction>
     <PossiblyUnusedMethod>
       <code>__call</code>
@@ -3133,6 +3133,7 @@
       <code>setPodcastIndexMedium</code>
       <code>setPodcastIndexPeople</code>
       <code>setPodcastIndexTrailer</code>
+      <code>setPodcastIndexTxts</code>
       <code>setPodcastIndexUpdateFrequency</code>
     </PossiblyUnusedMethod>
     <PossiblyUnusedParam>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -3109,6 +3109,7 @@
       <code>setPodcastIndexUpdateFrequency</code>
       <code>setPodcastIndexPersons</code>
       <code>setPodcastIndexTrailer</code>
+      <code>setPodcastIndexGuid</code>
     </PossiblyUnusedMethod>
     <PossiblyUnusedParam>
       <code>$params</code>
@@ -3140,6 +3141,7 @@
       <code>getPodcastIndexUpdateFrequency</code>
       <code>getPodcastIndexPersons</code>
       <code>getPodcastIndexTrailer</code>
+      <code>getPodcastIndexGuid</code>
     </MixedMethodCall>
     <RedundantCastGivenDocblockType>
       <code><![CDATA[(string) $funding['title']]]></code>

--- a/src/Reader/Extension/PodcastIndex/Feed.php
+++ b/src/Reader/Extension/PodcastIndex/Feed.php
@@ -267,11 +267,13 @@ class Feed extends Extension\AbstractFeed
 
     /**
      * Get the podcast trailer
+     *
+     * @return null|object{title: string, pubdate: string, url: string, length?: int, type?: string, season?: int}
      */
-    public function getPodcastIndexTrailer(): ?stdClass
+    public function getPodcastIndexTrailer(): object|null
     {
         if (array_key_exists('trailer', $this->data)) {
-            /** @var stdClass $object */
+            /** @var null|object{title: string, pubdate: string, url: string, length?: int, type?: string, season?: int} $object */
             $object = $this->data['trailer'];
             return $object;
         }
@@ -299,11 +301,13 @@ class Feed extends Extension\AbstractFeed
 
     /**
      * Get the podcast guid
+     *
+     * @return null|object{value: string}
      */
-    public function getPodcastIndexGuid(): ?stdClass
+    public function getPodcastIndexGuid(): object|null
     {
         if (array_key_exists('guid', $this->data)) {
-            /** @var stdClass $object */
+            /** @var null|object{value: string} $object */
             $object = $this->data['guid'];
             return $object;
         }
@@ -326,11 +330,13 @@ class Feed extends Extension\AbstractFeed
 
     /**
      * Get the podcast medium
+     *
+     * @return null|object{value: string}
      */
-    public function getPodcastIndexMedium(): ?stdClass
+    public function getPodcastIndexMedium(): object|null
     {
         if (array_key_exists('medium', $this->data)) {
-            /** @var stdClass $object */
+            /** @var null|object{value: string} $object */
             $object = $this->data['medium'];
             return $object;
         }

--- a/src/Reader/Extension/PodcastIndex/Feed.php
+++ b/src/Reader/Extension/PodcastIndex/Feed.php
@@ -20,6 +20,14 @@ class Feed extends Extension\AbstractFeed
      */
     public function isLocked(): bool
     {
+        return $this->isPodcastIndexLocked();
+    }
+
+    /**
+     * Is the podcast locked (not available for indexing)?
+     */
+    public function isPodcastIndexLocked(): bool
+    {
         if (isset($this->data['locked'])) {
             return $this->data['locked'];
         }
@@ -245,6 +253,38 @@ class Feed extends Extension\AbstractFeed
         $this->data['persons'] = $personCollection;
 
         return $this->data['persons'];
+    }
+
+    /**
+     * Get the podcast trailer
+     */
+    public function getPodcastIndexTrailer(): ?stdClass
+    {
+        if (array_key_exists('trailer', $this->data)) {
+            /** @var stdClass $object */
+            $object = $this->data['trailer'];
+            return $object;
+        }
+
+        $object = null;
+
+        $nodeList = $this->xpath->query($this->getXpathPrefix() . '/podcast:trailer');
+
+        if ($nodeList->length > 0) {
+            /** @var DOMElement $item */
+            $item            = $nodeList->item(0);
+            $object          = new stdClass();
+            $object->title   = $item->nodeValue;
+            $object->pubdate = $item->getAttribute('pubdate');
+            $object->url     = $item->getAttribute('url');
+            $object->length  = $item->getAttribute('length');
+            $object->type    = $item->getAttribute('type');
+            $object->season  = $item->getAttribute('season');
+        }
+
+        $this->data['trailer'] = $object;
+
+        return $this->data['trailer'];
     }
 
     /**

--- a/src/Reader/Extension/PodcastIndex/Feed.php
+++ b/src/Reader/Extension/PodcastIndex/Feed.php
@@ -111,9 +111,8 @@ class Feed extends Extension\AbstractFeed
     public function getPodcastIndexFunding(): ?stdClass
     {
         if (array_key_exists('funding', $this->data)) {
-            /** @var stdClass $object */
-            $object = $this->data['funding'];
-            return $object;
+            /** @psalm-var stdClass */
+            return $this->data['funding'];
         }
 
         $funding = null;
@@ -141,9 +140,8 @@ class Feed extends Extension\AbstractFeed
     public function getPodcastIndexLicense(): object|null
     {
         if (array_key_exists('license', $this->data)) {
-            /** @var null|object{identifier: string, url: string} $object */
-            $object = $this->data['license'];
-            return $object;
+            /** @psalm-var null|object{identifier: string, url: string} */
+            return $this->data['license'];
         }
 
         $license = null;
@@ -171,9 +169,8 @@ class Feed extends Extension\AbstractFeed
     public function getPodcastIndexLocation(): object|null
     {
         if (array_key_exists('location', $this->data)) {
-            /** @var null|object{description: string, geo?: string, osm?: string} $object */
-            $object = $this->data['location'];
-            return $object;
+            /** @psalm-var null|object{description: string, geo?: string, osm?: string} */
+            return $this->data['location'];
         }
 
         $location = null;
@@ -202,9 +199,8 @@ class Feed extends Extension\AbstractFeed
     public function getPodcastIndexImages(): object|null
     {
         if (array_key_exists('images', $this->data)) {
-            /** @var null|object{srcset: string} $object */
-            $object = $this->data['images'];
-            return $object;
+            /** @psalm-var null|object{srcset: string} */
+            return $this->data['images'];
         }
 
         $images = null;
@@ -231,9 +227,8 @@ class Feed extends Extension\AbstractFeed
     public function getPodcastIndexUpdateFrequency(): object|null
     {
         if (array_key_exists('updateFrequency', $this->data)) {
-            /** @var null|UpdateFrequencyObject $object */
-            $object = $this->data['updateFrequency'];
-            return $object;
+            /** @psalm-var null|UpdateFrequencyObject */
+            return $this->data['updateFrequency'];
         }
 
         $updateFrequency = null;
@@ -263,9 +258,8 @@ class Feed extends Extension\AbstractFeed
     public function getPodcastIndexPeople(): array
     {
         if (array_key_exists('people', $this->data)) {
-            /** @var list<PersonObject> $people */
-            $people = $this->data['people'];
-            return $people;
+            /** @psalm-var list<PersonObject> */
+            return $this->data['people'];
         }
 
         $nodeList = $this->xpath->query($this->getXpathPrefix() . '/podcast:person');
@@ -299,9 +293,8 @@ class Feed extends Extension\AbstractFeed
     public function getPodcastIndexTrailer(): object|null
     {
         if (array_key_exists('trailer', $this->data)) {
-            /** @var null|TrailerObject $object */
-            $object = $this->data['trailer'];
-            return $object;
+            /** @psalm-var null|TrailerObject */
+            return $this->data['trailer'];
         }
 
         $object = null;
@@ -333,9 +326,8 @@ class Feed extends Extension\AbstractFeed
     public function getPodcastIndexGuid(): object|null
     {
         if (array_key_exists('guid', $this->data)) {
-            /** @var null|object{value: string} $object */
-            $object = $this->data['guid'];
-            return $object;
+            /** @psalm-var null|object{value: string} */
+            return $this->data['guid'];
         }
 
         $object = null;
@@ -362,9 +354,8 @@ class Feed extends Extension\AbstractFeed
     public function getPodcastIndexMedium(): object|null
     {
         if (array_key_exists('medium', $this->data)) {
-            /** @var null|object{value: string} $object */
-            $object = $this->data['medium'];
-            return $object;
+            /** @psalm-var null|object{value: string} */
+            return $this->data['medium'];
         }
 
         $object = null;
@@ -391,9 +382,8 @@ class Feed extends Extension\AbstractFeed
     public function getPodcastIndexBlocks(): array
     {
         if (array_key_exists('blocks', $this->data)) {
-            /** @var list<object{value: string, id?: string}> $blocks */
-            $blocks = $this->data['blocks'];
-            return $blocks;
+            /** @psalm-var list<object{value: string, id?: string}> */
+            return $this->data['blocks'];
         }
 
         $blocks = [];
@@ -422,9 +412,8 @@ class Feed extends Extension\AbstractFeed
     public function getPodcastIndexTxts(): array
     {
         if (array_key_exists('txts', $this->data)) {
-            /** @var list<object{value: string, purpose?: string}> $txts */
-            $txts = $this->data['txts'];
-            return $txts;
+            /** @psalm-var list<object{value: string, purpose?: string}> */
+            return $this->data['txts'];
         }
 
         $txts = [];
@@ -453,9 +442,8 @@ class Feed extends Extension\AbstractFeed
     public function getPodcastIndexPodping(): object|null
     {
         if (array_key_exists('podping', $this->data)) {
-            /** @var null|object{usesPodping: bool} $object */
-            $object = $this->data['podping'];
-            return $object;
+            /** @psalm-var null|object{usesPodping: bool} */
+            return $this->data['podping'];
         }
 
         $object = null;
@@ -468,7 +456,7 @@ class Feed extends Extension\AbstractFeed
 
             $object = new stdClass();
 
-            $object->usesPodping = ($item->getAttribute('usesPodping') === 'true');
+            $object->usesPodping = $item->getAttribute('usesPodping') === 'true';
         }
 
         $this->data['podping'] = $object;

--- a/src/Reader/Extension/PodcastIndex/Feed.php
+++ b/src/Reader/Extension/PodcastIndex/Feed.php
@@ -400,20 +400,49 @@ class Feed extends Extension\AbstractFeed
 
         $nodeList = $this->xpath->query($this->getXpathPrefix() . '/podcast:block');
 
-        if ($nodeList->length > 0) {
-            foreach ($nodeList as $entry) {
-                assert($entry instanceof DOMElement);
-                $object        = new stdClass();
-                $object->value = $entry->nodeValue;
-                $object->id    = $entry->getAttribute('id');
+        foreach ($nodeList as $entry) {
+            assert($entry instanceof DOMElement);
+            $object        = new stdClass();
+            $object->value = $entry->nodeValue;
+            $object->id    = $entry->getAttribute('id');
 
-                $blocks[] = $object;
-            }
+            $blocks[] = $object;
         }
 
         $this->data['blocks'] = $blocks;
 
         return $this->data['blocks'];
+    }
+
+    /**
+     * Get the podcast txts
+     *
+     * @return list<object{value: string, purpose?: string}>
+     */
+    public function getPodcastIndexTxts(): array
+    {
+        if (array_key_exists('txts', $this->data)) {
+            /** @var list<object{value: string, purpose?: string}> $txts */
+            $txts = $this->data['txts'];
+            return $txts;
+        }
+
+        $txts = [];
+
+        $nodeList = $this->xpath->query($this->getXpathPrefix() . '/podcast:txt');
+
+        foreach ($nodeList as $entry) {
+            assert($entry instanceof DOMElement);
+            $object          = new stdClass();
+            $object->value   = $entry->nodeValue;
+            $object->purpose = $entry->getAttribute('purpose');
+
+            $txts[] = $object;
+        }
+
+        $this->data['txts'] = $txts;
+
+        return $this->data['txts'];
     }
 
     /**

--- a/src/Reader/Extension/PodcastIndex/Feed.php
+++ b/src/Reader/Extension/PodcastIndex/Feed.php
@@ -468,11 +468,7 @@ class Feed extends Extension\AbstractFeed
 
             $object = new stdClass();
 
-            if ($item->getAttribute('usesPodping') === 'true') {
-                $object->usesPodping = true;
-            } else {
-                $object->usesPodping = false;
-            }
+            $object->usesPodping = ($item->getAttribute('usesPodping') === 'true');
         }
 
         $this->data['podping'] = $object;

--- a/src/Reader/Extension/PodcastIndex/Feed.php
+++ b/src/Reader/Extension/PodcastIndex/Feed.php
@@ -288,6 +288,33 @@ class Feed extends Extension\AbstractFeed
     }
 
     /**
+     * Get the podcast guid
+     */
+    public function getPodcastIndexGuid(): ?stdClass
+    {
+        if (array_key_exists('guid', $this->data)) {
+            /** @var stdClass $object */
+            $object = $this->data['guid'];
+            return $object;
+        }
+
+        $object = null;
+
+        $nodeList = $this->xpath->query($this->getXpathPrefix() . '/podcast:guid');
+
+        if ($nodeList->length > 0) {
+            /** @var DOMElement $item */
+            $item          = $nodeList->item(0);
+            $object        = new stdClass();
+            $object->value = $item->nodeValue;
+        }
+
+        $this->data['guid'] = $object;
+
+        return $this->data['guid'];
+    }
+
+    /**
      * Register PodcastIndex namespace
      */
     protected function registerNamespaces(): void

--- a/src/Reader/Extension/PodcastIndex/Feed.php
+++ b/src/Reader/Extension/PodcastIndex/Feed.php
@@ -24,12 +24,20 @@ use function assert;
  *     rrule?: string
  *     }
  * @psalm-type PersonObject = object{
- *         name: string,
- *         role?: string,
- *         group?: string,
- *         img?: string,
- *         href?: string
+ *     name: string,
+ *     role?: string,
+ *     group?: string,
+ *     img?: string,
+ *     href?: string
  *  }
+ * @psalm-type TrailerObject = object{
+ *     title: string,
+ *     pubdate: string,
+ *     url: string,
+ *     length?: int,
+ *     type?: string,
+ *     season?: int
+ * }
  */
 class Feed extends Extension\AbstractFeed
 {
@@ -286,12 +294,12 @@ class Feed extends Extension\AbstractFeed
     /**
      * Get the podcast trailer
      *
-     * @return null|object{title: string, pubdate: string, url: string, length?: int, type?: string, season?: int}
+     * @return null|TrailerObject
      */
     public function getPodcastIndexTrailer(): object|null
     {
         if (array_key_exists('trailer', $this->data)) {
-            /** @var null|object{title: string, pubdate: string, url: string, length?: int, type?: string, season?: int} $object */
+            /** @var null|TrailerObject $object */
             $object = $this->data['trailer'];
             return $object;
         }
@@ -301,8 +309,8 @@ class Feed extends Extension\AbstractFeed
         $nodeList = $this->xpath->query($this->getXpathPrefix() . '/podcast:trailer');
 
         if ($nodeList->length > 0) {
-            /** @var DOMElement $item */
-            $item            = $nodeList->item(0);
+            $item = $nodeList->item(0);
+            assert($item instanceof DOMElement);
             $object          = new stdClass();
             $object->title   = $item->nodeValue;
             $object->pubdate = $item->getAttribute('pubdate');
@@ -335,8 +343,8 @@ class Feed extends Extension\AbstractFeed
         $nodeList = $this->xpath->query($this->getXpathPrefix() . '/podcast:guid');
 
         if ($nodeList->length > 0) {
-            /** @var DOMElement $item */
-            $item          = $nodeList->item(0);
+            $item = $nodeList->item(0);
+            assert($item instanceof DOMElement);
             $object        = new stdClass();
             $object->value = $item->nodeValue;
         }
@@ -364,8 +372,8 @@ class Feed extends Extension\AbstractFeed
         $nodeList = $this->xpath->query($this->getXpathPrefix() . '/podcast:medium');
 
         if ($nodeList->length > 0) {
-            /** @var DOMElement $item */
-            $item          = $nodeList->item(0);
+            $item = $nodeList->item(0);
+            assert($item instanceof DOMElement);
             $object        = new stdClass();
             $object->value = $item->nodeValue;
         }

--- a/src/Reader/Extension/PodcastIndex/Feed.php
+++ b/src/Reader/Extension/PodcastIndex/Feed.php
@@ -272,7 +272,7 @@ class Feed extends Extension\AbstractFeed
 
         $personCollection = [];
 
-        if ($nodeList->length) {
+        if ($nodeList->length > 0) {
             foreach ($nodeList as $entry) {
                 assert($entry instanceof DOMElement);
                 $person        = new stdClass();
@@ -381,6 +381,39 @@ class Feed extends Extension\AbstractFeed
         $this->data['medium'] = $object;
 
         return $this->data['medium'];
+    }
+
+    /**
+     * Get the podcast blocks
+     *
+     * @return list<object{value: string, id?: string}>
+     */
+    public function getPodcastIndexBlocks(): array
+    {
+        if (array_key_exists('blocks', $this->data)) {
+            /** @var list<object{value: string, id?: string}> $blocks */
+            $blocks = $this->data['blocks'];
+            return $blocks;
+        }
+
+        $blocks = [];
+
+        $nodeList = $this->xpath->query($this->getXpathPrefix() . '/podcast:block');
+
+        if ($nodeList->length > 0) {
+            foreach ($nodeList as $entry) {
+                assert($entry instanceof DOMElement);
+                $object        = new stdClass();
+                $object->value = $entry->nodeValue;
+                $object->id    = $entry->getAttribute('id');
+
+                $blocks[] = $object;
+            }
+        }
+
+        $this->data['blocks'] = $blocks;
+
+        return $this->data['blocks'];
     }
 
     /**

--- a/src/Reader/Extension/PodcastIndex/Feed.php
+++ b/src/Reader/Extension/PodcastIndex/Feed.php
@@ -446,6 +446,41 @@ class Feed extends Extension\AbstractFeed
     }
 
     /**
+     * Get the podcast podping
+     *
+     * @return null|object{usesPodping: bool}
+     */
+    public function getPodcastIndexPodping(): object|null
+    {
+        if (array_key_exists('podping', $this->data)) {
+            /** @var null|object{usesPodping: bool} $object */
+            $object = $this->data['podping'];
+            return $object;
+        }
+
+        $object = null;
+
+        $nodeList = $this->xpath->query($this->getXpathPrefix() . '/podcast:podping');
+
+        if ($nodeList->length > 0) {
+            $item = $nodeList->item(0);
+            assert($item instanceof DOMElement);
+
+            $object = new stdClass();
+
+            if ($item->getAttribute('usesPodping') === 'true') {
+                $object->usesPodping = true;
+            } else {
+                $object->usesPodping = false;
+            }
+        }
+
+        $this->data['podping'] = $object;
+
+        return $this->data['podping'];
+    }
+
+    /**
      * Register PodcastIndex namespace
      */
     protected function registerNamespaces(): void

--- a/src/Reader/Extension/PodcastIndex/Feed.php
+++ b/src/Reader/Extension/PodcastIndex/Feed.php
@@ -315,6 +315,33 @@ class Feed extends Extension\AbstractFeed
     }
 
     /**
+     * Get the podcast medium
+     */
+    public function getPodcastIndexMedium(): ?stdClass
+    {
+        if (array_key_exists('medium', $this->data)) {
+            /** @var stdClass $object */
+            $object = $this->data['medium'];
+            return $object;
+        }
+
+        $object = null;
+
+        $nodeList = $this->xpath->query($this->getXpathPrefix() . '/podcast:medium');
+
+        if ($nodeList->length > 0) {
+            /** @var DOMElement $item */
+            $item          = $nodeList->item(0);
+            $object        = new stdClass();
+            $object->value = $item->nodeValue;
+        }
+
+        $this->data['medium'] = $object;
+
+        return $this->data['medium'];
+    }
+
+    /**
      * Register PodcastIndex namespace
      */
     protected function registerNamespaces(): void

--- a/src/Writer/Extension/PodcastIndex/Feed.php
+++ b/src/Writer/Extension/PodcastIndex/Feed.php
@@ -366,6 +366,29 @@ class Feed
     }
 
     /**
+     * Set feed medium
+     *
+     * @param array $value [value: string]
+     * @return $this
+     * @throws Writer\Exception\InvalidArgumentException
+     */
+    public function setPodcastIndexMedium(array $value)
+    {
+        if (! isset($value['value'])) {
+            throw new Writer\Exception\InvalidArgumentException(
+                'invalid parameter: "medium" must be an array containing the key "value"'
+            );
+        }
+        if (! is_string($value['value'])) {
+            throw new Writer\Exception\InvalidArgumentException(
+                'invalid parameter: key "value" of "medium" must be a UUIDv5 string'
+            );
+        }
+        $this->data['medium'] = $value;
+        return $this;
+    }
+
+    /**
      * Overloading: proxy to internal setters
      *
      * @return mixed

--- a/src/Writer/Extension/PodcastIndex/Feed.php
+++ b/src/Writer/Extension/PodcastIndex/Feed.php
@@ -12,6 +12,7 @@ use Laminas\Stdlib\StringWrapper\StringWrapperInterface;
 use function array_key_exists;
 use function ctype_alpha;
 use function filter_var;
+use function in_array;
 use function is_bool;
 use function is_int;
 use function is_string;
@@ -415,6 +416,58 @@ class Feed
             );
         }
         $this->data['medium'] = $value;
+        return $this;
+    }
+
+    /**
+     * Add feed block
+     *
+     * @param array{value: string, id?: string} $value
+     * @return $this
+     * @throws Writer\Exception\InvalidArgumentException
+     */
+    public function addPodcastIndexBlock(array $value): self
+    {
+        if (! isset($value['value'])) {
+            throw new Writer\Exception\InvalidArgumentException(
+                'invalid parameter: "block" must be an array containing the key "value"'
+            );
+        }
+        if (! is_string($value['value']) || ! in_array($value['value'], ['yes', 'no'], true)) {
+            throw new Writer\Exception\InvalidArgumentException(
+                'invalid parameter: key "value" of "block" must be set to either "yes" or "no"'
+            );
+        }
+        if (isset($value['id']) && ! is_string($value['id'])) {
+            throw new Writer\Exception\InvalidArgumentException(
+                'invalid parameter: key "id" of "block" must be of type string'
+            );
+        }
+
+        if (! isset($this->data['blocks'])) {
+            $this->data['blocks'] = [];
+        }
+
+        /** @var list<array{value: string, id?: string}> $this->data['blocks'] */
+        $this->data['blocks'][] = $value;
+        return $this;
+    }
+
+    /**
+     * Set a new array of blocks.
+     * If no argument is passed, it will just remove all existing block entries.
+     *
+     * @psalm-param list<array{value: string, id?: string}> $values
+     * @return $this
+     * @throws Writer\Exception\InvalidArgumentException
+     */
+    public function setPodcastIndexBlocks(array $values = []): self
+    {
+        $this->data['blocks'] = [];
+
+        foreach ($values as $value) {
+            $this->addPodcastIndexBlock($value);
+        }
         return $this;
     }
 

--- a/src/Writer/Extension/PodcastIndex/Feed.php
+++ b/src/Writer/Extension/PodcastIndex/Feed.php
@@ -27,17 +27,25 @@ use const FILTER_VALIDATE_URL;
  * Describes PodcastIndex data of a RSS Feed
  *
  * @psalm-type UpdateFrequencyArray = array{
- *   description: string,
- *   complete?: bool,
- *   dtstart?: DateTimeInterface,
- *   rrule?: string
+ *     description: string,
+ *     complete?: bool,
+ *     dtstart?: DateTimeInterface,
+ *     rrule?: string
  *   }
  * @psalm-type PersonArray = array{
- *       name: string,
- *       role?: string,
- *       group?: string,
- *       img?: string,
- *       href?: string
+ *     name: string,
+ *     role?: string,
+ *     group?: string,
+ *     img?: string,
+ *     href?: string
+ *   }
+ * @psalm-type TrailerArray = array{
+ *     title: string,
+ *     pubdate: string,
+ *     url: string,
+ *     length?: int,
+ *     type?: string,
+ *     season?: int
  *   }
  */
 class Feed
@@ -317,7 +325,7 @@ class Feed
     /**
      * Set feed trailer
      *
-     * @param array{title: string, pubdate: string, url: string, length?: int, type?: string, season?: int} $value
+     * @param TrailerArray $value
      * @return $this
      * @throws Writer\Exception\InvalidArgumentException
      */

--- a/src/Writer/Extension/PodcastIndex/Feed.php
+++ b/src/Writer/Extension/PodcastIndex/Feed.php
@@ -12,6 +12,7 @@ use function array_key_exists;
 use function ctype_alpha;
 use function filter_var;
 use function is_bool;
+use function is_int;
 use function is_string;
 use function lcfirst;
 use function method_exists;
@@ -290,6 +291,54 @@ class Feed
         foreach ($values as $value) {
             $this->addPodcastIndexPerson($value);
         }
+        return $this;
+    }
+
+    /**
+     * Set feed trailer
+     *
+     * @param array $value [title: str, pubdate: str, url: str, length: int|null, type: str|null, season: int|null]
+     * @return $this
+     * @throws Writer\Exception\InvalidArgumentException
+     */
+    public function setPodcastIndexTrailer(array $value)
+    {
+        if (! isset($value['title']) || ! isset($value['pubdate']) || ! isset($value['url'])) {
+            throw new Writer\Exception\InvalidArgumentException(
+                'invalid parameter: "trailer" must be an array containing the keys "title", "pubdate" and "url"'
+            );
+        }
+        if (! is_string($value['title'])) {
+            throw new Writer\Exception\InvalidArgumentException(
+                'invalid parameter: key "title" of "trailer" must be of type string'
+            );
+        }
+        if (! is_string($value['pubdate'])) {
+            throw new Writer\Exception\InvalidArgumentException(
+                'invalid parameter: key "pubdate" of "trailer" must be an RFC2822 formatted date string'
+            );
+        }
+        if (! is_string($value['url']) || ! filter_var($value['url'], FILTER_VALIDATE_URL)) {
+            throw new Writer\Exception\InvalidArgumentException(
+                'invalid parameter: key "url" of "trailer" must be a url, starting with "http://" or "https://'
+            );
+        }
+        if (isset($value['length']) && ! is_int($value['length'])) {
+            throw new Writer\Exception\InvalidArgumentException(
+                'invalid parameter: key "length" of "trailer": must be of type integer'
+            );
+        }
+        if (isset($value['type']) && ! is_string($value['type'])) {
+            throw new Writer\Exception\InvalidArgumentException(
+                'invalid parameter: key "type" of "trailer" must be of type string'
+            );
+        }
+        if (isset($value['season']) && ! is_int($value['season'])) {
+            throw new Writer\Exception\InvalidArgumentException(
+                'invalid parameter: key "season" of "trailer" must be of type integer'
+            );
+        }
+        $this->data['trailer'] = $value;
         return $this;
     }
 

--- a/src/Writer/Extension/PodcastIndex/Feed.php
+++ b/src/Writer/Extension/PodcastIndex/Feed.php
@@ -525,6 +525,29 @@ class Feed
     }
 
     /**
+     * Set feed podping
+     *
+     * @param array{usesPodping: bool} $value
+     * @return $this
+     * @throws Writer\Exception\InvalidArgumentException
+     */
+    public function setPodcastIndexPodping(array $value): self
+    {
+        if (! isset($value['usesPodping'])) {
+            throw new Writer\Exception\InvalidArgumentException(
+                'invalid parameter: "podping" must be an array containing the key "usesPodping"'
+            );
+        }
+        if (! is_bool($value['usesPodping'])) {
+            throw new Writer\Exception\InvalidArgumentException(
+                'invalid parameter: key "usesPodping" of "podping" must be of type boolean'
+            );
+        }
+        $this->data['podping'] = $value;
+        return $this;
+    }
+
+    /**
      * Overloading: proxy to internal setters
      *
      * @return mixed

--- a/src/Writer/Extension/PodcastIndex/Feed.php
+++ b/src/Writer/Extension/PodcastIndex/Feed.php
@@ -293,11 +293,11 @@ class Feed
     /**
      * Set feed trailer
      *
-     * @param array $value [title: str, pubdate: str, url: str, length: int|null, type: str|null, season: int|null]
+     * @param array{title: string, pubdate: string, url: string, length?: int, type?: string, season?: int} $value
      * @return $this
      * @throws Writer\Exception\InvalidArgumentException
      */
-    public function setPodcastIndexTrailer(array $value)
+    public function setPodcastIndexTrailer(array $value): self
     {
         if (! isset($value['title']) || ! isset($value['pubdate']) || ! isset($value['url'])) {
             throw new Writer\Exception\InvalidArgumentException(
@@ -314,6 +314,7 @@ class Feed
                 'invalid parameter: key "pubdate" of "trailer" must be an RFC2822 formatted date string'
             );
         }
+        /** @psalm-suppress DocblockTypeContradiction */
         if (! is_string($value['url']) || ! filter_var($value['url'], FILTER_VALIDATE_URL)) {
             throw new Writer\Exception\InvalidArgumentException(
                 'invalid parameter: key "url" of "trailer" must be a url, starting with "http://" or "https://'
@@ -341,11 +342,11 @@ class Feed
     /**
      * Set feed guid
      *
-     * @param array $value [value: string]
+     * @param array{value: string} $value
      * @return $this
      * @throws Writer\Exception\InvalidArgumentException
      */
-    public function setPodcastIndexGuid(array $value)
+    public function setPodcastIndexGuid(array $value): self
     {
         if (! isset($value['value'])) {
             throw new Writer\Exception\InvalidArgumentException(
@@ -364,17 +365,18 @@ class Feed
     /**
      * Set feed medium
      *
-     * @param array $value [value: string]
+     * @param array{value: string} $value
      * @return $this
      * @throws Writer\Exception\InvalidArgumentException
      */
-    public function setPodcastIndexMedium(array $value)
+    public function setPodcastIndexMedium(array $value): self
     {
         if (! isset($value['value'])) {
             throw new Writer\Exception\InvalidArgumentException(
                 'invalid parameter: "medium" must be an array containing the key "value"'
             );
         }
+        /** @psalm-suppress DocblockTypeContradiction */
         if (! is_string($value['value'])) {
             throw new Writer\Exception\InvalidArgumentException(
                 'invalid parameter: key "value" of "medium" must be a UUIDv5 string'

--- a/src/Writer/Extension/PodcastIndex/Feed.php
+++ b/src/Writer/Extension/PodcastIndex/Feed.php
@@ -472,6 +472,59 @@ class Feed
     }
 
     /**
+     * Add feed txt
+     *
+     * @param array{value: string, purpose?: string} $value
+     * @return $this
+     * @throws Writer\Exception\InvalidArgumentException
+     * @psalm-suppress DocblockTypeContradiction
+     */
+    public function addPodcastIndexTxt(array $value): self
+    {
+        if (! isset($value['value'])) {
+            throw new Writer\Exception\InvalidArgumentException(
+                'invalid parameter: "txt" must be an array containing the key "value"'
+            );
+        }
+        if (! is_string($value['value'])) {
+            throw new Writer\Exception\InvalidArgumentException(
+                'invalid parameter: key "value" of "txt" must be of type string'
+            );
+        }
+        if (isset($value['purpose']) && ! is_string($value['purpose'])) {
+            throw new Writer\Exception\InvalidArgumentException(
+                'invalid parameter: key "purpose" of "txt" must be of type string'
+            );
+        }
+
+        if (! isset($this->data['txts'])) {
+            $this->data['txts'] = [];
+        }
+
+        /** @var list<array{value: string, purpose?: string}> $this->data['txts'] */
+        $this->data['txts'][] = $value;
+        return $this;
+    }
+
+    /**
+     * Set a new array of txts.
+     * If no argument is passed, it will just remove all existing txt entries.
+     *
+     * @psalm-param list<array{value: string, purpose?: string}> $values
+     * @return $this
+     * @throws Writer\Exception\InvalidArgumentException
+     */
+    public function setPodcastIndexTxts(array $values = []): self
+    {
+        $this->data['txts'] = [];
+
+        foreach ($values as $value) {
+            $this->addPodcastIndexTxt($value);
+        }
+        return $this;
+    }
+
+    /**
      * Overloading: proxy to internal setters
      *
      * @return mixed

--- a/src/Writer/Extension/PodcastIndex/Feed.php
+++ b/src/Writer/Extension/PodcastIndex/Feed.php
@@ -343,6 +343,29 @@ class Feed
     }
 
     /**
+     * Set feed guid
+     *
+     * @param array $value [value: string]
+     * @return $this
+     * @throws Writer\Exception\InvalidArgumentException
+     */
+    public function setPodcastIndexGuid(array $value)
+    {
+        if (! isset($value['value'])) {
+            throw new Writer\Exception\InvalidArgumentException(
+                'invalid parameter: "guid" must be an array containing the key "value"'
+            );
+        }
+        if (! is_string($value['value'])) {
+            throw new Writer\Exception\InvalidArgumentException(
+                'invalid parameter: key "value" of "guid" must be a UUIDv5 string'
+            );
+        }
+        $this->data['guid'] = $value;
+        return $this;
+    }
+
+    /**
      * Overloading: proxy to internal setters
      *
      * @return mixed

--- a/src/Writer/Extension/PodcastIndex/Renderer/Feed.php
+++ b/src/Writer/Extension/PodcastIndex/Renderer/Feed.php
@@ -15,6 +15,7 @@ use Laminas\Feed\Writer\Feed as FeedWriter;
  *
  * @psalm-import-type PersonArray from \Laminas\Feed\Writer\Extension\PodcastIndex\Feed
  * @psalm-import-type UpdateFrequencyArray from \Laminas\Feed\Writer\Extension\PodcastIndex\Feed
+ * @psalm-import-type TrailerArray from \Laminas\Feed\Writer\Extension\PodcastIndex\Feed
  */
 class Feed extends Extension\AbstractRenderer
 {
@@ -236,23 +237,26 @@ class Feed extends Extension\AbstractRenderer
      */
     protected function setTrailer(DOMDocument $dom, DOMElement $root): void
     {
-        /** @psalm-var null|array<string, mixed> $trailer */
-        $trailer = $this->getDataContainer()->getPodcastIndexTrailer();
+        /** @psalm-var FeedWriter $container */
+        $container = $this->getDataContainer();
+
+        /** @psalm-var null|TrailerArray $trailer */
+        $trailer = $container->getPodcastIndexTrailer();
         if ($trailer === null) {
             return;
         }
         $el   = $dom->createElement('podcast:trailer');
-        $text = $dom->createTextNode((string) $trailer['title']);
+        $text = $dom->createTextNode($trailer['title']);
         $el->appendChild($text);
-        $el->setAttribute('pubdate', (string) $trailer['pubdate']);
-        $el->setAttribute('url', (string) $trailer['url']);
-        if (! empty($trailer['length'])) {
+        $el->setAttribute('pubdate', $trailer['pubdate']);
+        $el->setAttribute('url', $trailer['url']);
+        if (isset($trailer['length'])) {
             $el->setAttribute('length', (string) $trailer['length']);
         }
-        if (! empty($trailer['type'])) {
-            $el->setAttribute('type', (string) $trailer['type']);
+        if (isset($trailer['type'])) {
+            $el->setAttribute('type', $trailer['type']);
         }
-        if (! empty($trailer['season'])) {
+        if (isset($trailer['season'])) {
             $el->setAttribute('season', (string) $trailer['season']);
         }
         $root->appendChild($el);
@@ -264,8 +268,11 @@ class Feed extends Extension\AbstractRenderer
      */
     protected function setGuid(DOMDocument $dom, DOMElement $root): void
     {
+        /** @psalm-var FeedWriter $container */
+        $container = $this->getDataContainer();
+
         /** @psalm-var null|array<string, string> $guid */
-        $guid = $this->getDataContainer()->getPodcastIndexGuid();
+        $guid = $container->getPodcastIndexGuid();
         if ($guid === null) {
             return;
         }
@@ -281,8 +288,11 @@ class Feed extends Extension\AbstractRenderer
      */
     protected function setMedium(DOMDocument $dom, DOMElement $root): void
     {
+        /** @psalm-var FeedWriter $container */
+        $container = $this->getDataContainer();
+
         /** @psalm-var null|array<string, string> $medium */
-        $medium = $this->getDataContainer()->getPodcastIndexMedium();
+        $medium = $container->getPodcastIndexMedium();
         if ($medium === null) {
             return;
         }

--- a/src/Writer/Extension/PodcastIndex/Renderer/Feed.php
+++ b/src/Writer/Extension/PodcastIndex/Renderer/Feed.php
@@ -36,6 +36,7 @@ class Feed extends Extension\AbstractRenderer
         $this->addPerson($this->dom, $this->base);
         $this->setPersons($this->dom, $this->base);
         $this->setTrailer($this->dom, $this->base);
+        $this->setGuid($this->dom, $this->base);
         if ($this->called) {
             $this->_appendNamespaces();
         }
@@ -233,6 +234,23 @@ class Feed extends Extension\AbstractRenderer
         if (! empty($trailer['season'])) {
             $el->setAttribute('season', (string) $trailer['season']);
         }
+        $root->appendChild($el);
+        $this->called = true;
+    }
+
+    /**
+     * Set feed guid
+     */
+    protected function setGuid(DOMDocument $dom, DOMElement $root): void
+    {
+        /** @psalm-var null|array<string, string> $guid */
+        $guid = $this->getDataContainer()->getPodcastIndexGuid();
+        if ($guid === null) {
+            return;
+        }
+        $el   = $dom->createElement('podcast:guid');
+        $text = $dom->createTextNode($guid['value']);
+        $el->appendChild($text);
         $root->appendChild($el);
         $this->called = true;
     }

--- a/src/Writer/Extension/PodcastIndex/Renderer/Feed.php
+++ b/src/Writer/Extension/PodcastIndex/Renderer/Feed.php
@@ -238,7 +238,7 @@ class Feed extends Extension\AbstractRenderer
     /**
      * Set feed trailer
      */
-    protected function setTrailer(DOMDocument $dom, DOMElement $root): void
+    private function setTrailer(DOMDocument $dom, DOMElement $root): void
     {
         /** @psalm-var FeedWriter $container */
         $container = $this->getDataContainer();
@@ -269,7 +269,7 @@ class Feed extends Extension\AbstractRenderer
     /**
      * Set feed guid
      */
-    protected function setGuid(DOMDocument $dom, DOMElement $root): void
+    private function setGuid(DOMDocument $dom, DOMElement $root): void
     {
         /** @psalm-var FeedWriter $container */
         $container = $this->getDataContainer();
@@ -289,7 +289,7 @@ class Feed extends Extension\AbstractRenderer
     /**
      * Set feed medium
      */
-    protected function setMedium(DOMDocument $dom, DOMElement $root): void
+    private function setMedium(DOMDocument $dom, DOMElement $root): void
     {
         /** @psalm-var FeedWriter $container */
         $container = $this->getDataContainer();
@@ -309,7 +309,7 @@ class Feed extends Extension\AbstractRenderer
     /**
      * Set feed blocks
      */
-    protected function setBlocks(DOMDocument $dom, DOMElement $root): void
+    private function setBlocks(DOMDocument $dom, DOMElement $root): void
     {
         /** @psalm-var FeedWriter $container */
         $container = $this->getDataContainer();
@@ -335,7 +335,7 @@ class Feed extends Extension\AbstractRenderer
     /**
      * Set feed txts
      */
-    protected function setTxts(DOMDocument $dom, DOMElement $root): void
+    private function setTxts(DOMDocument $dom, DOMElement $root): void
     {
         /** @psalm-var FeedWriter $container */
         $container = $this->getDataContainer();
@@ -361,7 +361,7 @@ class Feed extends Extension\AbstractRenderer
     /**
      * Set feed podping
      */
-    protected function setPodping(DOMDocument $dom, DOMElement $root): void
+    private function setPodping(DOMDocument $dom, DOMElement $root): void
     {
         /** @psalm-var FeedWriter $container */
         $container = $this->getDataContainer();

--- a/src/Writer/Extension/PodcastIndex/Renderer/Feed.php
+++ b/src/Writer/Extension/PodcastIndex/Renderer/Feed.php
@@ -37,6 +37,7 @@ class Feed extends Extension\AbstractRenderer
         $this->setPersons($this->dom, $this->base);
         $this->setTrailer($this->dom, $this->base);
         $this->setGuid($this->dom, $this->base);
+        $this->setMedium($this->dom, $this->base);
         if ($this->called) {
             $this->_appendNamespaces();
         }
@@ -250,6 +251,23 @@ class Feed extends Extension\AbstractRenderer
         }
         $el   = $dom->createElement('podcast:guid');
         $text = $dom->createTextNode($guid['value']);
+        $el->appendChild($text);
+        $root->appendChild($el);
+        $this->called = true;
+    }
+
+    /**
+     * Set feed medium
+     */
+    protected function setMedium(DOMDocument $dom, DOMElement $root): void
+    {
+        /** @psalm-var null|array<string, string> $medium */
+        $medium = $this->getDataContainer()->getPodcastIndexMedium();
+        if ($medium === null) {
+            return;
+        }
+        $el   = $dom->createElement('podcast:medium');
+        $text = $dom->createTextNode($medium['value']);
         $el->appendChild($text);
         $root->appendChild($el);
         $this->called = true;

--- a/src/Writer/Extension/PodcastIndex/Renderer/Feed.php
+++ b/src/Writer/Extension/PodcastIndex/Renderer/Feed.php
@@ -45,6 +45,7 @@ class Feed extends Extension\AbstractRenderer
         $this->setMedium($this->dom, $this->base);
         $this->setBlocks($this->dom, $this->base);
         $this->setTxts($this->dom, $this->base);
+        $this->setPodping($this->dom, $this->base);
         if ($this->called) {
             $this->_appendNamespaces();
         }
@@ -354,6 +355,26 @@ class Feed extends Extension\AbstractRenderer
             }
             $root->appendChild($el);
         }
+        $this->called = true;
+    }
+
+    /**
+     * Set feed podping
+     */
+    protected function setPodping(DOMDocument $dom, DOMElement $root): void
+    {
+        /** @psalm-var FeedWriter $container */
+        $container = $this->getDataContainer();
+
+        /** @psalm-var null|array{usesPodping: bool} $podping */
+        $podping = $container->getPodcastIndexPodping();
+        if ($podping === null) {
+            return;
+        }
+        $el          = $dom->createElement('podcast:podping');
+        $usesPodping = $podping['usesPodping'] ? 'true' : 'false';
+        $el->setAttribute('usesPodping', $usesPodping);
+        $root->appendChild($el);
         $this->called = true;
     }
 }

--- a/src/Writer/Extension/PodcastIndex/Renderer/Feed.php
+++ b/src/Writer/Extension/PodcastIndex/Renderer/Feed.php
@@ -44,6 +44,7 @@ class Feed extends Extension\AbstractRenderer
         $this->setGuid($this->dom, $this->base);
         $this->setMedium($this->dom, $this->base);
         $this->setBlocks($this->dom, $this->base);
+        $this->setTxts($this->dom, $this->base);
         if ($this->called) {
             $this->_appendNamespaces();
         }
@@ -324,6 +325,32 @@ class Feed extends Extension\AbstractRenderer
             $el->appendChild($text);
             if (isset($block['id']) && $block['id'] !== '') {
                 $el->setAttribute('id', $block['id']);
+            }
+            $root->appendChild($el);
+        }
+        $this->called = true;
+    }
+
+    /**
+     * Set feed txts
+     */
+    protected function setTxts(DOMDocument $dom, DOMElement $root): void
+    {
+        /** @psalm-var FeedWriter $container */
+        $container = $this->getDataContainer();
+
+        /** @psalm-var list<array{value: string, purpose?: string}>|null $txts */
+        $txts = $container->getPodcastIndexTxts();
+        if ($txts === null || $txts === []) {
+            return;
+        }
+
+        foreach ($txts as $txt) {
+            $el   = $dom->createElement('podcast:txt');
+            $text = $dom->createTextNode($txt['value']);
+            $el->appendChild($text);
+            if (isset($txt['purpose']) && $txt['purpose'] !== '') {
+                $el->setAttribute('purpose', $txt['purpose']);
             }
             $root->appendChild($el);
         }

--- a/src/Writer/Extension/PodcastIndex/Renderer/Feed.php
+++ b/src/Writer/Extension/PodcastIndex/Renderer/Feed.php
@@ -312,7 +312,7 @@ class Feed extends Extension\AbstractRenderer
         /** @psalm-var FeedWriter $container */
         $container = $this->getDataContainer();
 
-        /** @psalm-var list<array{value: string, id?: string}>|null $people */
+        /** @psalm-var list<array{value: string, id?: string}>|null $blocks */
         $blocks = $container->getPodcastIndexBlocks();
         if ($blocks === null || $blocks === []) {
             return;

--- a/src/Writer/Extension/PodcastIndex/Renderer/Feed.php
+++ b/src/Writer/Extension/PodcastIndex/Renderer/Feed.php
@@ -113,7 +113,7 @@ class Feed extends Extension\AbstractRenderer
         /** @psalm-var FeedWriter $container */
         $container = $this->getDataContainer();
 
-        /** @psalm-var null|array<string,string> $license */
+        /** @psalm-var null|array{identifier: string, url: string} $license */
         $license = $container->getPodcastIndexLicense();
         if ($license === null) {
             return;
@@ -134,7 +134,7 @@ class Feed extends Extension\AbstractRenderer
         /** @psalm-var FeedWriter $container */
         $container = $this->getDataContainer();
 
-        /** @psalm-var null|array<string,string> $location */
+        /** @psalm-var null|array{description: string, geo?: string, osm?: string} $location */
         $location = $container->getPodcastIndexLocation();
         if ($location === null) {
             return;
@@ -160,7 +160,7 @@ class Feed extends Extension\AbstractRenderer
         /** @psalm-var FeedWriter $container */
         $container = $this->getDataContainer();
 
-        /** @psalm-var null|array<string, string> $images */
+        /** @psalm-var null|array{srcset: string} $images */
         $images = $container->getPodcastIndexImages();
         if ($images === null) {
             return;
@@ -208,7 +208,7 @@ class Feed extends Extension\AbstractRenderer
         /** @psalm-var FeedWriter $container */
         $container = $this->getDataContainer();
 
-        /** @psalm-var list<PersonArray>|null $people */
+        /** @psalm-var null|list<PersonArray> $people */
         $people = $container->getPodcastIndexPeople();
         if ($people === null || $people === []) {
             return;
@@ -274,7 +274,7 @@ class Feed extends Extension\AbstractRenderer
         /** @psalm-var FeedWriter $container */
         $container = $this->getDataContainer();
 
-        /** @psalm-var null|array<string, string> $guid */
+        /** @psalm-var null|array{value: string} $guid */
         $guid = $container->getPodcastIndexGuid();
         if ($guid === null) {
             return;
@@ -294,7 +294,7 @@ class Feed extends Extension\AbstractRenderer
         /** @psalm-var FeedWriter $container */
         $container = $this->getDataContainer();
 
-        /** @psalm-var null|array<string, string> $medium */
+        /** @psalm-var null|array{value: string} $medium */
         $medium = $container->getPodcastIndexMedium();
         if ($medium === null) {
             return;
@@ -371,8 +371,10 @@ class Feed extends Extension\AbstractRenderer
         if ($podping === null) {
             return;
         }
-        $el          = $dom->createElement('podcast:podping');
+
         $usesPodping = $podping['usesPodping'] ? 'true' : 'false';
+
+        $el = $dom->createElement('podcast:podping');
         $el->setAttribute('usesPodping', $usesPodping);
         $root->appendChild($el);
         $this->called = true;

--- a/src/Writer/Extension/PodcastIndex/Renderer/Feed.php
+++ b/src/Writer/Extension/PodcastIndex/Renderer/Feed.php
@@ -35,6 +35,7 @@ class Feed extends Extension\AbstractRenderer
         $this->setUpdateFrequency($this->dom, $this->base);
         $this->addPerson($this->dom, $this->base);
         $this->setPersons($this->dom, $this->base);
+        $this->setTrailer($this->dom, $this->base);
         if ($this->called) {
             $this->_appendNamespaces();
         }
@@ -206,5 +207,33 @@ class Feed extends Extension\AbstractRenderer
     protected function setPersons(DOMDocument $dom, DOMElement $root): void
     {
         $this->addPerson($dom, $root);
+    }
+
+    /**
+     * Set feed trailer
+     */
+    protected function setTrailer(DOMDocument $dom, DOMElement $root): void
+    {
+        /** @psalm-var null|array<string, mixed> $trailer */
+        $trailer = $this->getDataContainer()->getPodcastIndexTrailer();
+        if ($trailer === null) {
+            return;
+        }
+        $el   = $dom->createElement('podcast:trailer');
+        $text = $dom->createTextNode((string) $trailer['title']);
+        $el->appendChild($text);
+        $el->setAttribute('pubdate', (string) $trailer['pubdate']);
+        $el->setAttribute('url', (string) $trailer['url']);
+        if (! empty($trailer['length'])) {
+            $el->setAttribute('length', (string) $trailer['length']);
+        }
+        if (! empty($trailer['type'])) {
+            $el->setAttribute('type', (string) $trailer['type']);
+        }
+        if (! empty($trailer['season'])) {
+            $el->setAttribute('season', (string) $trailer['season']);
+        }
+        $root->appendChild($el);
+        $this->called = true;
     }
 }

--- a/src/Writer/Extension/PodcastIndex/Renderer/Feed.php
+++ b/src/Writer/Extension/PodcastIndex/Renderer/Feed.php
@@ -43,6 +43,7 @@ class Feed extends Extension\AbstractRenderer
         $this->setTrailer($this->dom, $this->base);
         $this->setGuid($this->dom, $this->base);
         $this->setMedium($this->dom, $this->base);
+        $this->setBlocks($this->dom, $this->base);
         if ($this->called) {
             $this->_appendNamespaces();
         }
@@ -300,6 +301,32 @@ class Feed extends Extension\AbstractRenderer
         $text = $dom->createTextNode($medium['value']);
         $el->appendChild($text);
         $root->appendChild($el);
+        $this->called = true;
+    }
+
+    /**
+     * Set feed blocks
+     */
+    protected function setBlocks(DOMDocument $dom, DOMElement $root): void
+    {
+        /** @psalm-var FeedWriter $container */
+        $container = $this->getDataContainer();
+
+        /** @psalm-var list<array{value: string, id?: string}>|null $people */
+        $blocks = $container->getPodcastIndexBlocks();
+        if ($blocks === null || $blocks === []) {
+            return;
+        }
+
+        foreach ($blocks as $block) {
+            $el   = $dom->createElement('podcast:block');
+            $text = $dom->createTextNode($block['value']);
+            $el->appendChild($text);
+            if (isset($block['id']) && $block['id'] !== '') {
+                $el->setAttribute('id', $block['id']);
+            }
+            $root->appendChild($el);
+        }
         $this->called = true;
     }
 }

--- a/test/Reader/Integration/PodcastIndexRss2Test.php
+++ b/test/Reader/Integration/PodcastIndexRss2Test.php
@@ -230,6 +230,19 @@ class PodcastIndexRss2Test extends TestCase
         $this->assertEquals($expectedB, $txts[1]);
     }
 
+    public function testGetsPodping(): void
+    {
+        /** @var Reader\Extension\PodcastIndex\Feed $feed */
+        $feed = Reader\Reader::importString(
+            file_get_contents($this->feedSamplePath)
+        );
+
+        $expected              = new stdClass();
+        $expected->usesPodping = true;
+
+        $this->assertEquals($expected, $feed->getPodcastIndexPodping());
+    }
+
     /**
      * Entry level testing
      */

--- a/test/Reader/Integration/PodcastIndexRss2Test.php
+++ b/test/Reader/Integration/PodcastIndexRss2Test.php
@@ -190,6 +190,26 @@ class PodcastIndexRss2Test extends TestCase
         $this->assertEquals($expected, $feed->getPodcastIndexMedium());
     }
 
+    public function testGetsBlocks(): void
+    {
+        /** @var Reader\Extension\PodcastIndex\Feed $feed */
+        $feed = Reader\Reader::importString(
+            file_get_contents($this->feedSamplePath)
+        );
+
+        $expectedA        = new stdClass();
+        $expectedA->value = 'yes';
+        $expectedA->id    = '';
+
+        $expectedB        = new stdClass();
+        $expectedB->value = 'no';
+        $expectedB->id    = 'google';
+
+        $blocks = $feed->getPodcastIndexBlocks();
+        $this->assertEquals($expectedA, $blocks[0]);
+        $this->assertEquals($expectedB, $blocks[1]);
+    }
+
     /**
      * Entry level testing
      */

--- a/test/Reader/Integration/PodcastIndexRss2Test.php
+++ b/test/Reader/Integration/PodcastIndexRss2Test.php
@@ -146,6 +146,24 @@ class PodcastIndexRss2Test extends TestCase
         $this->assertEquals($expected, $persons[0]);
     }
 
+    public function testGetsTrailer(): void
+    {
+        /** @var Reader\Extension\PodcastIndex\Feed $feed */
+        $feed = Reader\Reader::importString(
+            file_get_contents($this->feedSamplePath)
+        );
+
+        $expected          = new stdClass();
+        $expected->title   = 'Season 4: Race for the Clouds';
+        $expected->pubdate = "Thu, 01 Apr 2021 08:00:00 EST";
+        $expected->url     = "https://example.org/season4teaser.mp4";
+        $expected->length  = 12345678;
+        $expected->type    = "video/mp4";
+        $expected->season  = 4;
+
+        $this->assertEquals($expected, $feed->getPodcastIndexTrailer());
+    }
+
     /**
      * Entry level testing
      */

--- a/test/Reader/Integration/PodcastIndexRss2Test.php
+++ b/test/Reader/Integration/PodcastIndexRss2Test.php
@@ -164,6 +164,19 @@ class PodcastIndexRss2Test extends TestCase
         $this->assertEquals($expected, $feed->getPodcastIndexTrailer());
     }
 
+    public function testGetsGuid(): void
+    {
+        /** @var Reader\Extension\PodcastIndex\Feed $feed */
+        $feed = Reader\Reader::importString(
+            file_get_contents($this->feedSamplePath)
+        );
+
+        $expected        = new stdClass();
+        $expected->value = '917393e3-1b1e-5cef-ace4-edaa54e1f810';
+
+        $this->assertEquals($expected, $feed->getPodcastIndexGuid());
+    }
+
     /**
      * Entry level testing
      */

--- a/test/Reader/Integration/PodcastIndexRss2Test.php
+++ b/test/Reader/Integration/PodcastIndexRss2Test.php
@@ -210,6 +210,26 @@ class PodcastIndexRss2Test extends TestCase
         $this->assertEquals($expectedB, $blocks[1]);
     }
 
+    public function testGetsTxts(): void
+    {
+        /** @var Reader\Extension\PodcastIndex\Feed $feed */
+        $feed = Reader\Reader::importString(
+            file_get_contents($this->feedSamplePath)
+        );
+
+        $expectedA          = new stdClass();
+        $expectedA->value   = 'S6lpp-7ZCn8-dZfGc-OoyaG';
+        $expectedA->purpose = 'verify';
+
+        $expectedB          = new stdClass();
+        $expectedB->value   = '2022-10-26T04:45:30.742Z';
+        $expectedB->purpose = 'release';
+
+        $txts = $feed->getPodcastIndexTxts();
+        $this->assertEquals($expectedA, $txts[0]);
+        $this->assertEquals($expectedB, $txts[1]);
+    }
+
     /**
      * Entry level testing
      */

--- a/test/Reader/Integration/PodcastIndexRss2Test.php
+++ b/test/Reader/Integration/PodcastIndexRss2Test.php
@@ -177,6 +177,19 @@ class PodcastIndexRss2Test extends TestCase
         $this->assertEquals($expected, $feed->getPodcastIndexGuid());
     }
 
+    public function testGetsMedium(): void
+    {
+        /** @var Reader\Extension\PodcastIndex\Feed $feed */
+        $feed = Reader\Reader::importString(
+            file_get_contents($this->feedSamplePath)
+        );
+
+        $expected        = new stdClass();
+        $expected->value = 'audiobook';
+
+        $this->assertEquals($expected, $feed->getPodcastIndexMedium());
+    }
+
     /**
      * Entry level testing
      */

--- a/test/Reader/Integration/_files/podcastindex.xml
+++ b/test/Reader/Integration/_files/podcastindex.xml
@@ -33,6 +33,7 @@
             <itunes:category text="Gadgets" />
         </itunes:category>
         <itunes:category text="TV &amp; Film" />
+
         <podcast:locked owner="john.doe@example.com">yes</podcast:locked>
         <podcast:funding url="http://example.com/donate">Support the show!</podcast:funding>
         <podcast:license url="https://example.org/mypodcastlicense/full.pdf">my-podcast-license-v1</podcast:license>
@@ -40,6 +41,7 @@
         <podcast:images srcset="https://example.com/images/ep1/pci_avatar-massive.jpg 1500w, https://example.com/images/ep1/pci_avatar-middle.jpg 600w, https://example.com/images/ep1/pci_avatar-small.jpg 300w, https://example.com/images/ep1/pci_avatar-tiny.jpg 150w"/>
         <podcast:updateFrequency rrule="FREQ=WEEKLY" dtstart="2023-08-28T00:00:00.000Z" complete="false">Every other Monday</podcast:updateFrequency>
         <podcast:person group="writing" role="guest" href="https://www.wikipedia/alicebrown" img="http://example.com/images/alicebrown.jpg">Alice Brown</podcast:person>
+        <podcast:trailer pubdate="Thu, 01 Apr 2021 08:00:00 EST" url="https://example.org/season4teaser.mp4" length="12345678" type="video/mp4" season="4" >Season 4: Race for the Clouds</podcast:trailer>
 
         <item>
             <title>Shake Shake Shake Your Spices</title>

--- a/test/Reader/Integration/_files/podcastindex.xml
+++ b/test/Reader/Integration/_files/podcastindex.xml
@@ -43,6 +43,7 @@
         <podcast:person group="writing" role="guest" href="https://www.wikipedia/alicebrown" img="http://example.com/images/alicebrown.jpg">Alice Brown</podcast:person>
         <podcast:trailer pubdate="Thu, 01 Apr 2021 08:00:00 EST" url="https://example.org/season4teaser.mp4" length="12345678" type="video/mp4" season="4" >Season 4: Race for the Clouds</podcast:trailer>
         <podcast:guid>917393e3-1b1e-5cef-ace4-edaa54e1f810</podcast:guid>
+        <podcast:medium>audiobook</podcast:medium>
 
         <item>
             <title>Shake Shake Shake Your Spices</title>

--- a/test/Reader/Integration/_files/podcastindex.xml
+++ b/test/Reader/Integration/_files/podcastindex.xml
@@ -44,6 +44,8 @@
         <podcast:trailer pubdate="Thu, 01 Apr 2021 08:00:00 EST" url="https://example.org/season4teaser.mp4" length="12345678" type="video/mp4" season="4" >Season 4: Race for the Clouds</podcast:trailer>
         <podcast:guid>917393e3-1b1e-5cef-ace4-edaa54e1f810</podcast:guid>
         <podcast:medium>audiobook</podcast:medium>
+        <podcast:block>yes</podcast:block>
+        <podcast:block id="google">no</podcast:block>
 
         <item>
             <title>Shake Shake Shake Your Spices</title>

--- a/test/Reader/Integration/_files/podcastindex.xml
+++ b/test/Reader/Integration/_files/podcastindex.xml
@@ -42,6 +42,7 @@
         <podcast:updateFrequency rrule="FREQ=WEEKLY" dtstart="2023-08-28T00:00:00.000Z" complete="false">Every other Monday</podcast:updateFrequency>
         <podcast:person group="writing" role="guest" href="https://www.wikipedia/alicebrown" img="http://example.com/images/alicebrown.jpg">Alice Brown</podcast:person>
         <podcast:trailer pubdate="Thu, 01 Apr 2021 08:00:00 EST" url="https://example.org/season4teaser.mp4" length="12345678" type="video/mp4" season="4" >Season 4: Race for the Clouds</podcast:trailer>
+        <podcast:guid>917393e3-1b1e-5cef-ace4-edaa54e1f810</podcast:guid>
 
         <item>
             <title>Shake Shake Shake Your Spices</title>

--- a/test/Reader/Integration/_files/podcastindex.xml
+++ b/test/Reader/Integration/_files/podcastindex.xml
@@ -48,6 +48,7 @@
         <podcast:block id="google">no</podcast:block>
         <podcast:txt purpose="verify">S6lpp-7ZCn8-dZfGc-OoyaG</podcast:txt>
         <podcast:txt purpose="release">2022-10-26T04:45:30.742Z</podcast:txt>
+        <podcast:podping usesPodping="true"/>
 
         <item>
             <title>Shake Shake Shake Your Spices</title>

--- a/test/Reader/Integration/_files/podcastindex.xml
+++ b/test/Reader/Integration/_files/podcastindex.xml
@@ -46,6 +46,8 @@
         <podcast:medium>audiobook</podcast:medium>
         <podcast:block>yes</podcast:block>
         <podcast:block id="google">no</podcast:block>
+        <podcast:txt purpose="verify">S6lpp-7ZCn8-dZfGc-OoyaG</podcast:txt>
+        <podcast:txt purpose="release">2022-10-26T04:45:30.742Z</podcast:txt>
 
         <item>
             <title>Shake Shake Shake Your Spices</title>

--- a/test/Writer/Extension/PodcastIndex/FeedTest.php
+++ b/test/Writer/Extension/PodcastIndex/FeedTest.php
@@ -406,4 +406,59 @@ class FeedTest extends TestCase
         $this->expectException(Writer\Exception\InvalidArgumentException::class);
         $feed->addPodcastIndexPerson($person);
     }
+
+    public function testSetTrailer(): void
+    {
+        $feed = new Writer\Feed();
+
+        $trailer = [
+            'title'   => 'Season 4: Race for the Clouds',
+            'pubdate' => "Thu, 01 Apr 2021 08:00:00 EST",
+            'url'     => "https://example.org/season4teaser.mp4",
+            'length'  => 12345678,
+            'type'    => "video/mp4",
+            'season'  => 4,
+        ];
+
+        $feed->setPodcastIndexTrailer($trailer);
+        $this->assertEquals($trailer, $feed->getPodcastIndexTrailer());
+    }
+
+    public function testSetTrailerWithRequiredArguments(): void
+    {
+        $feed = new Writer\Feed();
+
+        $trailer = [
+            'title'   => 'Season 4: Race for the Clouds',
+            'pubdate' => "Thu, 01 Apr 2021 08:00:00 EST",
+            'url'     => "https://example.org/season4teaser.mp4",
+        ];
+
+        $feed->setPodcastIndexTrailer($trailer);
+        $this->assertEquals($trailer, $feed->getPodcastIndexTrailer());
+    }
+
+    public function testSetTrailerThrowsExceptionOnInvalidArguments(): void
+    {
+        $feed = new Writer\Feed();
+
+        $trailer = [
+            'abc' => 'def',
+        ];
+        $this->expectException(Writer\Exception\InvalidArgumentException::class);
+        $feed->setPodcastIndexTrailer($trailer);
+    }
+
+    public function testSetLocationThrowsExceptionOnInvalidUrl(): void
+    {
+        $feed = new Writer\Feed();
+
+        $trailer = [
+            'title'   => 'Season 4: Race for the Clouds',
+            'pubdate' => "Thu, 01 Apr 2021 08:00:00 EST",
+            'url'     => "example.org/season4teaser.mp4",
+        ];
+        $this->expectException(Writer\Exception\InvalidArgumentException::class);
+        $feed->setPodcastIndexTrailer($trailer);
+    }
 }

--- a/test/Writer/Extension/PodcastIndex/FeedTest.php
+++ b/test/Writer/Extension/PodcastIndex/FeedTest.php
@@ -484,4 +484,27 @@ class FeedTest extends TestCase
         $this->expectException(Writer\Exception\InvalidArgumentException::class);
         $feed->setPodcastIndexGuid($data);
     }
+
+    public function testSetMedium(): void
+    {
+        $feed = new Writer\Feed();
+
+        $data = [
+            'value' => 'audiobook',
+        ];
+
+        $feed->setPodcastIndexMedium($data);
+        $this->assertEquals($data, $feed->getPodcastIndexMedium());
+    }
+
+    public function testSetMediumThrowsExceptionOnInvalidArgument(): void
+    {
+        $feed = new Writer\Feed();
+
+        $data = [
+            'abc' => 'def',
+        ];
+        $this->expectException(Writer\Exception\InvalidArgumentException::class);
+        $feed->setPodcastIndexMedium($data);
+    }
 }

--- a/test/Writer/Extension/PodcastIndex/FeedTest.php
+++ b/test/Writer/Extension/PodcastIndex/FeedTest.php
@@ -385,7 +385,7 @@ class FeedTest extends TestCase
         $this->assertNull($feed->getPodcastIndexPeople());
     }
 
-    public function testSetPersonWithOneArgument(): void
+    public function testAddPersonWithOneArgument(): void
     {
         $feed = new Writer\Feed();
 
@@ -523,5 +523,110 @@ class FeedTest extends TestCase
         ];
         $this->expectException(Writer\Exception\InvalidArgumentException::class);
         $feed->setPodcastIndexMedium($data);
+    }
+
+    public function testAddBlock(): void
+    {
+        $feed = new Writer\Feed();
+
+        $block = [
+            'value' => 'yes',
+            'id'    => 'google',
+        ];
+        $feed->addPodcastIndexBlock($block);
+
+        /** @var list<array{value: string, id?: string}> $blocks */
+        $blocks = $feed->getPodcastIndexBlocks();
+        $this->assertTrue(in_array($block, $blocks));
+    }
+
+    public function testSetBlocks(): void
+    {
+        $feed = new Writer\Feed();
+
+        $blocks = [
+            [
+                'value' => 'no',
+                'id'    => '',
+            ],
+            [
+                'value' => 'yes',
+                'id'    => 'google',
+            ],
+        ];
+
+        // set
+        $feed->setPodcastIndexBlocks($blocks);
+        /** @var list<array{value: string, id?: string}> $blocksSaved */
+        $blocksSaved = $feed->getPodcastIndexBlocks();
+        foreach ($blocks as $block) {
+            $this->assertTrue(in_array($block, $blocksSaved));
+        }
+
+        // add
+        $singleBlock = [
+            'value' => 'yes',
+            'id'    => 'apple',
+        ];
+        $feed->addPodcastIndexBlock($singleBlock);
+        $moreBlocksSaved = $feed->getPodcastIndexBlocks();
+        foreach ($blocks as $block) {
+            $this->assertTrue(in_array($block, $moreBlocksSaved));
+        }
+        $this->assertTrue(in_array($singleBlock, $moreBlocksSaved));
+
+        // update
+        $newBlocks = [
+            [
+                'value' => 'no',
+                'id'    => 'google',
+            ],
+        ];
+        $feed->setPodcastIndexBlocks($newBlocks);
+        /** @var list<array{value: string, id?: string}> $updated */
+        $updated = $feed->getPodcastIndexBlocks();
+        $this->assertEquals(1, count($updated));
+        $this->assertEquals($newBlocks, $updated);
+
+        // delete
+        $feed->setPodcastIndexBlocks();
+        $this->assertNull($feed->getPodcastIndexBlocks());
+    }
+
+    public function testAddBlockWithOneArgument(): void
+    {
+        $feed = new Writer\Feed();
+
+        $block = [
+            'value' => 'yes',
+        ];
+        $feed->addPodcastIndexBlock($block);
+
+        /** @var array<array> $blocks */
+        $blocks = $feed->getPodcastIndexBlocks();
+        $this->assertTrue(in_array($block, $blocks));
+    }
+
+    public function testAddBlockThrowsExceptionOnInvalidArguments(): void
+    {
+        $feed = new Writer\Feed();
+
+        $data = [
+            'abc' => 'def',
+        ];
+        $this->expectException(Writer\Exception\InvalidArgumentException::class);
+        $feed->addPodcastIndexBlock($data);
+    }
+
+    public function testAddBlockThrowsExceptionOnInvalidValue(): void
+    {
+        $feed = new Writer\Feed();
+
+        $data = [
+            'value' => true,
+            'id'    => 'google',
+        ];
+        $this->expectException(Writer\Exception\InvalidArgumentException::class);
+        $feed->addPodcastIndexBlock($data);
     }
 }

--- a/test/Writer/Extension/PodcastIndex/FeedTest.php
+++ b/test/Writer/Extension/PodcastIndex/FeedTest.php
@@ -634,4 +634,110 @@ class FeedTest extends TestCase
         $this->expectException(Writer\Exception\InvalidArgumentException::class);
         $feed->addPodcastIndexBlock($data);
     }
+
+    public function testAddTxt(): void
+    {
+        $feed = new Writer\Feed();
+
+        $txt = [
+            'value'   => 'S6lpp-7ZCn8-dZfGc-OoyaG',
+            'purpose' => 'verify',
+        ];
+        $feed->addPodcastIndexTxt($txt);
+
+        /** @var list<array{value: string, purpose?: string}> $txts */
+        $txts = $feed->getPodcastIndexTxts();
+        $this->assertTrue(in_array($txt, $txts));
+    }
+
+    public function testSetTxts(): void
+    {
+        $feed = new Writer\Feed();
+
+        $txts = [
+            [
+                'value'   => 'S6lpp-7ZCn8-dZfGc-OoyaG',
+                'purpose' => 'verify',
+            ],
+            [
+                'value'   => '2022-10-26T04:45:30.742Z',
+                'purpose' => 'release',
+            ],
+        ];
+
+        // set
+        $feed->setPodcastIndexTxts($txts);
+        /** @var list<object{value: string, purpose?: string}> $txtsSaved */
+        $txtsSaved = $feed->getPodcastIndexTxts();
+        foreach ($txts as $txt) {
+            $this->assertTrue(in_array($txt, $txtsSaved));
+        }
+
+        // add
+        $singleTxt = [
+            'value'   => 'naj3eEZaWVVY9a38uhX8FekACyhtqP4JN',
+            'purpose' => 'verify',
+        ];
+        $feed->addPodcastIndexTxt($singleTxt);
+        /** @psalm-var list<object{value: string, purpose?: string}> $moreTxtsSaved */
+        $moreTxtsSaved = $feed->getPodcastIndexTxts();
+        foreach ($txts as $txt) {
+            $this->assertTrue(in_array($txt, $moreTxtsSaved));
+        }
+        $this->assertTrue(in_array($singleTxt, $moreTxtsSaved));
+
+        // update
+        $newTxts = [
+            [
+                'value'   => '05124',
+                'purpose' => 'applepodcastsverify',
+            ],
+        ];
+        $feed->setPodcastIndexTxts($newTxts);
+        /** @var list<object{value: string, purpose?: string}> $updated */
+        $updated = $feed->getPodcastIndexTxts();
+        $this->assertEquals(1, count($updated));
+        $this->assertEquals($newTxts, $updated);
+
+        // delete
+        $feed->setPodcastIndexTxts();
+        $this->assertNull($feed->getPodcastIndexTxts());
+    }
+
+    public function testAddTxtWithOneArgument(): void
+    {
+        $feed = new Writer\Feed();
+
+        $txt = [
+            'value' => 'naj3eEZaWVVY9a38uhX8FekACyhtqP4JN',
+        ];
+        $feed->addPodcastIndexTxt($txt);
+
+        /** @psalm-var list<object{value: string, purpose?: string}> $txts */
+        $txts = $feed->getPodcastIndexTxts();
+        $this->assertTrue(in_array($txt, $txts));
+    }
+
+    public function testAddTxtThrowsExceptionOnInvalidArguments(): void
+    {
+        $feed = new Writer\Feed();
+
+        $data = [
+            'abc' => 'def',
+        ];
+        $this->expectException(Writer\Exception\InvalidArgumentException::class);
+        $feed->addPodcastIndexTxt($data);
+    }
+
+    public function testAddTxtThrowsExceptionOnInvalidValue(): void
+    {
+        $feed = new Writer\Feed();
+
+        $data = [
+            'value'   => true,
+            'purpose' => 'google',
+        ];
+        $this->expectException(Writer\Exception\InvalidArgumentException::class);
+        $feed->addPodcastIndexTxt($data);
+    }
 }

--- a/test/Writer/Extension/PodcastIndex/FeedTest.php
+++ b/test/Writer/Extension/PodcastIndex/FeedTest.php
@@ -740,4 +740,27 @@ class FeedTest extends TestCase
         $this->expectException(Writer\Exception\InvalidArgumentException::class);
         $feed->addPodcastIndexTxt($data);
     }
+
+    public function testSetPodping(): void
+    {
+        $feed = new Writer\Feed();
+
+        $data = [
+            'usesPodping' => true,
+        ];
+
+        $feed->setPodcastIndexPodping($data);
+        $this->assertEquals($data, $feed->getPodcastIndexPodping());
+    }
+
+    public function testSetPodpingThrowsExceptionOnInvalidArgument(): void
+    {
+        $feed = new Writer\Feed();
+
+        $data = [
+            'abc' => 'def',
+        ];
+        $this->expectException(Writer\Exception\InvalidArgumentException::class);
+        $feed->setPodcastIndexPodping($data);
+    }
 }

--- a/test/Writer/Extension/PodcastIndex/FeedTest.php
+++ b/test/Writer/Extension/PodcastIndex/FeedTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace LaminasTest\Feed\Writer\Extension\PodcastIndex;
 
 use DateTime;
+use Laminas\Feed\Reader\Extension\PodcastIndex\Feed;
 use Laminas\Feed\Writer;
 use PHPUnit\Framework\TestCase;
 
@@ -13,6 +14,9 @@ use function implode;
 use function in_array;
 use function time;
 
+/**
+ * @psalm-import-type PersonObject from Feed
+ */
 class FeedTest extends TestCase
 {
     public function testSetLocked(): void
@@ -334,7 +338,7 @@ class FeedTest extends TestCase
         ];
         $feed->addPodcastIndexPerson($person);
 
-        /** @var array<array> $people */
+        /** @var list<PersonObject> $people */
         $people = $feed->getPodcastIndexPeople();
         $this->assertTrue(in_array($person, $people));
     }
@@ -359,7 +363,7 @@ class FeedTest extends TestCase
         ];
         // set
         $feed->setPodcastIndexPeople($people);
-        /** @var array<array> $peopleSaved */
+        /** @var list<PersonObject> $peopleSaved */
         $peopleSaved = $feed->getPodcastIndexPeople();
         foreach ($people as $person) {
             $this->assertTrue(in_array($person, $peopleSaved));
@@ -375,7 +379,7 @@ class FeedTest extends TestCase
             ],
         ];
         $feed->setPodcastIndexPeople($newPersons);
-        /** @var array<array> $updated */
+        /** @var list<PersonObject> $updated */
         $updated = $feed->getPodcastIndexPeople();
         $this->assertEquals(1, count($updated));
         $this->assertEquals($newPersons, $updated);
@@ -394,7 +398,7 @@ class FeedTest extends TestCase
         ];
         $feed->addPodcastIndexPerson($person);
 
-        /** @var array<array> $people */
+        /** @var list<PersonObject> $people */
         $people = $feed->getPodcastIndexPeople();
         $this->assertTrue(in_array($person, $people));
     }
@@ -557,7 +561,7 @@ class FeedTest extends TestCase
 
         // set
         $feed->setPodcastIndexBlocks($blocks);
-        /** @var list<array{value: string, id?: string}> $blocksSaved */
+        /** @var list<object{value: string, id?: string}> $blocksSaved */
         $blocksSaved = $feed->getPodcastIndexBlocks();
         foreach ($blocks as $block) {
             $this->assertTrue(in_array($block, $blocksSaved));
@@ -569,6 +573,7 @@ class FeedTest extends TestCase
             'id'    => 'apple',
         ];
         $feed->addPodcastIndexBlock($singleBlock);
+        /** @psalm-var list<object{value: string, id?: string}> $moreBlocksSaved */
         $moreBlocksSaved = $feed->getPodcastIndexBlocks();
         foreach ($blocks as $block) {
             $this->assertTrue(in_array($block, $moreBlocksSaved));
@@ -583,7 +588,7 @@ class FeedTest extends TestCase
             ],
         ];
         $feed->setPodcastIndexBlocks($newBlocks);
-        /** @var list<array{value: string, id?: string}> $updated */
+        /** @var list<object{value: string, id?: string}> $updated */
         $updated = $feed->getPodcastIndexBlocks();
         $this->assertEquals(1, count($updated));
         $this->assertEquals($newBlocks, $updated);
@@ -602,7 +607,7 @@ class FeedTest extends TestCase
         ];
         $feed->addPodcastIndexBlock($block);
 
-        /** @var array<array> $blocks */
+        /** @psalm-var list<object{value: string, id?: string}> $blocks */
         $blocks = $feed->getPodcastIndexBlocks();
         $this->assertTrue(in_array($block, $blocks));
     }

--- a/test/Writer/Extension/PodcastIndex/FeedTest.php
+++ b/test/Writer/Extension/PodcastIndex/FeedTest.php
@@ -461,4 +461,27 @@ class FeedTest extends TestCase
         $this->expectException(Writer\Exception\InvalidArgumentException::class);
         $feed->setPodcastIndexTrailer($trailer);
     }
+
+    public function testSetGuid(): void
+    {
+        $feed = new Writer\Feed();
+
+        $data = [
+            'value' => '917393e3-1b1e-5cef-ace4-edaa54e1f810',
+        ];
+
+        $feed->setPodcastIndexGuid($data);
+        $this->assertEquals($data, $feed->getPodcastIndexGuid());
+    }
+
+    public function testSetGuidThrowsExceptionOnInvalidArgument(): void
+    {
+        $feed = new Writer\Feed();
+
+        $data = [
+            'abc' => 'def',
+        ];
+        $this->expectException(Writer\Exception\InvalidArgumentException::class);
+        $feed->setPodcastIndexGuid($data);
+    }
 }

--- a/test/Writer/Renderer/Extension/PodcastIndex/FeedTest.php
+++ b/test/Writer/Renderer/Extension/PodcastIndex/FeedTest.php
@@ -310,4 +310,17 @@ class FeedTest extends TestCase
         $this->assertStringContainsString('<podcast:txt purpose="verify">S6lpp-7ZCn8-dZfGc-OoyaG</podcast:txt>', $xml);
         $this->assertStringContainsString('<podcast:txt>2022-10-26T04:45:30.742Z</podcast:txt>', $xml);
     }
+
+    public function testRendersRssPodpingTag(): void
+    {
+        $data = [
+            'usesPodping' => true,
+        ];
+        $this->validWriter->setPodcastIndexPodping($data);
+
+        $rssFeed = new Renderer\Feed\Rss($this->validWriter);
+        $xml     = $rssFeed->render()->saveXml();
+
+        $this->assertStringContainsString('<podcast:podping usesPodping="true"/>', $xml);
+    }
 }

--- a/test/Writer/Renderer/Extension/PodcastIndex/FeedTest.php
+++ b/test/Writer/Renderer/Extension/PodcastIndex/FeedTest.php
@@ -198,4 +198,18 @@ class FeedTest extends TestCase
         $this->assertStringContainsString($trailer['pubdate'], $xml);
         $this->assertStringContainsString($trailer['url'], $xml);
     }
+
+    public function testRendersRssGuidTag(): void
+    {
+        $data = [
+            'value' => '917393e3-1b1e-5cef-ace4-edaa54e1f810',
+        ];
+        $this->validWriter->setPodcastIndexGuid($data);
+
+        $rssFeed = new Renderer\Feed\Rss($this->validWriter);
+        $xml     = $rssFeed->render()->saveXml();
+
+        $this->assertStringContainsString('<podcast:guid', $xml);
+        $this->assertStringContainsString($data['value'], $xml);
+    }
 }

--- a/test/Writer/Renderer/Extension/PodcastIndex/FeedTest.php
+++ b/test/Writer/Renderer/Extension/PodcastIndex/FeedTest.php
@@ -180,4 +180,22 @@ class FeedTest extends TestCase
         $this->assertStringContainsString(">$fName</podcast:person>", $xml);
         $this->assertStringContainsString(">$sName</podcast:person>", $xml);
     }
+
+    public function testRendersRssTrailerTag(): void
+    {
+        $trailer = [
+            'title'   => 'Season 4: Race for the Clouds',
+            'pubdate' => "Thu, 01 Apr 2021 08:00:00 EST",
+            'url'     => "https://example.org/season4teaser.mp4",
+        ];
+        $this->validWriter->setPodcastIndexTrailer($trailer);
+
+        $rssFeed = new Renderer\Feed\Rss($this->validWriter);
+        $xml     = $rssFeed->render()->saveXml();
+
+        $this->assertStringContainsString('<podcast:trailer', $xml);
+        $this->assertStringContainsString($trailer['title'], $xml);
+        $this->assertStringContainsString($trailer['pubdate'], $xml);
+        $this->assertStringContainsString($trailer['url'], $xml);
+    }
 }

--- a/test/Writer/Renderer/Extension/PodcastIndex/FeedTest.php
+++ b/test/Writer/Renderer/Extension/PodcastIndex/FeedTest.php
@@ -212,4 +212,18 @@ class FeedTest extends TestCase
         $this->assertStringContainsString('<podcast:guid', $xml);
         $this->assertStringContainsString($data['value'], $xml);
     }
+
+    public function testRendersRssMediumTag(): void
+    {
+        $data = [
+            'value' => 'audiobook',
+        ];
+        $this->validWriter->setPodcastIndexMedium($data);
+
+        $rssFeed = new Renderer\Feed\Rss($this->validWriter);
+        $xml     = $rssFeed->render()->saveXml();
+
+        $this->assertStringContainsString('<podcast:medium', $xml);
+        $this->assertStringContainsString($data['value'], $xml);
+    }
 }

--- a/test/Writer/Renderer/Extension/PodcastIndex/FeedTest.php
+++ b/test/Writer/Renderer/Extension/PodcastIndex/FeedTest.php
@@ -231,4 +231,44 @@ class FeedTest extends TestCase
         $this->assertStringContainsString('<podcast:medium', $xml);
         $this->assertStringContainsString($data['value'], $xml);
     }
+
+    public function testRendersRssBlockTag(): void
+    {
+        $data = [
+            'value' => 'no',
+            'id'    => 'google',
+        ];
+
+        $this->validWriter->addPodcastIndexBlock($data);
+
+        $rssFeed = new Renderer\Feed\Rss($this->validWriter);
+        $xml     = $rssFeed->render()->saveXml();
+
+        $this->assertStringContainsString('<podcast:block', $xml);
+        $this->assertStringContainsString($data['value'], $xml);
+        $this->assertStringContainsString($data['id'], $xml);
+        $this->assertSame(1, substr_count($xml, $data['id']));
+    }
+
+    public function testRendersRssBlockTags(): void
+    {
+        $data = [
+            [
+                'value' => 'yes',
+                'id'    => '',
+            ],
+            [
+                'value' => 'no',
+                'id'    => 'google',
+            ],
+        ];
+
+        $this->validWriter->setPodcastIndexBlocks($data);
+
+        $rssFeed = new Renderer\Feed\Rss($this->validWriter);
+        $xml     = $rssFeed->render()->saveXml();
+
+        $this->assertStringContainsString('<podcast:block>yes</podcast:block>', $xml);
+        $this->assertStringContainsString('<podcast:block id="google">no</podcast:block>', $xml);
+    }
 }

--- a/test/Writer/Renderer/Extension/PodcastIndex/FeedTest.php
+++ b/test/Writer/Renderer/Extension/PodcastIndex/FeedTest.php
@@ -271,4 +271,43 @@ class FeedTest extends TestCase
         $this->assertStringContainsString('<podcast:block>yes</podcast:block>', $xml);
         $this->assertStringContainsString('<podcast:block id="google">no</podcast:block>', $xml);
     }
+
+    public function testRendersRssTxtTag(): void
+    {
+        $data = [
+            'value'   => 'S6lpp-7ZCn8-dZfGc-OoyaG',
+            'purpose' => 'verify',
+        ];
+
+        $this->validWriter->addPodcastIndexTxt($data);
+
+        $rssFeed = new Renderer\Feed\Rss($this->validWriter);
+        $xml     = $rssFeed->render()->saveXml();
+
+        $this->assertStringContainsString('<podcast:txt', $xml);
+        $this->assertStringContainsString($data['value'], $xml);
+        $this->assertStringContainsString($data['purpose'], $xml);
+        $this->assertSame(1, substr_count($xml, $data['purpose']));
+    }
+
+    public function testRendersRssTxtTags(): void
+    {
+        $data = [
+            [
+                'value'   => 'S6lpp-7ZCn8-dZfGc-OoyaG',
+                'purpose' => 'verify',
+            ],
+            [
+                'value' => '2022-10-26T04:45:30.742Z',
+            ],
+        ];
+
+        $this->validWriter->setPodcastIndexTxts($data);
+
+        $rssFeed = new Renderer\Feed\Rss($this->validWriter);
+        $xml     = $rssFeed->render()->saveXml();
+
+        $this->assertStringContainsString('<podcast:txt purpose="verify">S6lpp-7ZCn8-dZfGc-OoyaG</podcast:txt>', $xml);
+        $this->assertStringContainsString('<podcast:txt>2022-10-26T04:45:30.742Z</podcast:txt>', $xml);
+    }
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | yes
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | no

### Description

1. Extended PodcastIndex support for additional namespaces:

- Feed Trailer
- Feed Guid
- Feed Medium
- Feed Block
- Feed Txt
- Feed Podping

2. Added tests for the above namespaces
3. Added documentation for the above namespaces
4. Fixed a docs entry on the method `setPodcastIndexPeople()`
5. Updated general type security in the Extension's Renderer and Tests
