### PR TITLE
Remove redundant processing of an invalid date field

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -639,7 +639,6 @@
     </InvalidReturnStatement>
     <MixedArgument>
       <code>$dateModified</code>
-      <code>$dateModified</code>
     </MixedArgument>
     <MixedArrayAccess>
       <code><![CDATA[$author['name']]]></code>
@@ -717,7 +716,6 @@
     </NullableReturnStatement>
     <PossiblyNullArgument>
       <code><![CDATA[$author->nodeValue]]></code>
-      <code>$standard</code>
     </PossiblyNullArgument>
     <PossiblyUnusedReturnValue>
       <code>array</code>
@@ -1994,13 +1992,11 @@
       <code><![CDATA[null|array<string, string>]]></code>
     </ImplementedReturnTypeMismatch>
     <InvalidArgument>
-      <code>$lastBuildDateParsed</code>
       <code>Reader\Reader::arrayUnique($authors)</code>
     </InvalidArgument>
     <MixedArgument>
       <code>$authors</code>
       <code>$categoryCollection</code>
-      <code>$dateModified</code>
       <code>$dateModified</code>
       <code>$hubs</code>
       <code>$lastBuildDate</code>
@@ -2148,7 +2144,6 @@
     </NullableReturnStatement>
     <PossiblyNullArgument>
       <code><![CDATA[$author->nodeValue]]></code>
-      <code>$standard</code>
     </PossiblyNullArgument>
     <PossiblyNullReference>
       <code>getAuthors</code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -2170,7 +2170,6 @@
     <PossiblyUnusedMethod>
       <code>getHubs</code>
       <code>getImage</code>
-      <code>getLastBuildDate</code>
     </PossiblyUnusedMethod>
     <PropertyNotSetInConstructor>
       <code>Rss</code>

--- a/src/Reader/Entry/Rss.php
+++ b/src/Reader/Entry/Rss.php
@@ -179,7 +179,7 @@ class Rss extends AbstractEntry implements EntryInterface
     /**
      * Get the entry's date of creation
      *
-     * @return DateTime
+     * @return null|DateTime
      */
     public function getDateCreated()
     {
@@ -189,7 +189,7 @@ class Rss extends AbstractEntry implements EntryInterface
     /**
      * Get the entry's date of modification
      *
-     * @return DateTime
+     * @return null|DateTime
      * @throws Exception\RuntimeException
      */
     public function getDateModified()
@@ -206,31 +206,15 @@ class Rss extends AbstractEntry implements EntryInterface
         ) {
             $dateModified = $this->xpath->evaluate('string(' . $this->xpathQueryRss . '/pubDate)');
             if ($dateModified) {
-                $dateModifiedParsed = strtotime($dateModified);
-                if ($dateModifiedParsed) {
-                    $date = new DateTime('@' . $dateModifiedParsed);
-                } else {
-                    $dateStandards = [
-                        DateTime::RSS,
-                        DateTime::RFC822,
-                        DateTime::RFC2822,
-                        null,
-                    ];
-                    foreach ($dateStandards as $standard) {
-                        try {
-                            $date = date_create_from_format($standard, $dateModified);
-                            break;
-                        } catch (\Exception $e) {
-                            if ($standard === null) {
-                                throw new Exception\RuntimeException(
-                                    'Could not load date due to unrecognised format'
-                                    . ' (should follow RFC 822 or 2822): ' . $e->getMessage(),
-                                    0,
-                                    $e
-                                );
-                            }
-                        }
-                    }
+                try {
+                    $date = new DateTime($dateModified);
+                } catch (\Exception $e) {
+                    throw new Exception\RuntimeException(
+                        'Could not load date due to unrecognised format'
+                        . ' (should follow RFC 822 or 2822): ' . $e->getMessage(),
+                        0,
+                        $e
+                    );
                 }
             }
         }

--- a/src/Reader/Entry/Rss.php
+++ b/src/Reader/Entry/Rss.php
@@ -22,12 +22,10 @@ use stdClass;
 
 use function array_key_exists;
 use function count;
-use function date_create_from_format;
 use function in_array;
 use function is_array;
 use function is_string;
 use function preg_match;
-use function strtotime;
 use function trim;
 
 class Rss extends AbstractEntry implements EntryInterface
@@ -179,7 +177,7 @@ class Rss extends AbstractEntry implements EntryInterface
     /**
      * Get the entry's date of creation
      *
-     * @return null|DateTime
+     * @return DateTime
      */
     public function getDateCreated()
     {
@@ -189,7 +187,7 @@ class Rss extends AbstractEntry implements EntryInterface
     /**
      * Get the entry's date of modification
      *
-     * @return null|DateTime
+     * @return DateTime
      * @throws Exception\RuntimeException
      */
     public function getDateModified()

--- a/src/Reader/Feed/Rss.php
+++ b/src/Reader/Feed/Rss.php
@@ -185,7 +185,7 @@ class Rss extends AbstractFeed
     /**
      * Get the feed modification date
      *
-     * @return DateTime
+     * @return null|DateTime
      * @throws Exception\RuntimeException
      */
     public function getDateModified()
@@ -205,30 +205,13 @@ class Rss extends AbstractFeed
                 $dateModified = $this->xpath->evaluate('string(/rss/channel/lastBuildDate)');
             }
             if ($dateModified) {
-                $dateModifiedParsed = strtotime($dateModified);
-                if ($dateModifiedParsed) {
-                    $date = new DateTime('@' . $dateModifiedParsed);
-                } else {
-                    $dateStandards = [
-                        DateTime::RSS,
-                        DateTime::RFC822,
-                        DateTime::RFC2822,
-                    ];
-                    foreach ($dateStandards as $standard) {
-                        $date = DateTime::createFromFormat(
-                            $standard,
-                            $dateModified
-                        );
-                        if ($date instanceof DateTime) {
-                            break;
-                        }
-                    }
-                    if (! $date) {
-                        throw new Exception\RuntimeException(
-                            'Could not load date due to unrecognised'
-                            . ' format (should follow RFC 822 or 2822).'
-                        );
-                    }
+                try {
+                    $date = new DateTime($dateModified);
+                } catch (\Exception $e) {
+                    throw new Exception\RuntimeException(
+                        'Could not load date due to unrecognised'
+                        . ' format (should follow RFC 822 or 2822).'
+                    );
                 }
             }
         }
@@ -253,7 +236,7 @@ class Rss extends AbstractFeed
     /**
      * Get the feed lastBuild date
      *
-     * @return DateTime
+     * @return null|DateTime
      * @throws Exception\RuntimeException
      */
     public function getLastBuildDate()
@@ -270,31 +253,15 @@ class Rss extends AbstractFeed
         ) {
             $lastBuildDate = $this->xpath->evaluate('string(/rss/channel/lastBuildDate)');
             if ($lastBuildDate) {
-                $lastBuildDateParsed = strtotime($lastBuildDate);
-                if ($lastBuildDateParsed) {
-                    $date = new DateTime('@' . $lastBuildDateParsed);
-                } else {
-                    $dateStandards = [
-                        DateTime::RSS,
-                        DateTime::RFC822,
-                        DateTime::RFC2822,
-                        null,
-                    ];
-                    foreach ($dateStandards as $standard) {
-                        try {
-                            $date = DateTime::createFromFormat($standard, $lastBuildDateParsed);
-                            break;
-                        } catch (\Exception $e) {
-                            if ($standard === null) {
-                                throw new Exception\RuntimeException(
-                                    'Could not load date due to unrecognised format'
-                                    . ' (should follow RFC 822 or 2822): ' . $e->getMessage(),
-                                    0,
-                                    $e
-                                );
-                            }
-                        }
-                    }
+                try {
+                    $date = new DateTime($lastBuildDate);
+                } catch (\Exception $e) {
+                    throw new Exception\RuntimeException(
+                        'Could not load date due to unrecognised format'
+                        . ' (should follow RFC 822 or 2822): ' . $e->getMessage(),
+                        0,
+                        $e
+                    );
                 }
             }
         }

--- a/src/Reader/Feed/Rss.php
+++ b/src/Reader/Feed/Rss.php
@@ -15,7 +15,6 @@ use function array_unique;
 use function count;
 use function is_array;
 use function preg_match;
-use function strtotime;
 use function trim;
 
 /** @template-extends AbstractFeed<Reader\Entry\Rss> */
@@ -185,7 +184,7 @@ class Rss extends AbstractFeed
     /**
      * Get the feed modification date
      *
-     * @return null|DateTime
+     * @return DateTime
      * @throws Exception\RuntimeException
      */
     public function getDateModified()
@@ -236,7 +235,7 @@ class Rss extends AbstractFeed
     /**
      * Get the feed lastBuild date
      *
-     * @return null|DateTime
+     * @return DateTime
      * @throws Exception\RuntimeException
      */
     public function getLastBuildDate()

--- a/test/Reader/Entry/RssTest.php
+++ b/test/Reader/Entry/RssTest.php
@@ -1919,7 +1919,7 @@ class RssTest extends TestCase
         ];
     }
 
-    public function testGetDateModifiedShouldThrowExceptionForInvalidDate(): void
+    public function testGetsDateModifiedShouldThrowExceptionForInvalidDate(): void
     {
         $feed = Reader\Reader::importString(
             file_get_contents($this->feedSamplePath . '/datemodified/plain/invalid.xml')
@@ -1930,7 +1930,7 @@ class RssTest extends TestCase
             'Could not load date due to unrecognised format (should follow RFC 822 or 2822)'
         );
         $entry = $feed->current();
-        $date = $entry->getDateModified();
+        $entry->getDateModified();
     }
 
     /**

--- a/test/Reader/Entry/RssTest.php
+++ b/test/Reader/Entry/RssTest.php
@@ -1919,6 +1919,20 @@ class RssTest extends TestCase
         ];
     }
 
+    public function testGetDateModifiedShouldThrowExceptionForInvalidDate(): void
+    {
+        $feed = Reader\Reader::importString(
+            file_get_contents($this->feedSamplePath . '/datemodified/plain/invalid.xml')
+        );
+
+        $this->expectException(Reader\Exception\RuntimeException::class);
+        $this->expectExceptionMessage(
+            'Could not load date due to unrecognised format (should follow RFC 822 or 2822)'
+        );
+        $entry = $feed->current();
+        $date = $entry->getDateModified();
+    }
+
     /**
      * Get CommentCount (Unencoded Text)
      */

--- a/test/Reader/Entry/_files/Rss/datemodified/plain/invalid.xml
+++ b/test/Reader/Entry/_files/Rss/datemodified/plain/invalid.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<rss version="2.0">
+    <channel>
+        <item>
+            <!-- missing month -->
+            <pubDate>Sat, 07 2009 08:03:50 +0000</pubDate>
+        </item>
+    </channel>
+</rss>

--- a/test/Reader/Feed/RssTest.php
+++ b/test/Reader/Feed/RssTest.php
@@ -2110,7 +2110,7 @@ class RssTest extends TestCase
         $this->assertEquals(null, $feed->getLastBuildDate());
     }
 
-    public function testGetLastBuildDateShouldThrowExceptionForInvalidDate(): void
+    public function testGetsLastBuildDateShouldThrowExceptionForInvalidDate(): void
     {
         $feed = Reader\Reader::importString(
             file_get_contents(
@@ -2187,7 +2187,7 @@ class RssTest extends TestCase
         ];
     }
 
-    public function testGetDateModifiedShouldThrowExceptionForInvalidDate(): void
+    public function testGetsDateModifiedShouldThrowExceptionForInvalidDate(): void
     {
         $feed = Reader\Reader::importString(
             file_get_contents(

--- a/test/Reader/Feed/RssTest.php
+++ b/test/Reader/Feed/RssTest.php
@@ -5,6 +5,7 @@ namespace LaminasTest\Feed\Reader\Feed;
 use DateTime;
 use DateTimeInterface;
 use Laminas\Feed\Reader;
+use Laminas\Feed\Reader\Feed\Rss;
 use PHPUnit\Framework\TestCase;
 
 use function array_values;
@@ -2122,7 +2123,8 @@ class RssTest extends TestCase
             'Could not load date due to unrecognised format (should follow RFC 822 or 2822)'
         );
 
-        $feed->getLastBuildDate();
+        $this->assertInstanceOf(Rss::class, $feed);
+        $_date = $feed->getLastBuildDate();
     }
 
     /**

--- a/test/Reader/Feed/RssTest.php
+++ b/test/Reader/Feed/RssTest.php
@@ -2124,7 +2124,7 @@ class RssTest extends TestCase
         );
 
         $this->assertInstanceOf(Rss::class, $feed);
-        $_date = $feed->getLastBuildDate();
+        $feed->getLastBuildDate();
     }
 
     /**

--- a/test/Reader/Feed/RssTest.php
+++ b/test/Reader/Feed/RssTest.php
@@ -2109,6 +2109,22 @@ class RssTest extends TestCase
         $this->assertEquals(null, $feed->getLastBuildDate());
     }
 
+    public function testGetLastBuildDateShouldThrowExceptionForInvalidDate(): void
+    {
+        $feed = Reader\Reader::importString(
+            file_get_contents(
+                $this->feedSamplePath . '/lastbuilddate/plain/invalid.xml'
+            )
+        );
+
+        $this->expectException(Reader\Exception\RuntimeException::class);
+        $this->expectExceptionMessage(
+            'Could not load date due to unrecognised format (should follow RFC 822 or 2822)'
+        );
+
+        $feed->getLastBuildDate();
+    }
+
     /**
      * Get DateModified (Unencoded Text)
      *

--- a/test/Reader/Feed/_files/Rss/lastbuilddate/plain/invalid.xml
+++ b/test/Reader/Feed/_files/Rss/lastbuilddate/plain/invalid.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<rss version="2.0">
+    <channel>
+        <!-- missing year -->
+        <lastBuildDate>Sat, 07 Mar  08:03:50 +0000</lastBuildDate>
+    </channel>
+</rss>


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Assuming the current release is 1.5.0, the next patch release is 1.5.1, the next minor is 1.6.0 and the next major is 2.0.0, The Current release branch will be `1.5.x`, the next minor branch will be `1.6.x`, and the next major branch will be `2.0.x`

Pick the target branch based on the following criteria:
  * Documentation improvement: Current release branch 1.5.x
  * Bugfix: Current release branch 1.5.x
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: Next minor 1.6.x
  * New feature, or refactor of existing code: Next minor 1.6.x
  * Backwards incompatible features and refactoring: Next major 2.0.x

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

<!--

Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE CURRENT RELEASE BRANCH

- Are you adding documentation?
  - TARGET THE CURRENT RELEASE BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE NEXT MINOR BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE CURRENT RELEASE BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE NEXT MINOR BRANCH OR THE NEXT MAJOR IF BC WILL BE BROKEN

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE NEXT MINOR BRANCH OR THE NEXT MAJOR IF BC WILL BE BROKEN
-->
This change removes redundant further processing  when an invalid date field has already failed. That removes the cause of the original issue #78 which was that an incorrect variable was being used.

The date parser used by strtotime, DateTime etc already handles dates in the RSS, RFC822, RFC2822 formats so there is no purpose in validating against those specific formats.
https://www.php.net/manual/en/datetime.formats.php#datetime.formats.compound

Unit tests before and after the change have the same result

```
TESTS_LAMINAS_FEED_READER_ONLINE_ENABLED=1 phpunit --group Laminas_Feed --verbose

OK, but incomplete, skipped, or risky tests!
Tests: 1536, Assertions: 1760, Skipped: 2, Incomplete: 11.
```

